### PR TITLE
TNC-2284 / v2.2 / feat(tools): add alerts_list, the read-only view of active system alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `storage_pool_status`, `storage_list_datasets`.
+  `system_info`, `storage_pool_status`, `storage_list_datasets`, `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,5 +63,6 @@ export {
   systemInfo,
   poolStatus,
   listDatasets,
+  alertsList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -1,0 +1,34 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * The system's own health verdict. `system_info` and the storage tools describe
+ * what a system *is*; this reports what it is *complaining about*, already
+ * computed by the middleware rather than inferred from capacity numbers.
+ */
+export const alertsList: ReadOnlyTool = {
+  name: 'alerts_list',
+  description:
+    'Active alerts a TrueNAS system has raised: severity level, alert class, ' +
+    'the message, when it fired, and whether it has been dismissed. Dismissed ' +
+    'alerts are still active conditions and are included.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const alerts = await firstValueFrom(system.client.api.call('alert.list'));
+    return alerts.map((alert) => ({
+      id: alert.id,
+      // The middleware's own class identifier, e.g. `ZpoolCapacityWarning`.
+      klass: alert.klass,
+      level: alert.level,
+      // The rendered message. Null when the middleware could not format it;
+      // the raw `text` template it falls back from carries unsubstituted
+      // placeholders, so it is not a useful substitute and is not surfaced.
+      formatted: alert.formatted,
+      datetime: alert.datetime,
+      dismissed: alert.dismissed,
+    }));
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,16 +1,18 @@
 import { ToolCatalog } from '@/catalog/catalog';
+import { alertsList } from '@/tools/alerts';
 import { createSnapshot } from '@/tools/snapshots';
 import { listDatasets, poolStatus } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: three read-only tools plus one mutating tool. */
+/** The sketch's catalog: four read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(poolStatus);
   catalog.register(listDatasets);
+  catalog.register(alertsList);
   catalog.register(createSnapshot);
   return catalog;
 }
 
-export { createSnapshot, listDatasets, poolStatus, systemInfo };
+export { alertsList, createSnapshot, listDatasets, poolStatus, systemInfo };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { of } from 'rxjs';
 import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { Role } from '@/interfaces';
-import { createDefaultCatalog, createSnapshot, listDatasets, poolStatus } from '@/tools/index';
+import {
+  alertsList,
+  createDefaultCatalog,
+  createSnapshot,
+  listDatasets,
+  poolStatus,
+} from '@/tools/index';
 
 /**
  * A SystemHandle answering from a canned method→response map. Both seams are
@@ -23,13 +29,18 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the four sketch tools', () => {
+  it('registers the five sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
       'storage_list_datasets',
+      'alerts_list',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises alerts_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('alerts_list');
   });
 });
 
@@ -88,6 +99,76 @@ describe('storage_list_datasets', () => {
       [['pool', '=', 'tank']],
       { extra: { retrieve_children: true, properties: ['used', 'available'] } },
     );
+  });
+});
+
+describe('alerts_list', () => {
+  // Every property the middleware's Alert carries, so the assertions below show
+  // what the tool drops as well as what it keeps.
+  const alert = (over: Record<string, unknown>) => ({
+    uuid: 'u1',
+    source: 'AlertSource',
+    klass: 'ZpoolCapacityWarning',
+    args: { pool: 'tank' },
+    node: 'A',
+    key: '[]',
+    datetime: '2026-08-28T12:00:00+00:00',
+    last_occurrence: '2026-08-28T13:00:00+00:00',
+    dismissed: false,
+    mail: null,
+    text: 'Pool %(pool)s is low on space.',
+    id: 'a1',
+    level: 'WARNING',
+    formatted: 'Pool tank is low on space.',
+    one_shot: false,
+    ...over,
+  });
+
+  it('trims alert.list to the named fields', async () => {
+    const { ctx, call } = fakeSystem({ ['alert.list']: [alert({})] });
+    expect(await alertsList.handler(ctx, {})).toEqual([
+      {
+        id: 'a1',
+        klass: 'ZpoolCapacityWarning',
+        level: 'WARNING',
+        formatted: 'Pool tank is low on space.',
+        datetime: '2026-08-28T12:00:00+00:00',
+        dismissed: false,
+      },
+    ]);
+    // The tool reads the alert list and nothing else.
+    expect(call.mock.calls).toEqual([['alert.list']]);
+  });
+
+  it('does not surface a field the middleware adds later', async () => {
+    const { ctx } = fakeSystem({
+      ['alert.list']: [alert({ future_field: 'added by a later TrueNAS release' })],
+    });
+    const [result] = (await alertsList.handler(ctx, {})) as Record<string, unknown>[];
+    expect(Object.keys(result)).toEqual([
+      'id',
+      'klass',
+      'level',
+      'formatted',
+      'datetime',
+      'dismissed',
+    ]);
+  });
+
+  it('returns dismissed alerts, distinguishable by the boolean', async () => {
+    const { ctx } = fakeSystem({
+      ['alert.list']: [alert({ id: 'a1' }), alert({ id: 'a2', dismissed: true })],
+    });
+    const result = (await alertsList.handler(ctx, {})) as { id: string; dismissed: boolean }[];
+    expect(result.map((a) => [a.id, a.dismissed])).toEqual([
+      ['a1', false],
+      ['a2', true],
+    ]);
+  });
+
+  it('returns [] for a system with no alerts', async () => {
+    const { ctx } = fakeSystem({ ['alert.list']: [] });
+    expect(await alertsList.handler(ctx, {})).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #12.

`system_info` and the storage tools describe what a system **is**; nothing reported what it is **complaining about**. Alerts are the middleware's own health verdict, already computed, so an LLM asked *"review my systems' health"* no longer has to infer one from capacity numbers.

## What it does

`src/tools/alerts.ts` exports `alertsList: ReadOnlyTool`, catalog name `alerts_list`, `requiredRole: Role.ReadOnly`, `mutating: false`. It calls `alert.list` and nothing else, and maps each alert to six explicitly named fields, following `storage.ts` rather than returning the middleware payload:

`id`, `klass`, `level`, `formatted`, `datetime`, `dismissed`

Registered in `createDefaultCatalog()` between `storage_list_datasets` and `snapshots_create` — read-only tools stay grouped ahead of the mutating one — and re-exported from `src/tools/index.ts` and `src/index.ts`.

Dismissed alerts are returned and carry the boolean. They are still true conditions, and hiding them would make the tool contradict the web UI.

## Field names came from the pinned client, not the ticket

The ticket marked the property names **(unconfirmed)** and said to read them off the client. Doing that corrected two of them, against `@truenas/api-client` 2.x's `Alert` for v25.10.0 (which is what `ApiSurface` resolves to):

- There is **no `klass_name`** — the class identifier is `klass` alone.
- **`formatted` is `string | null`**, not `string`.

The raw `text` field is the unrendered template (`Pool %(pool)s is low on space.`), so it is not a useful fallback for a null `formatted` and is not surfaced. `datetime` is typed `string` by the generated types and is passed through as such.

## Tests

Four cases in `src/tools/tools.spec.ts` using the existing `fakeSystem` helper, plus the exact-list `toEqual` assertion updated to five tools and a new assertion that `alerts_list` is advertised to a `Role.ReadOnly` credential. The fixture carries **every** property the middleware's `Alert` has, so the assertions show what the tool drops as well as what it keeps; one case adds an invented `future_field` and asserts the exact output key list, which is the "a later TrueNAS release does not leak through" criterion made checkable.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` (85 tests) and `yarn build` all pass locally — the same four the CI workflow gates on. Coverage is **97.66 statements / 96.38 branches**, above the 97 / 96 floors; `alerts.ts` is at 100 / 100. `yarn smoke` needs a live system and credentials and was not run.

The shared review from `iXsystems/ux-github-workflows@master` ran locally on this diff — the same reviewer, rubric and threshold as the required check, in a separate process — and returned **nothing at or above MEDIUM**.

## What I did not change, and why

Both are the LOWs that clean round raised. They are recorded here rather than fixed, so they survive without costing another review round:

- **`scripts/smoke.ts:12` still says "the three read-only tools"** and does not exercise `alerts_list`. Its comment is accurate about the script as it stands — the script does exercise three — so nothing in it is false today, but the count is on its way to being stale, and #13 and #14 will each make it more so. Worth one ticket that adds all three new tools to the smoke script at once rather than three separate touches of the same line.
- **`uuid` and `last_occurrence` are dropped.** `uuid` is the identifier `alert.dismiss` and `alert.restore` take, and dismissing is explicitly out of scope for this ticket. `last_occurrence` is when the alert most recently recurred; `datetime` is when it fired, which is what the description promises and what the acceptance criteria name. Both are cheap to add if a dismissal tool or a recurrence-aware health report needs them — the ticket's own reasoning is that every field that survives is one the LLM pays for on every call.

## Note on PR #11

#11 (`feat!: require @truenas/api-client 3.x`) is still open, so this branches from `main` as it stands. Nothing here should conflict with it: `ApiSurface` is unchanged by that PR, `alert.list` exists on v25.10.0 through v27.0.0, and none of the six fields this reads was touched by the v26 or v27 deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
