### PR TITLE
feat(tools): add apps_list, installed apps with state and upgrade availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_list_datasets`, `disks_list`,
-  `alerts_list`.
+  `apps_list`, `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
   poolStatus,
   listDatasets,
   disksList,
+  appsList,
   alertsList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -10,12 +10,15 @@ import { ReadOnlyTool } from '@/catalog/tool';
  * apps are where a home or small-business TrueNAS spends most of its
  * operational attention.
  *
- * The mapping is an allowlist rather than a trim, and here that is about size
- * rather than secrecy: an `app.query` row carries the app's full chart
- * metadata, its rendered portals, its `config` (the values the user filled in
- * at install time) and `active_workloads` — every container, port and volume.
- * Passing that through would make this the most expensive response in the
- * catalog, so naming the fields is the point of the tool rather than a nicety.
+ * The mapping is an allowlist rather than a trim, and it is doing two jobs at
+ * once. Size is the loud one: an `app.query` row carries the app's full chart
+ * metadata, its rendered portals and `active_workloads` — every container, port
+ * and volume — so passing it through would make this the most expensive
+ * response in the catalog. Secrecy is the quiet one: `config` holds the values
+ * the user filled in at install time, which routinely include an API key or a
+ * claim token, so naming the output fields is what keeps them out of the tool
+ * result and so out of the conversation, exactly as in `disks.ts`. Trimming is
+ * the point of the tool rather than a nicety, on both counts.
  */
 
 export const appsList: ReadOnlyTool = {

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -1,0 +1,51 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/** Applications installed on a system: what is deployed, what is running, and
+ * what has an update waiting.
+ *
+ * Nothing else in the catalog knows an application exists, so "what is running
+ * on this box" and "is anything out of date" are unanswerable without it — and
+ * apps are where a home or small-business TrueNAS spends most of its
+ * operational attention.
+ *
+ * The mapping is an allowlist rather than a trim, and here that is about size
+ * rather than secrecy: an `app.query` row carries the app's full chart
+ * metadata, its rendered portals, its `config` (the values the user filled in
+ * at install time) and `active_workloads` — every container, port and volume.
+ * Passing that through would make this the most expensive response in the
+ * catalog, so naming the fields is the point of the tool rather than a nicety.
+ */
+
+export const appsList: ReadOnlyTool = {
+  name: 'apps_list',
+  description:
+    'Applications installed on a TrueNAS system: name, installed version, ' +
+    'running state, and whether an update is waiting. Apps that are not ' +
+    'running are included — `state` distinguishes STOPPED from CRASHED, and ' +
+    'from the transient DEPLOYING and STOPPING. `upgrade_available` means a ' +
+    'newer catalog version exists (`latest_version` names it, and is null ' +
+    'when the system does not know of one); `image_updates_available` is the ' +
+    'separate question of whether the containers the app already runs have ' +
+    'newer images, which is the only kind of update a custom app can have.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const apps = await firstValueFrom(system.client.api.query('app.query'));
+    return apps.map((app) => ({
+      name: app.name,
+      // The catalog version of the app as installed. `human_version` is the
+      // middleware's display string for the same thing and is deliberately
+      // not surfaced: it splices the upstream software's version onto this
+      // one, so the two read as disagreeing, and only `version` is comparable
+      // with `latest_version`.
+      version: app.version,
+      latest_version: app.latest_version,
+      state: app.state,
+      upgrade_available: app.upgrade_available,
+      image_updates_available: app.image_updates_available,
+    }));
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,20 +1,22 @@
 import { ToolCatalog } from '@/catalog/catalog';
 import { alertsList } from '@/tools/alerts';
+import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { createSnapshot } from '@/tools/snapshots';
 import { listDatasets, poolStatus } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: five read-only tools plus one mutating tool. */
+/** The sketch's catalog: six read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(poolStatus);
   catalog.register(listDatasets);
   catalog.register(disksList);
+  catalog.register(appsList);
   catalog.register(alertsList);
   catalog.register(createSnapshot);
   return catalog;
 }
 
-export { alertsList, createSnapshot, disksList, listDatasets, poolStatus, systemInfo };
+export { alertsList, appsList, createSnapshot, disksList, listDatasets, poolStatus, systemInfo };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -4,6 +4,7 @@ import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { Role } from '@/interfaces';
 import {
   alertsList,
+  appsList,
   createDefaultCatalog,
   createSnapshot,
   disksList,
@@ -30,12 +31,13 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the six sketch tools', () => {
+  it('registers the seven sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
       'storage_list_datasets',
       'disks_list',
+      'apps_list',
       'alerts_list',
       'snapshots_create',
     ]);
@@ -47,6 +49,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises disks_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('disks_list');
+  });
+
+  it('advertises apps_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('apps_list');
   });
 });
 
@@ -207,6 +213,135 @@ describe('disks_list', () => {
   it('returns [] for a system with no disks', async () => {
     const { ctx } = fakeSystem({ ['disk.query']: [] });
     expect(await disksList.handler(ctx, {})).toEqual([]);
+  });
+});
+
+describe('apps_list', () => {
+  // Every property the middleware's app row carries, so the assertions below
+  // show what the tool drops as well as what it keeps. `config`, `portals`,
+  // `metadata` and `active_workloads` are the bulky ones, and are here to be
+  // dropped.
+  const app = (over: Record<string, unknown>) => ({
+    name: 'plex',
+    id: 'plex',
+    state: 'RUNNING',
+    upgrade_available: false,
+    latest_version: '1.2.3',
+    latest_app_version: '1.41.0.8994',
+    image_updates_available: false,
+    custom_app: false,
+    migrated: false,
+    human_version: '1.41.0.8994_1.2.3',
+    version: '1.2.3',
+    metadata: { app_version: '1.41.0.8994', capabilities: [], run_as_context: [] },
+    active_workloads: {
+      containers: 1,
+      used_ports: [{ container_port: 32400, protocol: 'tcp' }],
+      container_details: [{ id: 'abc', service_name: 'plex', image: 'plexinc/pms-docker' }],
+      volumes: [{ source: '/mnt/tank/plex', destination: '/config' }],
+    },
+    notes: null,
+    action_required: false,
+    portals: { 'Web UI': 'http://nas:32400' },
+    version_details: null,
+    config: { plex_claim_token: 'claim-abc123' },
+    ...over,
+  });
+
+  it('trims app.query to the named fields', async () => {
+    const { ctx, query } = fakeSystem({ ['app.query']: [app({})] });
+    expect(await appsList.handler(ctx, {})).toEqual([
+      {
+        name: 'plex',
+        version: '1.2.3',
+        latest_version: '1.2.3',
+        state: 'RUNNING',
+        upgrade_available: false,
+        image_updates_available: false,
+      },
+    ]);
+    // The tool reads the app list and nothing else, with no filters and no
+    // options: unlike disks_list there is no `extra` the rows depend on.
+    expect(query.mock.calls).toEqual([['app.query']]);
+  });
+
+  it('surfaces neither the install-time config nor a field a later release adds', async () => {
+    const { ctx } = fakeSystem({
+      ['app.query']: [app({ future_field: 'added by a later TrueNAS release' })],
+    });
+    const [result] = (await appsList.handler(ctx, {})) as Record<string, unknown>[];
+    expect(Object.keys(result)).toEqual([
+      'name',
+      'version',
+      'latest_version',
+      'state',
+      'upgrade_available',
+      'image_updates_available',
+    ]);
+  });
+
+  it('includes apps that are not running, keeping stopped and crashed apart', async () => {
+    const { ctx } = fakeSystem({
+      ['app.query']: [
+        app({ name: 'plex', state: 'RUNNING' }),
+        app({ name: 'nextcloud', state: 'STOPPED' }),
+        app({ name: 'jellyfin', state: 'CRASHED' }),
+        app({ name: 'immich', state: 'DEPLOYING' }),
+      ],
+    });
+    const result = (await appsList.handler(ctx, {})) as { name: string; state: string }[];
+    expect(result.map((a) => [a.name, a.state])).toEqual([
+      ['plex', 'RUNNING'],
+      ['nextcloud', 'STOPPED'],
+      ['jellyfin', 'CRASHED'],
+      ['immich', 'DEPLOYING'],
+    ]);
+  });
+
+  it('reports a waiting catalog upgrade and a waiting image update separately', async () => {
+    // A custom app has no catalog version to move to, so `upgrade_available`
+    // is permanently false and `image_updates_available` is the only signal
+    // that it is out of date. Collapsing the two would report it up to date.
+    const { ctx } = fakeSystem({
+      ['app.query']: [
+        app({
+          name: 'sonarr',
+          upgrade_available: true,
+          latest_version: '2.0.0',
+          version: '1.9.0',
+          image_updates_available: false,
+        }),
+        app({
+          name: 'my-own-thing',
+          upgrade_available: false,
+          latest_version: null,
+          image_updates_available: true,
+        }),
+      ],
+    });
+    expect(await appsList.handler(ctx, {})).toEqual([
+      {
+        name: 'sonarr',
+        version: '1.9.0',
+        latest_version: '2.0.0',
+        state: 'RUNNING',
+        upgrade_available: true,
+        image_updates_available: false,
+      },
+      {
+        name: 'my-own-thing',
+        version: '1.2.3',
+        latest_version: null,
+        state: 'RUNNING',
+        upgrade_available: false,
+        image_updates_available: true,
+      },
+    ]);
+  });
+
+  it('returns [] for a system with no apps installed', async () => {
+    const { ctx } = fakeSystem({ ['app.query']: [] });
+    expect(await appsList.handler(ctx, {})).toEqual([]);
   });
 });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -218,9 +218,10 @@ describe('disks_list', () => {
 
 describe('apps_list', () => {
   // Every property the middleware's app row carries, so the assertions below
-  // show what the tool drops as well as what it keeps. `config`, `portals`,
-  // `metadata` and `active_workloads` are the bulky ones, and are here to be
-  // dropped.
+  // show what the tool drops as well as what it keeps. `portals`, `metadata`
+  // and `active_workloads` are the bulky ones; `config` is the install-time
+  // form the user filled in, and its `plex_claim_token` is a credential. All
+  // four are here to be dropped.
   const app = (over: Record<string, unknown>) => ({
     name: 'plex',
     id: 'plex',


### PR DESCRIPTION
## What this does

Adds `apps_list`, a read-only tool returning the applications installed on each
targeted system. Nothing in the catalog knew an application existed, so half of
the suggested prompt *"check for updates to any of my TrueNAS systems and their
running Applications"* had no tool to answer it.

Each app is returned as exactly six named fields:

| field | from | why |
|---|---|---|
| `name` | `AppEntry.name` | |
| `version` | `AppEntry.version` | the installed catalog version |
| `latest_version` | `AppEntry.latest_version` | what it would move to; `null` when the system knows of none |
| `state` | `AppEntry.state` | `RUNNING` / `STOPPED` / `CRASHED` / `DEPLOYING` / `STOPPING` |
| `upgrade_available` | `AppEntry.upgrade_available` | a newer catalog version exists |
| `image_updates_available` | `AppEntry.image_updates_available` | the containers it already runs have newer images |

Registered in `createDefaultCatalog()` between `disks_list` and `alerts_list`,
re-exported from `src/tools/index.ts` and `src/index.ts`, and named in the
README's "Read-only family" line.

## Two decisions worth stating

**Upgrade availability is two fields, not one.** The middleware treats it as
two questions and they come apart: a custom app has no catalog version to move
to, so `upgrade_available` is permanently `false` and `image_updates_available`
is the only signal it is out of date. Collapsing them would report such an app
as current. A test covers both directions.

**`human_version` is not surfaced.** It splices the upstream software's version
onto the catalog one (e.g. `1.41.0.8994_1.2.3`), so alongside `version` it reads
as a disagreement, and only `version` is comparable with `latest_version`.

The field mapping is an allowlist rather than a trim, doing two jobs: an
`app.query` row carries full chart metadata, rendered portals and
`active_workloads` (every container, port and volume), which would make this the
most expensive response in the catalog — and `config` holds the install-time
form the user filled in, which routinely carries an API key or claim token. The
spec fixture includes a `plex_claim_token` and asserts it does not come out.

## Endpoint facts, confirmed against the pinned client

`app.query` is present on `DefaultApiDirectory` with `entity: AppEntry`, and
every field above is a declared property of that interface with the types used
here — including the exact `state` union. The ticket flagged the state and
upgrade property names as unconfirmed; they are confirmed now.

## Scope held

Not filed and not touched here, per the ticket: installing/upgrading/starting/
stopping an app (all mutating), VMs and containers (`vm.query`,
`virt.instance.query`, `container.query` — separate shapes, separate ticket),
and the *system* update check (`update.status`).

## Verification

Run locally, all passing:

- `yarn typecheck`
- `yarn lint`
- `yarn test:coverage` — 97 tests; global 97.82 statements / 96.47 branches,
  against floors of 97 / 96. `src/tools/apps.ts` is at 100%.
- `yarn build`

## Local review

`local-review.py` ran the shared review from
`iXsystems/ux-github-workflows@master` — the same reviewer, rubric and threshold
as the required check — in a separate process. It returned **nothing at or above
MEDIUM**, and two LOW findings.

**One LOW is fixed** (second commit, prose only): the rationale comment said the
allowlist was "about size rather than secrecy" while the diff's own fixture put
a credential in `config`. That was the comment contradicting the test beside it.

**One LOW is not fixed, deliberately:** `custom_app` is not mapped, so a caller
cannot tell a custom app from a catalog app whose catalog has not refreshed. It
is a fair point and it is an added field rather than a correction — outside what
this ticket asked for, and better taken as its own change if the distinction
turns out to matter to a caller. Recorded here so it is not lost.

## Base

Branched from `main` at `e74c0b9` (the `disks_list` merge). PR #11
(`feat!: require @truenas/api-client 3.x`) is still open and unmerged, so this
is written against the pinned 2.x `ApiSurface` as the ticket directed; if #11
lands first this will need a rebase, and the fields used here are plain
properties of `AppEntry` rather than anything `ApiSurface`-shaped.

Fixes #14
