### PR TITLE
TNC-2123 / v2.1 / ci: add Claude review workflow for pull requests

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -1,0 +1,57 @@
+Please review the changes and provide comprehensive feedback.
+
+Focus on:
+- Code quality and best practices
+- Maintainability, good architecture design and patterns
+- Adherence to project conventions
+- Potential bugs or issues
+- Performance considerations
+- Security implications
+
+This is the shared core TypeScript library for TrueNAS MCP: the tool catalog,
+system registry, safety model (plan/confirm, roles), and multi-system fan-out
+used by both the standalone community server and the TrueNAS Connect browser
+adapter. Pay particular attention to:
+- Safety invariants: mutating tools must never execute without a valid,
+  single-use confirmation token bound to the exact tool + arguments + target
+  systems; irreversibly destructive operations must stay out of the catalog;
+  the advertised tool list must respect role filtering.
+- No environment assumptions: the core must not touch the filesystem, process,
+  network APIs, or DOM directly — everything environment-specific enters
+  through the injected interfaces (CredentialProvider, ConfirmationGate,
+  AuditSink). It must run in both Node and the browser.
+- Credential isolation: no shared state between registered systems; credentials
+  must never appear in results, plans, or audit events.
+- Type safety: avoid `any`, prefer precise types, and ensure generics are used
+  correctly.
+- Public API surface: exported types, functions, and method signatures are
+  contracts — watch for breaking changes, inconsistent naming, and missing or
+  misleading JSDoc.
+- Async correctness: unhandled promise rejections, missing `await`, and race
+  conditions — especially in the fan-out and executor paths.
+- Resource lifecycle: API clients, subscriptions, and listeners should be
+  cleaned up and not leak.
+
+Do not provide:
+- summary of what PR does
+- list of steps you took to review
+- numeric rating or score
+
+When describing positive aspects of the PR, just mention them briefly in one - three sentences.
+
+Ignore small nit-picky issues like formatting or style unless they significantly impact readability.
+
+Provide constructive feedback with specific suggestions for improvement.
+Use inline comments to highlight specific areas of concern.
+
+Some common pitfalls to watch for:
+- Fixing an issue in a specific place without considering other places or overall architecture.
+- Leaving in unused code.
+- Missing or inadequate test coverage for new behavior.
+- Writing tests that interact with methods that should be private or protected.
+
+Use an enthusiastic and positive tone, you can use some emojis.
+
+Keep review brief and focused:
+- do not repeat yourself
+- keep overall assessment concise (one sentence)

--- a/.github/workflows/check-team.yml
+++ b/.github/workflows/check-team.yml
@@ -1,0 +1,56 @@
+name: Check Team Membership
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    outputs:
+      is_member:
+        description: "Whether the PR author has write access to the repository"
+        value: ${{ jobs.check.outputs.is_member }}
+
+jobs:
+  check:
+    name: Check Team Membership
+    runs-on: ubuntu-latest
+    outputs:
+      is_member: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check membership
+        id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            try {
+              const username = context.payload.pull_request.user.login;
+              console.log(`Checking repository access for user: ${username}`);
+
+              // Check if user has write access to the repository
+              const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: username
+              });
+
+              console.log(`User ${username} has permission: ${permissionLevel.permission}`);
+
+              // Users with write or admin access are considered team members
+              const hasWriteAccess = ['write', 'admin'].includes(permissionLevel.permission);
+              console.log(`Has write access: ${hasWriteAccess}`);
+
+              return hasWriteAccess ? 'true' : 'false';
+            } catch (error) {
+              console.log(`Error checking permissions: ${error.message}`);
+
+              // If we can't check permissions, check if it's the PR author's association
+              const association = context.payload.pull_request.author_association;
+              console.log(`PR author association: ${association}`);
+
+              // MEMBER, OWNER, and COLLABORATOR associations indicate team members
+              const isTeamMember = ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(association);
+              console.log(`Is team member based on association: ${isTeamMember}`);
+
+              return isTeamMember ? 'true' : 'false';
+            }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,45 @@
+name: Claude Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+jobs:
+  check-team:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/check-team.yml
+
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [check-team]
+    if: |
+      needs.check-team.outputs.is_member == 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-claude')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@v1.0.133
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          claude_args: "--model claude-opus-4-8"
+          track_progress: true
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request using the guidelines below.
+            It should be already checked out in the current directory.
+
+            {{file:.claude/review-prompt.md}}


### PR DESCRIPTION
Adds the same Claude review setup as `api-client-ts`:

- `.github/workflows/claude.yml` — runs an automatic Claude review on PRs targeting `master`, gated on the author having write access and skippable with the `skip-claude` label
- `.github/workflows/check-team.yml` — reusable team-membership check (copied verbatim)
- `.claude/review-prompt.md` — review guidelines adapted for this repo: safety invariants (plan/confirm token enforcement, destructive-action policy, role filtering), no environment assumptions, and credential isolation, in addition to the usual type-safety and API-surface concerns

Requires the `CLAUDE_API_KEY` repository secret (same as `api-client-ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)