### PR TITLE
TNC-2168 / v2.1 / ci: add coverage floors as blocking gates (testing plan Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
       - run: yarn install --immutable
       - run: yarn typecheck
       - run: yarn lint
-      - run: yarn test
+      - run: yarn test:coverage
       - run: yarn build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     coverage: {
       provider: 'v8',
-      // Explicit include so a new src file that no spec imports still enters
-      // the denominator at 0% instead of being invisible to the floors.
+      // Narrows the untested-file scan to src. Vitest 3 already pulls
+      // unimported files into the denominator via the coverage.all default;
+      // vitest 4 removes that option and requires an explicit include for a
+      // new src file that no spec imports to keep reporting at 0%.
       include: ['src/**/*.ts'],
       exclude: [
         ...coverageConfigDefaults.exclude,
@@ -38,7 +40,9 @@ export default defineConfig({
       thresholds: {
         branches: 94,
         statements: 96,
-        // Per-file floors on the files where the safety model lives.
+        // Per-file floors on the files where the safety model lives. A key
+        // that matches no file passes vacuously, so renaming one of these
+        // files must carry its key along or the floor silently disappears.
         'src/execution/executor.ts': { branches: 92, statements: 97 },
         'src/registry/system-registry.ts': { branches: 93, statements: 97 },
         'src/execution/confirmation.ts': { branches: 94, statements: 97 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 const srcDir = fileURLToPath(new URL('./src', import.meta.url));
 
@@ -14,5 +14,33 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['src/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        // Manual smoke script against a live system, not a test.
+        'scripts/**',
+        // Re-export barrel; no logic of its own.
+        'src/index.ts',
+        // Types only; no runtime exports for v8 to see.
+        'src/catalog/tool.ts',
+      ],
+      // Floors, not targets: set at the measured level so a decrease fails CI.
+      // Raised by hand in the same PR that raises the coverage — never lowered,
+      // never auto-updated. See docs/testing-plan.md in truenas-mcp-server.
+      // Branch is the primary gate; the statements floor exists because v8
+      // reports a file that no test touches as 100% branch (no branches
+      // recorded), so a branch-only floor cannot see a file losing all its
+      // tests at once.
+      thresholds: {
+        branches: 94,
+        statements: 96,
+        // Per-file floors on the files where the safety model lives.
+        'src/execution/executor.ts': { branches: 92, statements: 97 },
+        'src/registry/system-registry.ts': { branches: 93, statements: 97 },
+        'src/execution/confirmation.ts': { branches: 94, statements: 97 },
+        'src/catalog/catalog.ts': { branches: 95, statements: 96 },
+      },
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     coverage: {
       provider: 'v8',
+      // Explicit include so a new src file that no spec imports still enters
+      // the denominator at 0% instead of being invisible to the floors.
+      include: ['src/**/*.ts'],
       exclude: [
         ...coverageConfigDefaults.exclude,
         // Manual smoke script against a live system, not a test.


### PR DESCRIPTION
Phase 0 of the tiers 0–2 testing plan ([docs/testing-plan.md in truenas-mcp-server](https://github.com/truenas-connect/truenas-mcp-server/blob/main/docs/testing-plan.md)) — the base-repo half.

## What

- `vitest.config.ts` gains a `coverage` block:
  - **Exclusions**, each with a comment stating why: `scripts/` (manual smoke script), `src/index.ts` (re-export barrel), `src/catalog/tool.ts` (types only, no runtime exports).
  - **Global branch floor** at the measured post-exclusion figure (94).
  - **Per-file branch floors** on the safety-model files, at measured level per the plan's Gates table — not the 95 target, which Phase 1b owns: `executor.ts` 92, `system-registry.ts` 93, `confirmation.ts` 94, `catalog.ts` 95.
- CI runs `yarn test:coverage` instead of `yarn test`. The script and `@vitest/coverage-v8` were already present; this is config plus CI wiring only.

## One deviation from the plan, found during verification

The plan's acceptance check ("verified by temporarily deleting a test locally") exposed a hole: v8 reports a file that **no** test touches as 100% branch (no branches recorded → vacuously satisfied), so deleting `executor.spec.ts` outright made the global branch figure go *up* and the gate stayed green. Branch-only floors cannot see a file losing all of its tests at once.

So each floor is paired with a **statements floor at measured level** as a backstop. Branch remains the primary gate per the plan's rule 3; statements only catches the wholesale-deletion case branch is structurally blind to.

## Verified locally

- Green on landing: `yarn test:coverage` exits 0.
- Skipping one executor test trips the branch floor: `branches (91.93%) does not meet "src/execution/executor.ts" threshold (92%)`, exit 1.
- Deleting `executor.spec.ts` entirely trips the statements floors (global 69.61 < 96, executor 0 < 97), exit 1.

## Review follow-up

- **`coverage.include` added** (second commit). Correction to that commit's message: on the pinned vitest 3.2.7 an unimported src file already entered the denominator (`coverage.all` defaults true), so the include did not change current behavior — it narrows the scan to `src/**` and future-proofs for vitest 4, which removes `coverage.all` and would otherwise stop scanning untested files. Measured figures unchanged; an orphan src file reports 0% and trips both global floors (verified with and without the include).
- **Rename footgun documented** (third commit): a per-file threshold key that matches no file passes vacuously, so renaming a gated file without carrying its key silently drops that safety floor. Comment added next to the keys.
- **`fanout.ts` has no per-file floor — deliberate.** The Gates table in the testing plan defines the per-file set, and fanout is not in it; it measures 100/100 today, so the global floors already fail on any regression there. Widening the gated set is a plan change, not a Phase 0 decision.

