### PR TITLE
TNC-2170 / v2.1 / test: raise safety-file branch floors to 95 (testing plan Phase 1b)

### DIFF
--- a/src/execution/confirmation.spec.ts
+++ b/src/execution/confirmation.spec.ts
@@ -85,6 +85,15 @@ describe('ConfirmationService', () => {
     expect(() => service.consume(third, key)).not.toThrow();
   });
 
+  it('still mints a usable token when maxPending is zero', () => {
+    // Degenerate but constructible config: with an empty map and
+    // maxPending 0 the eviction loop has nothing to evict, and its guard
+    // must terminate the loop rather than spin forever.
+    const service = new ConfirmationService({ maxPending: 0 });
+    const token = service.mint(key);
+    expect(() => service.consume(token, key)).not.toThrow();
+  });
+
   it('sweeps abandoned expired tokens on mint', () => {
     let time = 0;
     let id = 0;

--- a/src/execution/executor.spec.ts
+++ b/src/execution/executor.spec.ts
@@ -366,6 +366,45 @@ describe('ToolExecutor — plan/confirm', () => {
     expect(sinkErrors).toHaveLength(1);
   });
 
+  it('reports a sink failure via console.error when no onAuditError is supplied', async () => {
+    const registry = new SystemRegistry();
+    registry.add({ name: 'a', client: {} as TrueNasApiClient } as SystemHandle);
+    const catalog = new ToolCatalog();
+    catalog.register({
+      name: 'ok_read',
+      description: 'test',
+      inputSchema: { type: 'object', properties: {} },
+      requiredRole: Role.ReadOnly,
+      mutating: false,
+      handler: async () => 'fine',
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const executor = new ToolExecutor({
+        catalog,
+        registry,
+        confirmations: new ConfirmationService(),
+        audit: {
+          record: () => {
+            throw new Error('audit db down');
+          },
+        },
+      });
+
+      // The default handler must keep the failure visible without altering
+      // the tool-call outcome.
+      const outcome = await executor.execute('ok_read');
+      expect(outcome.type).toBe('RESULTS');
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Audit sink failed for ok_read/read:',
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('a rejecting async audit sink routes to onAuditError', async () => {
     const registry = new SystemRegistry();
     registry.add({ name: 'a', client: {} as TrueNasApiClient } as SystemHandle);

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -109,11 +109,16 @@ export class ToolExecutor {
       const byName = new Map([...fanned, ...denied].map((r) => [r.system, r]));
       const results = targets.map((t): SystemResult<unknown> => {
         const result = byName.get(t.name);
+        /* v8 ignore start -- unreachable defensive guard: partitionByRole
+           assigns every target to exactly one of allowed/denied, and fanOut
+           returns one result per input system, so allowed ∪ denied always
+           covers targets. No public-API path can reach this; it exists to
+           fail loudly here instead of crashing later in record() if that
+           invariant is ever broken by a refactor. */
         if (!result) {
-          // allowed ∪ denied always covers targets; if that invariant breaks,
-          // fail loudly here instead of crashing later in record().
           throw new Error(`Internal error: no result for system "${t.name}"`);
         }
+        /* v8 ignore stop */
         return result;
       });
       if (fanned.length > 0) {

--- a/src/registry/system-registry.spec.ts
+++ b/src/registry/system-registry.spec.ts
@@ -72,6 +72,12 @@ describe('SystemRegistry', () => {
     expect(registry.resolve(['a', 'a', 'b']).map((s) => s.name)).toEqual(['a', 'b']);
   });
 
+  it('rejects an empty list of names', () => {
+    const registry = new SystemRegistry();
+    registry.add(handle('a'));
+    expect(() => registry.resolve([])).toThrow(/must name at least one system/);
+  });
+
   it('names unknown systems in the error', () => {
     const registry = new SystemRegistry();
     registry.add(handle('a'));
@@ -199,6 +205,31 @@ describe('connectSystems', () => {
         },
       ),
     ).rejects.toThrow(/bad: auth failed/);
+    expect(connected.close).toHaveBeenCalled();
+    expect(registry.names()).toEqual([]);
+  });
+
+  it('a throwing close during rollback does not mask the connect failure', async () => {
+    const registry = new SystemRegistry();
+    const connected = {
+      close: vi.fn(() => {
+        throw new Error('socket already gone');
+      }),
+    } as unknown as TrueNasApiClient;
+    await expect(
+      connectSystems(
+        registry,
+        { getSystems: async () => [spec('good'), spec('bad')] },
+        async (s) => {
+          if (s.name === 'bad') {
+            throw new Error('auth failed');
+          }
+          return connected;
+        },
+      ),
+    ).rejects.toThrow(/bad: auth failed/);
+    // The rollback close was attempted, its throw was swallowed, and the
+    // reported error is still the connect failure.
     expect(connected.close).toHaveBeenCalled();
     expect(registry.names()).toEqual([]);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,14 +38,14 @@ export default defineConfig({
       // recorded), so a branch-only floor cannot see a file losing all its
       // tests at once.
       thresholds: {
-        branches: 94,
-        statements: 96,
+        branches: 96,
+        statements: 97,
         // Per-file floors on the files where the safety model lives. A key
         // that matches no file passes vacuously, so renaming one of these
         // files must carry its key along or the floor silently disappears.
         'src/execution/executor.ts': { branches: 95, statements: 97 },
-        'src/registry/system-registry.ts': { branches: 95, statements: 97 },
-        'src/execution/confirmation.ts': { branches: 95, statements: 97 },
+        'src/registry/system-registry.ts': { branches: 96, statements: 97 },
+        'src/execution/confirmation.ts': { branches: 97, statements: 97 },
         'src/catalog/catalog.ts': { branches: 95, statements: 96 },
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,9 +43,9 @@ export default defineConfig({
         // Per-file floors on the files where the safety model lives. A key
         // that matches no file passes vacuously, so renaming one of these
         // files must carry its key along or the floor silently disappears.
-        'src/execution/executor.ts': { branches: 92, statements: 97 },
-        'src/registry/system-registry.ts': { branches: 93, statements: 97 },
-        'src/execution/confirmation.ts': { branches: 94, statements: 97 },
+        'src/execution/executor.ts': { branches: 95, statements: 97 },
+        'src/registry/system-registry.ts': { branches: 95, statements: 97 },
+        'src/execution/confirmation.ts': { branches: 95, statements: 97 },
         'src/catalog/catalog.ts': { branches: 95, statements: 96 },
       },
     },


### PR DESCRIPTION
Phase 1b of the tiers 0–2 testing plan ([docs/testing-plan.md](https://github.com/truenas-connect/truenas-mcp-server/blob/main/docs/testing-plan.md)): cover the outstanding branches in the three base safety files, then raise their branch floors from {92, 93, 94} to the 95 target. Statements floors and the catalog floor untouched. Sibling to server Phase 1 (truenas-connect/truenas-mcp-server#9).

## Per-branch disposition

The plan's judgment rule was applied per branch — test what is reachable, exclude (with reasoning in the source) what is not:

| Location | What it is | Disposition |
| --- | --- | --- |
| `executor.ts:83-84` | default `onAuditError` handler | **Tested** — executor built without `onAuditError`, throwing sink; asserts the outcome is unchanged and `console.error` got `'Audit sink failed for ok_read/read:'` + an Error |
| `executor.ts:115-116` | "no result for system" internal-invariant guard | **Excluded** with `/* v8 ignore */` — `fanOut` returns one result per input and `partitionByRole` assigns every target to exactly one side, so allowed ∪ denied always covers targets; no public-API path reaches it. The guard stays, to fail loudly if a refactor ever breaks the invariant |
| `system-registry.ts:91-92` | `resolve([])` empty-list rejection | **Tested** — `[]` passes the type check but dedupes to zero names; genuinely reachable |
| `system-registry.ts:173` | swallowed `close()` throw during `connectSystems` rollback | **Tested** through the public factory seam — a throwing rollback `close()` must not mask the original connect failure |
| `confirmation.ts:99-100` | `oldest === undefined` break in `mint()`'s eviction loop | **Tested** as a boundary: `maxPending: 0` is constructible (`?? 100` doesn't catch 0) and without the break `mint()` would loop forever on `pending.delete(undefined)`; asserts mint terminates and the token is consumable |

The `maxPending: 0` case is the one to weigh in review: it is an honest termination test of a constructible configuration, but if you'd rather reject `maxPending <= 0` in the constructor, that's a production change outside this phase's scope — flag it and we'll split it out.

## Results

- Branch: `executor.ts` 95.23, `system-registry.ts` 96.55, `confirmation.ts` 97.05 (all statements 100). Global: 96.34 branch / 97.59 statements.
- Floors raised 92/93/94 → 95 in the same PR, per rule 4.
- 76 → 80 tests, all green; `typecheck` and `lint` clean.