### PR TITLE
feat(tools): add disks_list, the disk inventory with pool membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `storage_pool_status`, `storage_list_datasets`, `alerts_list`.
+  `system_info`, `storage_pool_status`, `storage_list_datasets`, `disks_list`,
+  `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
   systemInfo,
   poolStatus,
   listDatasets,
+  disksList,
   alertsList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/disks.ts
+++ b/src/tools/disks.ts
@@ -5,8 +5,12 @@ import { ReadOnlyTool } from '@/catalog/tool';
 /** Hardware inventory: the physical disks under the pools.
  *
  * `storage_pool_status` reports pools as units and says nothing about the
- * devices beneath them, so "is anything about to fail" or "do I have a spare
- * bay" has no inventory to reason over without this.
+ * devices beneath them, so "which disks are there", "what is unassigned" and
+ * "which model and size is each" have no inventory to reason over without this.
+ *
+ * Physical placement is not among them: `enclosure` (the shelf and slot a disk
+ * sits in) is dropped, so this cannot answer "do I have a spare bay". It
+ * answers the weaker "do I have an unassigned disk", via `pool`.
  *
  * The mapping below is an allowlist rather than a trim, which matters more here
  * than for the other read-only tools: a `disk.query` row carries the SED

--- a/src/tools/disks.ts
+++ b/src/tools/disks.ts
@@ -1,0 +1,58 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/** Hardware inventory: the physical disks under the pools.
+ *
+ * `storage_pool_status` reports pools as units and says nothing about the
+ * devices beneath them, so "is anything about to fail" or "do I have a spare
+ * bay" has no inventory to reason over without this.
+ *
+ * The mapping below is an allowlist rather than a trim, which matters more here
+ * than for the other read-only tools: a `disk.query` row carries the SED
+ * passphrase (`passwd`) and its KMIP key id, and naming the output fields
+ * explicitly is what keeps them out of the tool result and so out of the
+ * conversation. Serial numbers are identifying but not secret, and are response
+ * data rather than arguments, so the "no secrets as arguments" rule in
+ * `catalog/tool.ts` is not in play.
+ */
+
+export const disksList: ReadOnlyTool = {
+  name: 'disks_list',
+  description:
+    'Physical disks attached to a TrueNAS system: device name, model, serial ' +
+    'number, size in bytes, media type (HDD/SSD) and transfer mode, plus which ' +
+    'ZFS pool each disk belongs to. `pool` is null when the disk belongs to no ' +
+    'pool; the field is absent entirely when the system did not report pool ' +
+    'membership, which is not the same as the disk being unassigned.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const disks = await firstValueFrom(
+      // Filters and options are inlined so the call's own parameter types
+      // apply, as in storage.ts. `extra.pools` is what makes the middleware
+      // attach each disk's owning pool; the client types `extra` as an open
+      // `Record<string, unknown>`, so it carries the key without confirming
+      // it — which is why the mapping below treats an absent `pool` as its
+      // own state rather than assuming the request was honoured.
+      system.client.api.query('disk.query', [], { extra: { pools: true } }),
+    );
+    return disks.map((disk) => ({
+      name: disk['name'],
+      model: disk['model'],
+      serial: disk['serial'],
+      size_bytes: disk['size'],
+      // Two distinct fields the middleware happens to name similarly: `type`
+      // is the medium (HDD/SSD), `transfermode` is the link mode (e.g. Auto,
+      // SATA300).
+      type: disk['type'],
+      transfermode: disk['transfermode'],
+      // Spread rather than assigned: `pool: undefined` and no `pool` key are
+      // the same after JSON serialization but not to a caller reading the
+      // object, and the two states this has to keep apart are "in no pool"
+      // (null) and "membership not reported" (absent).
+      ...('pool' in disk ? { pool: disk['pool'] } : {}),
+    }));
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,18 +1,20 @@
 import { ToolCatalog } from '@/catalog/catalog';
 import { alertsList } from '@/tools/alerts';
+import { disksList } from '@/tools/disks';
 import { createSnapshot } from '@/tools/snapshots';
 import { listDatasets, poolStatus } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: four read-only tools plus one mutating tool. */
+/** The sketch's catalog: five read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(poolStatus);
   catalog.register(listDatasets);
+  catalog.register(disksList);
   catalog.register(alertsList);
   catalog.register(createSnapshot);
   return catalog;
 }
 
-export { alertsList, createSnapshot, listDatasets, poolStatus, systemInfo };
+export { alertsList, createSnapshot, disksList, listDatasets, poolStatus, systemInfo };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -6,6 +6,7 @@ import {
   alertsList,
   createDefaultCatalog,
   createSnapshot,
+  disksList,
   listDatasets,
   poolStatus,
 } from '@/tools/index';
@@ -29,11 +30,12 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the five sketch tools', () => {
+  it('registers the six sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
       'storage_list_datasets',
+      'disks_list',
       'alerts_list',
       'snapshots_create',
     ]);
@@ -41,6 +43,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises alerts_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('alerts_list');
+  });
+
+  it('advertises disks_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('disks_list');
   });
 });
 
@@ -99,6 +105,108 @@ describe('storage_list_datasets', () => {
       [['pool', '=', 'tank']],
       { extra: { retrieve_children: true, properties: ['used', 'available'] } },
     );
+  });
+});
+
+describe('disks_list', () => {
+  // Every property the middleware's disk row carries, so the assertions below
+  // show what the tool drops as well as what it keeps. `passwd` and `kmip_uid`
+  // are the SED credential fields, and are here to be dropped.
+  const disk = (over: Record<string, unknown>) => ({
+    identifier: '{serial}ABC123',
+    name: 'sda',
+    subsystem: 'scsi',
+    number: 2048,
+    serial: 'ABC123',
+    lunid: null,
+    size: 4000787030016,
+    transfermode: 'Auto',
+    hddstandby: 'ALWAYS ON',
+    advpowermgmt: 'DISABLED',
+    expiretime: null,
+    model: 'WDC_WD40EFRX',
+    rotationrate: 5400,
+    type: 'HDD',
+    zfs_guid: '12345678901234567890',
+    bus: 'SCSI',
+    devname: 'sda',
+    enclosure: { number: 0, slot: 3 },
+    pool: 'tank',
+    passwd: 'the-sed-passphrase',
+    kmip_uid: null,
+    sed: false,
+    sed_status: null,
+    ...over,
+  });
+
+  /** A row from a system that did not answer the pool question at all. */
+  const withoutPool = (row: Record<string, unknown>): Record<string, unknown> => {
+    const copy = { ...row };
+    delete copy['pool'];
+    return copy;
+  };
+
+  it('trims disk.query to the named fields', async () => {
+    const { ctx } = fakeSystem({ ['disk.query']: [disk({})] });
+    expect(await disksList.handler(ctx, {})).toEqual([
+      {
+        name: 'sda',
+        model: 'WDC_WD40EFRX',
+        serial: 'ABC123',
+        size_bytes: 4000787030016,
+        type: 'HDD',
+        transfermode: 'Auto',
+        pool: 'tank',
+      },
+    ]);
+  });
+
+  it('asks the middleware to attach pool membership', async () => {
+    const { ctx, query } = fakeSystem({ ['disk.query']: [] });
+    await disksList.handler(ctx, {});
+    // Without `extra.pools` the rows carry no membership at all, which the
+    // handler would then have to report as unknown for every disk.
+    expect(query).toHaveBeenCalledWith('disk.query', [], { extra: { pools: true } });
+  });
+
+  it('surfaces neither the SED passphrase nor a field a later release adds', async () => {
+    const { ctx } = fakeSystem({
+      ['disk.query']: [disk({ future_field: 'added by a later TrueNAS release' })],
+    });
+    const [result] = (await disksList.handler(ctx, {})) as Record<string, unknown>[];
+    expect(Object.keys(result)).toEqual([
+      'name',
+      'model',
+      'serial',
+      'size_bytes',
+      'type',
+      'transfermode',
+      'pool',
+    ]);
+  });
+
+  it('distinguishes a disk in no pool from one whose membership was not reported', async () => {
+    // `pool: null` is the middleware saying "this disk belongs to no pool". A
+    // row with no `pool` key at all is a system that did not answer the
+    // question — an older middleware, or one that ignored `extra.pools`.
+    const { ctx } = fakeSystem({
+      ['disk.query']: [
+        disk({ name: 'sda', pool: 'tank' }),
+        disk({ name: 'sdb', pool: null }),
+        withoutPool(disk({ name: 'sdc' })),
+      ],
+    });
+    const result = (await disksList.handler(ctx, {})) as Record<string, unknown>[];
+    expect(result.map((d) => [d['name'], 'pool' in d, d['pool']])).toEqual([
+      ['sda', true, 'tank'],
+      ['sdb', true, null],
+      ['sdc', false, undefined],
+    ]);
+  });
+
+  it('returns [] for a system with no disks', async () => {
+    const { ctx } = fakeSystem({ ['disk.query']: [] });
+    expect(await disksList.handler(ctx, {})).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #13

`storage_pool_status` reports pools as units and says nothing about the hardware beneath them, so every disk-level question — which disks are there, what is unassigned, which model and size is each — had no inventory to reason over.

## What it does

`src/tools/disks.ts` exports `disksList: ReadOnlyTool`, catalog name `disks_list`, `requiredRole: Role.ReadOnly`, `mutating: false`. It makes one call and maps each row to six explicitly named fields, plus a seventh whose presence is itself information:

`name`, `model`, `serial`, `size_bytes`, `type`, `transfermode` — and `pool`

Registered in `createDefaultCatalog()` between `storage_list_datasets` and `alerts_list` — grouped with the other storage/hardware tools, and read-only tools stay ahead of the mutating one — and re-exported from `src/tools/index.ts` and `src/index.ts`.

## The API call, and what the pinned client does and does not confirm

`system.client.api.query('disk.query', [], { extra: { pools: true } })` — one call, nothing else.

- **`disk.query` is typed on the pinned surface.** It is in `ApiCallDirectory$7`, which is `ApiDirectory$7` = `DefaultApiDirectory` = what `ApiSurface` resolves to (v25.10.0). It is also in `ApiCallDirectoryBase`, so its signature is identical in every generated version through v27.0.0.
- **`extra: { pools: true }` is accepted but not confirmed.** The ticket asked me to check this against the pinned client's parameter types, and the answer is in between: `QueryOptions<T>.extra` is typed `Record<string, unknown>` — "method-specific extra options (see the method's API documentation)" — so the key typechecks without the client having any opinion on whether the middleware honours it. It is not typed away, and it is not verified either.
- **`pool` is on the disk record, not added by an extra.** `DiskEntry` is erased to `Record<string, unknown>`, but `DiskEntryInput` — the shape the client gives `disk.query`'s own added/changed events — declares `pool: string | null` alongside `name`, `model`, `serial`, `size`, `transfermode` and `type`. So the field is part of the record's documented shape.

That left one genuine unknown: whether a given system populates `pool` at all. Rather than pick a side, the tool makes the answer visible — see below. I did not fall back to correlating against `pool.query` topology: that would be a second call and a second failure mode for a field the record already declares, and it would mask exactly the case the acceptance criteria ask to keep visible.

**Not run against a live TrueNAS system.** `yarn smoke` needs a host and credentials this machine does not have, so the `extra.pools` round trip is unverified against real middleware. That is the one claim here resting on the generated types alone.

## `pool` has three states, and they are distinguishable

The acceptance criteria ask that an unassigned disk be distinguishable from a disk whose pool could not be read, so:

| Result | Means |
|---|---|
| `pool: "tank"` | the disk belongs to `tank` |
| `pool: null` | the middleware says this disk belongs to no pool |
| no `pool` key | the system did not report membership — older middleware, or one that ignored `extra.pools` |

The key is spread in conditionally rather than assigned as `undefined`. The two are identical after `JSON.stringify` but not to a caller reading the object, and `'pool' in disk` is the distinction the third row depends on.

## The field list is an allowlist, and that is load-bearing here

A `disk.query` row carries `passwd` — the SED passphrase — and `kmip_uid`. Naming the output fields explicitly is what keeps them out of the tool result and so out of the conversation. The test fixture carries both, populated, and asserts the exact output key list, so a future change that widens the mapping fails rather than leaks.

Serial numbers are surfaced: identifying but not secret, and response data rather than arguments, so the "tools must not accept secrets as arguments" rule in `src/catalog/tool.ts` is not in play — as the ticket says.

Dropped, deliberately: `identifier`, `devname`, `lunid`, `zfs_guid`, `subsystem`, `number`, `bus`, `rotationrate`, `enclosure`, `sed`, `sed_status`, `hddstandby`, `advpowermgmt`, `expiretime`, `passwd`, `kmip_uid`. `name` rather than `devname` or `identifier` is the device name surfaced, because `name` is what the client's other disk verbs key on — `disk.temperatures` takes `name: string[]`.

**Both `type` and `transfermode` are included, because "transfer type" is ambiguous.** The ticket's summary and acceptance criteria say *transfer type*; the Appendix I quote says *type*. There is no field called "transfer type" — the candidates are `type` (the medium: HDD/SSD) and `transfermode` (the link mode: Auto, SATA300). The criteria say "at least", so both are surfaced under the middleware's own names rather than my guessing which was meant. If a reviewer knows which one was intended, dropping the other is a one-line follow-up.

## Tests

Five cases in `src/tools/tools.spec.ts` using the existing `fakeSystem` helper, plus the exact-list `toEqual` assertion updated to six tools and a new assertion that `disks_list` is advertised to a `Role.ReadOnly` credential. The fixture carries **every** property `DiskEntryInput` declares, so the assertions show what the tool drops as well as what it keeps; one case adds an invented `future_field` and asserts the exact output key list, which is the "the returned objects carry only fields the tool names explicitly" criterion made checkable. One case asserts the query is called with `extra.pools`, and one covers all three `pool` states in a single response.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` (91 tests) and `yarn build` all pass locally — the same four the CI workflow gates on. Coverage is **97.74 statements / 96.44 branches**, above the 97 / 96 floors; `disks.ts` is at 100 / 100. `yarn smoke` needs a live system and credentials and was not run.

The shared review from `iXsystems/ux-github-workflows@master` ran locally on this diff — the same reviewer, rubric and threshold as the required check, in a separate process — and returned **nothing at or above MEDIUM**.

## What I did not change, and why

The three LOWs that clean round raised, minus the one it was right about.

- **Fixed, because the comment contradicted the code:** the file's doc comment motivated the tool with *"do I have a spare bay"*, which needs `enclosure` — a field the allowlist drops. It now names the questions the returned fields answer and says which one they do not. Comment only; no behaviour change, and no further review round, since prose cannot break the build and the required check reads the diff again anyway.
- **`scripts/smoke.ts` still exercises three read-only tools and its header still says three.** There are now five. This is the same LOW #12 raised and recorded, and it is one line worse rather than newly true. It wants one ticket adding `disks_list`, `alerts_list` and whatever #14 lands to the smoke script together, rather than three separate touches of the same line — which is exactly why it is not being touched here for the second time.
- **`disks_list` takes no arguments and returns every disk.** `storage_list_datasets` offers a `pool` filter; this does not. Dataset counts are unbounded by anything but policy, while disk counts are bounded by the chassis, so an unfiltered inventory is a different proposition. The ticket's scope names no arguments and the criteria ask for the full inventory. A `pool` filter is cheap to add if a real response turns out to be too large.
- **The coverage floors stay at 97 / 96 while the measured figures are 97.74 / 96.44.** `vitest.config.ts` says floors are "raised by hand in the same PR that raises the coverage". I have left them, matching #12, which also raised coverage and did not move them: raising the floor to the exact measured value in a PR that lands alongside two siblings touching the same five files would fail whichever of #13 and #14 lands second for a rounding difference rather than for a real regression. Worth one deliberate bump once all three have landed.

## Note on the sibling tickets

#12 (`alerts_list`) is merged and this branches from `main` after it. #14 (`apps_list`) touches the same five registration points — `createDefaultCatalog()`, `src/tools/index.ts`, `src/index.ts`, the README "Read-only family" line, and the exact-list assertion — so whichever of the two lands second will conflict there and must rebase. That is mechanical and expected.

#11 (`feat!: require @truenas/api-client 3.x`) is still open. Nothing here should conflict with it: `disk.query` is in `ApiCallDirectoryBase`, so its signature is identical in every generated version, and none of the seven fields was touched by the v26 or v27 deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
