### PR TITLE
TNC-2234 / v2.2 / ci: map the Claude Code OAuth token for PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,4 +40,11 @@ jobs:
       issues: write
       pull-requests: write
     secrets:
+      # Both are mapped on purpose, and the shared workflow prefers the token.
+      # `UX_CLAUDE_CODE_OAUTH_TOKEN` is an org secret granted per repository:
+      # where the grant is missing it resolves to the empty string rather than
+      # failing, so the API key below covers that case and this repo moves to
+      # subscription billing on its own once the grant lands. Drop the key line
+      # when API billing is retired, not before.
+      claude-code-oauth-token: ${{ secrets.UX_CLAUDE_CODE_OAUTH_TOKEN }}
       anthropic-api-key: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
The shared review workflow prefers `claude-code-oauth-token` over `anthropic-api-key`. Map both: `UX_CLAUDE_CODE_OAUTH_TOKEN` is an org secret granted per repository and arrives as the empty string where the grant is missing, so the API key stays as the fallback and this repo moves to subscription billing on its own once the grant lands.

Same change as truenas-connect/ui#375. The shared-workflow side (prefer-token auth, both-mapped supported) is already on `master`.