### PR TITLE
TNC-2146 / v2.1 / chore: point repository.url at the truenas-connect org

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/truenas/truenas-mcp-base.git"
+    "url": "git+https://github.com/truenas-connect/truenas-mcp-base.git"
   },
   "keywords": [
     "truenas",


### PR DESCRIPTION
## What

`package.json` declared:

```
"url": "git+https://github.com/truenas/truenas-mcp-base.git"
```

The repo actually lives under `truenas-connect`. Corrected to match the real remote.

## Why it matters

`repository.url` is what npm renders as the "Repository" link on a package page, and what tooling (`npm repo`, provenance attestation, Dependabot) resolves to find the source. Wrong today it's only cosmetic — the package is `0.0.0` and unpublished — but it would ship a broken link the moment it isn't.

## Verification

`grep -rn "github.com/truenas/"` across the repo now returns nothing. The sibling `truenas-mcp-server` was checked too and already had the correct org.

Not built or tested — this field isn't read at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)