### PR TITLE
feat!: require @truenas/api-client 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@truenas/api-client": "^2.0.0",
+    "@truenas/api-client": "^3.0.3",
     "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
-    "@truenas/api-client": "^2.0.0",
+    "@truenas/api-client": "^3.0.3",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,12 +796,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@truenas/api-client@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@truenas/api-client@npm:2.0.0"
+"@truenas/api-client@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@truenas/api-client@npm:3.0.3"
   peerDependencies:
     rxjs: ^7.8.0
-  checksum: 10c0/32e484524ff31af5cd1d17285901f948a68ea9095aad075dde0dd9af7ea2430383d78ad48b7ccf1ea08abeb1a6c3acf726ed35834723d197138533f54ca6817e
+  checksum: 10c0/e7794895395a5b03493cf1ab25cd5ffe693cbadcfb852082794967a3125cc73f8bd53934d30b7f8482da9111811b1690fe1a286a3d9e128b8485af8a113c7b80
   languageName: node
   linkType: hard
 
@@ -810,7 +810,7 @@ __metadata:
   resolution: "@truenas/mcp-base@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.18.0"
-    "@truenas/api-client": "npm:^2.0.0"
+    "@truenas/api-client": "npm:^3.0.3"
     "@types/node": "npm:^22.0.0"
     "@vitest/coverage-v8": "npm:^3.0.0"
     eslint: "npm:^9.18.0"
@@ -821,7 +821,7 @@ __metadata:
     typescript-eslint: "npm:^8.20.0"
     vitest: "npm:^3.0.0"
   peerDependencies:
-    "@truenas/api-client": ^2.0.0
+    "@truenas/api-client": ^3.0.3
     rxjs: ^7.8.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Requested by @aervin in the project channel: update `@truenas/api-client` to latest, which ships a 27 client.

`^2.0.0` → `^3.0.3`. Latest was 3.0.2 when the request came in; **3.0.3 published two minutes later**, so this is on 3.0.3.

## What 3.x actually changes for us

2.0.0 already shipped the generated **v27 types**. What it did not ship was the runtime, and it said so in its own source:

> This should be the newest generated version by the same argument as MIN, but `instantiateClientForVersion` only maps `25.10` and `26` — a v27 system would pass the range check and then throw on client selection. It moves to the newest generated version once a v27 client exists. Until then it lags on purpose.

`MAX_SUPPORTED_VERSION` moves `v26.0.0` → `v27.0.0` in 3.x, and the v27 client is mapped. Concretely, on 2.0.0 a TrueNAS 27 appliance either:

- advertises only v27 → every version is `too-new`, `VersionTooNewError`, connection refused; or
- still advertises v26 → negotiates down to v26 and never reaches its own surface.

Which of those you hit depends on what a real 27 box returns from `/api/versions`, and that is tier 4 territory — not something this PR can settle.

3.0.3 additionally accepts `version` on `createTrueNasClient`, skipping discovery and *deriving* the typed surface from the version string. Nothing here uses it. It is called out because it is the seam a per-system surface would arrive through, rather than by widening `ApiSurface` globally.

## What this does NOT do

**`ApiSurface` is unchanged**, and I want that read as deliberate rather than overlooked. It stays `DefaultApiDirectory`, which 3.x still resolves to v25.10.0 — the oldest supported version. So the bump does not widen what tools may call:

| surface | call methods |
| --- | --- |
| v25.10.0 — our `ApiSurface` | 663 |
| v26.0.0 | 701 |
| v27.0.0 | 711 |

v27 adds 71 methods over v25.10.0 and drops 23 — the whole `virt.*` family, replaced by `container.*`, plus `pool.dataset.encryption_algorithm_choices`. **None of those 71 are reachable from a tool until `ApiSurface` moves**, which is the separate decision the type's own comment reserves: *"Widen it only in step with a decision about the minimum TrueNAS version this supports."* Happy to open that discussion — it is not this PR.

## Compatibility check

The tools name four methods. All four exist in v27, and nothing they touch was removed:

| method | in v25.10.0 | in v27.0.0 |
| --- | --- | --- |
| `pool.query` | yes | yes |
| `pool.dataset.query` | yes | yes |
| `pool.snapshot.create` | yes | yes |
| `system.info` | yes | yes |

`pool.query` and `pool.snapshot.create` *are* redefined in the v26 delta, which is worth knowing since our types stay pinned to v25.10.0 — but only because their entity types moved, and both changes are additive: `PoolEntry` gains `all_sed`, snapshot create gains `suspend_vms`. No field `storage_pool_status` reads or `snapshots_create` sends changed shape.

Three symbols were dropped in 3.x — `ContainerDeviceContainerNICDeviceInput`, `index_Algorithm`, `index_PoolDatasetEncryptionAlgorithmChoicesResult`. Grepped both repos: none are referenced.

## Breaking

The **peer range** moves to `^3.0.3`, so consumers must move too. Hence `feat!`.

## Verification

`typecheck`, `lint`, 80 tests with coverage, `build` — all green. `smoke` needs real credentials and was not run.

Since api-client is trusted and mocked at the `api.call` seam, the tests are not the meaningful signal here — **typecheck is**, because it is what proves `createTrueNasClient<ApiSurface>` still resolves against 3.x's new overload pair. It does.

## Merge order

This must land **before** truenas-connect/truenas-mcp-server#26, which reports `YN0060` until this is on `main` and its lockfile pin is refreshed.

Co-Authored-By: Aaron Ervin <aaron.ervin@truenas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
