### PR TITLE
feat(tools): add storage_pool_topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `storage_pool_status`, `storage_list_datasets`, `disks_list`,
-  `apps_list`, `alerts_list`.
+  `system_info`, `storage_pool_status`, `storage_pool_topology`,
+  `storage_list_datasets`, `disks_list`, `apps_list`, `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export {
   createDefaultCatalog,
   systemInfo,
   poolStatus,
+  poolTopology,
   listDatasets,
   disksList,
   appsList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,15 +2,17 @@ import { ToolCatalog } from '@/catalog/catalog';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
+import { poolTopology } from '@/tools/pools';
 import { createSnapshot } from '@/tools/snapshots';
 import { listDatasets, poolStatus } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: six read-only tools plus one mutating tool. */
+/** The sketch's catalog: seven read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(poolStatus);
+  catalog.register(poolTopology);
   catalog.register(listDatasets);
   catalog.register(disksList);
   catalog.register(appsList);
@@ -19,4 +21,13 @@ export function createDefaultCatalog(): ToolCatalog {
   return catalog;
 }
 
-export { alertsList, appsList, createSnapshot, disksList, listDatasets, poolStatus, systemInfo };
+export {
+  alertsList,
+  appsList,
+  createSnapshot,
+  disksList,
+  listDatasets,
+  poolStatus,
+  poolTopology,
+  systemInfo,
+};

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -44,30 +44,39 @@ interface TopologyNode {
 
 /** One vdev, or one device beneath it: the same shape at every depth. */
 interface TopologyDevice {
-  name: string | undefined;
-  type: string | undefined;
-  status: string | undefined;
+  name: string | null;
+  type: string | null;
+  status: string | null;
   disk: string | null;
   devices: TopologyDevice[];
 }
 
+/**
+ * A field the middleware did not send, reported as null rather than dropped.
+ *
+ * `undefined` serializes to no key at all, so a middleware that omits a field
+ * would hand the caller an object missing one the description promises — a
+ * shape it has not been told about, rather than a value it can see is absent.
+ * Unlike `pool` in `disks.ts`, absent and null have nothing to keep apart on a
+ * topology node: each field has one intended meaning, and "not reported" is it.
+ */
+const orNull = (value: string | null | undefined): string | null => value ?? null;
+
 function mapNode(node: TopologyNode): TopologyDevice {
   return {
-    name: node.name,
+    name: orNull(node.name),
     // The vdev kind — MIRROR, RAIDZ1, DISK, and so on — not the medium. A leaf
     // is reported as type DISK, which is how a single-disk (stripe) vdev and a
     // member of a mirror end up looking alike; their depth is what separates
     // them.
-    type: node.type,
-    status: node.status,
+    type: orNull(node.type),
+    status: orNull(node.status),
     // Null on a node that groups other devices, and null again on a leaf whose
-    // disk the middleware could not resolve — a pulled or dead device, where it
-    // reports the identifier under `unavail_disk` instead. Normalized rather
-    // than passed through, because an absent key serializes to no key at all
-    // and the description promises the caller a null. Unlike `pool` in
-    // `disks.ts`, there is nothing here for absent and null to keep apart: both
-    // mean this node does not name a disk.
-    disk: node.disk ?? null,
+    // disk the middleware could not resolve — a pulled or dead device, for
+    // which it sends `unavail_disk` in place of a disk. That block is dropped
+    // with the rest of the per-node detail, so a device in that state is
+    // located by its position in the tree rather than named.
+    disk: orNull(node.disk),
     // Nested rather than flattened. A disk being replaced is reported as a
     // `replacing` vdev holding the outgoing and incoming disks, and a draid's
     // distributed spare nests the same way; flattening would present both
@@ -86,16 +95,17 @@ export const poolTopology: ReadOnlyTool = {
     'state of that vdev or device: ONLINE is healthy, and FAULTED, DEGRADED, ' +
     'OFFLINE, UNAVAIL and REMOVED are the states that make a pool unhealthy, ' +
     'so they are what identifies the device behind a degraded pool. A device ' +
-    'in the `spare` category is the exception and is not failing in either of ' +
-    'its own states: AVAIL is an idle spare standing by, INUSE one that has ' +
-    'been swapped in for a failed disk. `disk` names the physical device, ' +
-    'matching `name` in `disks_list`. It is null on a vdev that groups other ' +
-    'devices rather than sitting on one, and null again on a device the system ' +
-    'can no longer resolve to a disk — one that has been pulled or has died ' +
-    'outright, which is what a REMOVED or UNAVAIL status on a leaf means. So a ' +
-    'null `disk` is read together with `type`: a leaf reports type DISK and ' +
-    'names itself in `name`, and that name is what identifies it when there is ' +
-    'no `disk` to give. `devices` nests: a mirror lists its ' +
+    'in the `spare` category has two states of its own that are not failures: ' +
+    'AVAIL is an idle spare standing by, INUSE one that has been swapped in ' +
+    'for a failed disk. Any other status on a spare is a failing spare, and is ' +
+    'read like any other. `disk` names the physical device, matching `name` in ' +
+    '`disks_list`. It is null on a vdev that groups other devices rather than ' +
+    'sitting on one, and null again on a device the system can no longer ' +
+    'resolve to a disk — one pulled or dead outright, which is what a REMOVED ' +
+    'or UNAVAIL status on a leaf usually means. Such a device is still ' +
+    'reported, in its place in the tree, and `name` is what ZFS calls that ' +
+    'slot; there is simply no disk left to name, so it cannot be matched ' +
+    'against `disks_list`. `devices` nests: a mirror lists its ' +
     'members, and a member being replaced lists the outgoing and incoming ' +
     'disks beneath it.',
   inputSchema: { type: 'object', properties: {} },

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -71,16 +71,19 @@ export const poolTopology: ReadOnlyTool = {
   name: 'storage_pool_topology',
   description:
     'The vdev layout of each ZFS pool and the state of every device in it. ' +
-    "Each vdev carries a `category` naming the role it serves in the pool — " +
+    'Each vdev carries a `category` naming the role it serves in the pool — ' +
     '`data`, `special`, `dedup`, `log`, `cache` or `spare` — so a cache or ' +
-    'spare device is never read as one holding data. `status` is reported on ' +
-    'every vdev and every device: anything other than ONLINE (FAULTED, ' +
-    'DEGRADED, OFFLINE, UNAVAIL, REMOVED) is why a pool is unhealthy, and is ' +
-    'the field to filter on to find the failing device. `disk` names the ' +
-    'physical device, matching `name` in `disks_list`, and is null on a vdev ' +
-    'that groups other devices rather than sitting on one. `devices` nests: a ' +
-    'mirror lists its members, and a member being replaced lists the outgoing ' +
-    'and incoming disks beneath it.',
+    'spare device is never read as one holding data. `status` is the ZFS ' +
+    'state of that vdev or device: ONLINE is healthy, and FAULTED, DEGRADED, ' +
+    'OFFLINE, UNAVAIL and REMOVED are the states that make a pool unhealthy, ' +
+    'so they are what identifies the device behind a degraded pool. A device ' +
+    'in the `spare` category is the exception and is not failing in either of ' +
+    'its own states: AVAIL is an idle spare standing by, INUSE one that has ' +
+    'been swapped in for a failed disk. `disk` names the physical device, ' +
+    'matching `name` in `disks_list`, and is null on a vdev that groups other ' +
+    'devices rather than sitting on one. `devices` nests: a mirror lists its ' +
+    'members, and a member being replaced lists the outgoing and incoming ' +
+    'disks beneath it.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -19,8 +19,11 @@ import { ReadOnlyTool } from '@/catalog/tool';
  */
 
 /**
- * The vdev roles a pool's topology is divided into, in the order they are
- * reported. Iterating a fixed list rather than the payload's own keys is what
+ * The vdev roles a pool's topology is divided into, ordered for a reader
+ * rather than after the payload: `PoolTopology` declares them data, log,
+ * cache, spare, special, dedup, and the two storage roles are grouped up
+ * beside `data` here because they hold pool data and the other three do not.
+ * Iterating a fixed list rather than the payload's own keys is what
  * keeps a category a later TrueNAS release adds out of the response — the same
  * guarantee the per-node field list gives, one level up.
  */
@@ -44,7 +47,7 @@ interface TopologyDevice {
   name: string | undefined;
   type: string | undefined;
   status: string | undefined;
-  disk: string | null | undefined;
+  disk: string | null;
   devices: TopologyDevice[];
 }
 
@@ -57,8 +60,14 @@ function mapNode(node: TopologyNode): TopologyDevice {
     // them.
     type: node.type,
     status: node.status,
-    // Null on a node that groups other devices: only a leaf sits on a disk.
-    disk: node.disk,
+    // Null on a node that groups other devices, and null again on a leaf whose
+    // disk the middleware could not resolve — a pulled or dead device, where it
+    // reports the identifier under `unavail_disk` instead. Normalized rather
+    // than passed through, because an absent key serializes to no key at all
+    // and the description promises the caller a null. Unlike `pool` in
+    // `disks.ts`, there is nothing here for absent and null to keep apart: both
+    // mean this node does not name a disk.
+    disk: node.disk ?? null,
     // Nested rather than flattened. A disk being replaced is reported as a
     // `replacing` vdev holding the outgoing and incoming disks, and a draid's
     // distributed spare nests the same way; flattening would present both
@@ -80,8 +89,13 @@ export const poolTopology: ReadOnlyTool = {
     'in the `spare` category is the exception and is not failing in either of ' +
     'its own states: AVAIL is an idle spare standing by, INUSE one that has ' +
     'been swapped in for a failed disk. `disk` names the physical device, ' +
-    'matching `name` in `disks_list`, and is null on a vdev that groups other ' +
-    'devices rather than sitting on one. `devices` nests: a mirror lists its ' +
+    'matching `name` in `disks_list`. It is null on a vdev that groups other ' +
+    'devices rather than sitting on one, and null again on a device the system ' +
+    'can no longer resolve to a disk — one that has been pulled or has died ' +
+    'outright, which is what a REMOVED or UNAVAIL status on a leaf means. So a ' +
+    'null `disk` is read together with `type`: a leaf reports type DISK and ' +
+    'names itself in `name`, and that name is what identifies it when there is ' +
+    'no `disk` to give. `devices` nests: a mirror lists its ' +
     'members, and a member being replaced lists the outgoing and incoming ' +
     'disks beneath it.',
   inputSchema: { type: 'object', properties: {} },

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -1,0 +1,107 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/** Pool internals: the vdev tree beneath each pool, and the state of every
+ * device in it.
+ *
+ * `storage_pool_status` reports a pool as one unit, so it can say a pool is
+ * DEGRADED and not which device made it so. The vdev tree is where that answer
+ * lives, and it is the difference between "your pool is unhealthy" and "disk
+ * sdf in mirror-1 has faulted".
+ *
+ * The mapping is an allowlist rather than a trim, as in `disks.ts` and
+ * `apps.ts`, and here the volume is the reason: a raw topology node carries per
+ * vdev I/O statistics, a GUID, device paths and the middleware's own
+ * `unavail_disk` block, on every node of a tree that has one leaf per disk in
+ * the system. Passed through, a 24-bay system's topology would dwarf every
+ * other response in the catalog.
+ */
+
+/**
+ * The vdev roles a pool's topology is divided into, in the order they are
+ * reported. Iterating a fixed list rather than the payload's own keys is what
+ * keeps a category a later TrueNAS release adds out of the response — the same
+ * guarantee the per-node field list gives, one level up.
+ */
+const VDEV_CATEGORIES = ['data', 'special', 'dedup', 'log', 'cache', 'spare'] as const;
+
+/**
+ * A node of the vdev tree as the middleware reports it. The generated types
+ * erase every topology category to `unknown[]`, so the fields read here are
+ * re-stated, the same way `storage.ts` re-states a ZFS property.
+ */
+interface TopologyNode {
+  name?: string;
+  type?: string;
+  status?: string;
+  disk?: string | null;
+  children?: TopologyNode[];
+}
+
+/** One vdev, or one device beneath it: the same shape at every depth. */
+interface TopologyDevice {
+  name: string | undefined;
+  type: string | undefined;
+  status: string | undefined;
+  disk: string | null | undefined;
+  devices: TopologyDevice[];
+}
+
+function mapNode(node: TopologyNode): TopologyDevice {
+  return {
+    name: node.name,
+    // The vdev kind — MIRROR, RAIDZ1, DISK, and so on — not the medium. A leaf
+    // is reported as type DISK, which is how a single-disk (stripe) vdev and a
+    // member of a mirror end up looking alike; their depth is what separates
+    // them.
+    type: node.type,
+    status: node.status,
+    // Null on a node that groups other devices: only a leaf sits on a disk.
+    disk: node.disk,
+    // Nested rather than flattened. A disk being replaced is reported as a
+    // `replacing` vdev holding the outgoing and incoming disks, and a draid's
+    // distributed spare nests the same way; flattening would present both
+    // members as peers of the mirror they sit under.
+    devices: (node.children ?? []).map(mapNode),
+  };
+}
+
+export const poolTopology: ReadOnlyTool = {
+  name: 'storage_pool_topology',
+  description:
+    'The vdev layout of each ZFS pool and the state of every device in it. ' +
+    "Each vdev carries a `category` naming the role it serves in the pool — " +
+    '`data`, `special`, `dedup`, `log`, `cache` or `spare` — so a cache or ' +
+    'spare device is never read as one holding data. `status` is reported on ' +
+    'every vdev and every device: anything other than ONLINE (FAULTED, ' +
+    'DEGRADED, OFFLINE, UNAVAIL, REMOVED) is why a pool is unhealthy, and is ' +
+    'the field to filter on to find the failing device. `disk` names the ' +
+    'physical device, matching `name` in `disks_list`, and is null on a vdev ' +
+    'that groups other devices rather than sitting on one. `devices` nests: a ' +
+    'mirror lists its members, and a member being replaced lists the outgoing ' +
+    'and incoming disks beneath it.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: `topology` is part of a pool row as it stands,
+    // and the client exposes no option that changes how it is nested.
+    const pools = await firstValueFrom(system.client.api.query('pool.query'));
+    return pools.map((pool) => ({
+      name: pool.name,
+      // The pool's own verdict, repeated from `storage_pool_status` so that a
+      // caller reaching for the tree does not have to make a second call to
+      // learn whether the tree is worth reading.
+      status: pool.status,
+      vdevs: VDEV_CATEGORIES.flatMap((category) =>
+        // A pool that has never been imported reports `topology: null`, and an
+        // older middleware may not carry every category.
+        ((pool.topology?.[category] ?? []) as TopologyNode[]).map((vdev) => ({
+          category,
+          ...mapNode(vdev),
+        })),
+      ),
+    }));
+  },
+};

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -135,6 +135,13 @@ describe('storage_pool_topology', () => {
   const group = (over: Record<string, unknown>) =>
     node({ type: 'MIRROR', path: null, device: null, disk: null, ...over });
 
+  /** A node from a middleware that did not send one of the keys read here. */
+  const without = (key: string, row: Record<string, unknown>): Record<string, unknown> => {
+    const copy = { ...row };
+    delete copy[key];
+    return copy;
+  };
+
   const pool = (topology: unknown, over: Record<string, unknown> = {}) => ({
     id: 1,
     name: 'tank',
@@ -256,6 +263,48 @@ describe('storage_pool_topology', () => {
     ]);
   });
 
+  it('gives a null disk for a device the middleware cannot resolve, key or no key', async () => {
+    // A pulled disk is reported as a leaf with `disk: null` and the identifier
+    // moved to `unavail_disk`, which this tool drops; an older middleware sends
+    // no `disk` key at all. Both are the state the description calls a null,
+    // and an absent key would serialize to no key rather than to one — so the
+    // second device is the one that fails if the mapping stops normalizing.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [
+              group({
+                name: 'mirror-0',
+                status: 'DEGRADED',
+                children: [
+                  node({
+                    name: 'sdf2',
+                    status: 'REMOVED',
+                    disk: null,
+                    unavail_disk: { guid: '9999', dev: 'sdf2' },
+                  }),
+                  without('disk', node({ name: 'sdg2', status: 'UNAVAIL' })),
+                ],
+              }),
+            ],
+          }),
+          { status: 'DEGRADED', healthy: false },
+        ),
+      ],
+    });
+    const [result] = (await poolTopology.handler(ctx, {})) as MappedPool[];
+    const [mirror] = result.vdevs;
+    expect(mirror.devices).toEqual([
+      { name: 'sdf2', type: 'DISK', status: 'REMOVED', disk: null, devices: [] },
+      { name: 'sdg2', type: 'DISK', status: 'UNAVAIL', disk: null, devices: [] },
+    ]);
+    // `toEqual` treats an absent key and an undefined one alike, so the null
+    // itself is asserted separately — that is the whole claim being made here.
+    expect(Object.keys(mirror.devices[1])).toContain('disk');
+    expect(mirror.devices[1].disk).toBeNull();
+  });
+
   it('nests a replacement beneath the mirror rather than beside its members', async () => {
     // Mid-resilver the middleware reports a `replacing` vdev holding both the
     // outgoing and the incoming disk. Flattened, the mirror would read as
@@ -325,13 +374,6 @@ describe('storage_pool_topology', () => {
     expect(Object.keys(vdev.devices[0])).toEqual(['name', 'type', 'status', 'disk', 'devices']);
   });
 
-  /** A node from a middleware that reported no `children` key on a leaf. */
-  const withoutChildren = (row: Record<string, unknown>): Record<string, unknown> => {
-    const copy = { ...row };
-    delete copy['children'];
-    return copy;
-  };
-
   it('reports a pool with no topology, and one whose keys are absent', async () => {
     // `topology` is null on a pool the middleware could not read the layout of;
     // a middleware older than a category omits its key, and one that reports a
@@ -340,7 +382,10 @@ describe('storage_pool_topology', () => {
     const { ctx } = fakeSystem({
       ['pool.query']: [
         pool(null, { name: 'unimported' }),
-        pool({ data: [withoutChildren(node({ name: 'sda2', disk: 'sda' }))] }, { name: 'stripe' }),
+        pool(
+          { data: [without('children', node({ name: 'sda2', disk: 'sda' }))] },
+          { name: 'stripe' },
+        ),
       ],
     });
     expect(await poolTopology.handler(ctx, {})).toEqual([

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -10,6 +10,7 @@ import {
   disksList,
   listDatasets,
   poolStatus,
+  poolTopology,
 } from '@/tools/index';
 
 /**
@@ -31,10 +32,11 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the seven sketch tools', () => {
+  it('registers the eight sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
+      'storage_pool_topology',
       'storage_list_datasets',
       'disks_list',
       'apps_list',
@@ -53,6 +55,12 @@ describe('createDefaultCatalog', () => {
 
   it('advertises apps_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('apps_list');
+  });
+
+  it('advertises storage_pool_topology to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'storage_pool_topology',
+    );
   });
 });
 
@@ -73,6 +81,285 @@ describe('storage_pool_status', () => {
         free_bytes: 60,
       },
     ]);
+  });
+});
+
+/** The shape `storage_pool_topology` returns, for the assertions below. */
+interface MappedDevice {
+  name: string;
+  type: string;
+  status: string;
+  disk: string | null;
+  devices: MappedDevice[];
+}
+interface MappedVdev extends MappedDevice {
+  category: string;
+}
+interface MappedPool {
+  name: string;
+  status: string;
+  vdevs: MappedVdev[];
+}
+
+describe('storage_pool_topology', () => {
+  // Every property a topology node carries, so the assertions below show what
+  // the tool drops as well as what it keeps. `stats` is the bulky one — the
+  // middleware repeats that block on every node of a tree with one leaf per
+  // disk in the system — and `path`, `guid`, `device` and `unavail_disk` are
+  // here to be dropped alongside it.
+  const node = (over: Record<string, unknown>) => ({
+    name: 'sda2',
+    type: 'DISK',
+    path: '/dev/disk/by-partuuid/11111111-2222-3333-4444-555555555555',
+    guid: '12345678901234567890',
+    status: 'ONLINE',
+    stats: {
+      timestamp: 1756000000000000000,
+      read_errors: 0,
+      write_errors: 0,
+      checksum_errors: 0,
+      ops: [0, 1, 2, 3, 4, 5],
+      bytes: [0, 1, 2, 3, 4, 5],
+      size: 4000787030016,
+      allocated: 1000000000,
+      fragmentation: 3,
+    },
+    children: [],
+    device: 'sda2',
+    disk: 'sda',
+    unavail_disk: null,
+    ...over,
+  });
+
+  /** A vdev that groups devices: no disk of its own, members underneath. */
+  const group = (over: Record<string, unknown>) =>
+    node({ type: 'MIRROR', path: null, device: null, disk: null, ...over });
+
+  const pool = (topology: unknown, over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'tank',
+    guid: '1',
+    status: 'ONLINE',
+    healthy: true,
+    size: 100,
+    allocated: 40,
+    free: 60,
+    topology,
+    ...over,
+  });
+
+  /** A full topology, with the five categories a plain pool leaves empty. */
+  const topologyOf = (over: Record<string, unknown>) => ({
+    data: [],
+    special: [],
+    dedup: [],
+    log: [],
+    cache: [],
+    spare: [],
+    ...over,
+  });
+
+  it('maps each vdev to its members, keeping the tree', async () => {
+    const { ctx, query } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [
+              group({
+                name: 'mirror-0',
+                children: [node({ name: 'sda2', disk: 'sda' }), node({ name: 'sdb2', disk: 'sdb' })],
+              }),
+            ],
+          }),
+        ),
+      ],
+    });
+    expect(await poolTopology.handler(ctx, {})).toEqual([
+      {
+        name: 'tank',
+        status: 'ONLINE',
+        vdevs: [
+          {
+            category: 'data',
+            name: 'mirror-0',
+            type: 'MIRROR',
+            status: 'ONLINE',
+            disk: null,
+            devices: [
+              { name: 'sda2', type: 'DISK', status: 'ONLINE', disk: 'sda', devices: [] },
+              { name: 'sdb2', type: 'DISK', status: 'ONLINE', disk: 'sdb', devices: [] },
+            ],
+          },
+        ],
+      },
+    ]);
+    // `topology` is part of a pool row as it stands, so the tool asks for the
+    // pool list with no filters and no options.
+    expect(query.mock.calls).toEqual([['pool.query']]);
+  });
+
+  it('labels cache, log and spare vdevs rather than folding them in with data', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [group({ name: 'raidz1-0', type: 'RAIDZ1' })],
+            special: [group({ name: 'mirror-1' })],
+            dedup: [group({ name: 'mirror-2' })],
+            log: [node({ name: 'nvme0n1p1', disk: 'nvme0n1' })],
+            cache: [node({ name: 'nvme1n1p1', disk: 'nvme1n1' })],
+            // A spare that has not been called on reports AVAIL, not ONLINE.
+            spare: [node({ name: 'sdz2', disk: 'sdz', status: 'AVAIL' })],
+          }),
+        ),
+      ],
+    });
+    const [result] = (await poolTopology.handler(ctx, {})) as MappedPool[];
+    expect(result.vdevs.map((v) => [v.category, v.name, v.status])).toEqual([
+      ['data', 'raidz1-0', 'ONLINE'],
+      ['special', 'mirror-1', 'ONLINE'],
+      ['dedup', 'mirror-2', 'ONLINE'],
+      ['log', 'nvme0n1p1', 'ONLINE'],
+      ['cache', 'nvme1n1p1', 'ONLINE'],
+      ['spare', 'sdz2', 'AVAIL'],
+    ]);
+  });
+
+  it('names the failed device by status, on the device and on the vdev above it', async () => {
+    // The question the tool exists for: the pool says DEGRADED, and the answer
+    // to "which device" has to be reachable by filtering a field rather than by
+    // reading prose.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [
+              group({
+                name: 'mirror-0',
+                status: 'DEGRADED',
+                children: [
+                  node({ name: 'sda2', disk: 'sda' }),
+                  node({ name: 'sdf2', disk: 'sdf', status: 'FAULTED' }),
+                ],
+              }),
+            ],
+          }),
+          { status: 'DEGRADED', healthy: false },
+        ),
+      ],
+    });
+    const [result] = (await poolTopology.handler(ctx, {})) as MappedPool[];
+    expect(result.status).toBe('DEGRADED');
+    const failed = result.vdevs.flatMap((v) => v.devices).filter((d) => d.status !== 'ONLINE');
+    expect(failed).toEqual([
+      { name: 'sdf2', type: 'DISK', status: 'FAULTED', disk: 'sdf', devices: [] },
+    ]);
+  });
+
+  it('nests a replacement beneath the mirror rather than beside its members', async () => {
+    // Mid-resilver the middleware reports a `replacing` vdev holding both the
+    // outgoing and the incoming disk. Flattened, the mirror would read as
+    // having three members and no indication which two are the same slot.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [
+              group({
+                name: 'mirror-0',
+                status: 'DEGRADED',
+                children: [
+                  node({ name: 'sda2', disk: 'sda' }),
+                  group({
+                    name: 'replacing-1',
+                    type: 'REPLACING',
+                    status: 'DEGRADED',
+                    children: [
+                      node({ name: 'sdf2', disk: 'sdf', status: 'FAULTED' }),
+                      node({ name: 'sdg2', disk: 'sdg' }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ),
+      ],
+    });
+    const [result] = (await poolTopology.handler(ctx, {})) as MappedPool[];
+    const [mirror] = result.vdevs;
+    expect(mirror.devices.map((d) => [d.name, d.type, d.devices.map((c) => c.disk)])).toEqual([
+      ['sda2', 'DISK', []],
+      ['replacing-1', 'REPLACING', ['sdf', 'sdg']],
+    ]);
+  });
+
+  it('surfaces neither the per-vdev statistics nor a field a later release adds', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(
+          topologyOf({
+            data: [
+              group({
+                name: 'mirror-0',
+                children: [node({ future_field: 'added by a later TrueNAS release' })],
+              }),
+            ],
+            // A vdev category a later release adds is dropped whole: the tool
+            // walks the six roles it names, not the payload's own keys.
+            future_category: [node({ name: 'sdx2', disk: 'sdx' })],
+          }),
+          { future_field: 'added by a later TrueNAS release' },
+        ),
+      ],
+    });
+    const [result] = (await poolTopology.handler(ctx, {})) as Record<string, unknown>[];
+    expect(Object.keys(result)).toEqual(['name', 'status', 'vdevs']);
+    const [vdev] = result['vdevs'] as MappedVdev[];
+    expect(Object.keys(vdev)).toEqual(['category', 'name', 'type', 'status', 'disk', 'devices']);
+    expect(Object.keys(vdev.devices[0])).toEqual(['name', 'type', 'status', 'disk', 'devices']);
+  });
+
+  /** A node from a middleware that reported no `children` key on a leaf. */
+  const withoutChildren = (row: Record<string, unknown>): Record<string, unknown> => {
+    const copy = { ...row };
+    delete copy['children'];
+    return copy;
+  };
+
+  it('reports a pool with no topology, and one whose keys are absent', async () => {
+    // `topology` is null on a pool the middleware could not read the layout of;
+    // a middleware older than a category omits its key, and one that reports a
+    // leaf without `children` omits that. None is an error, and none may take
+    // the rest of the pools down with it.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool(null, { name: 'unimported' }),
+        pool({ data: [withoutChildren(node({ name: 'sda2', disk: 'sda' }))] }, { name: 'stripe' }),
+      ],
+    });
+    expect(await poolTopology.handler(ctx, {})).toEqual([
+      { name: 'unimported', status: 'ONLINE', vdevs: [] },
+      {
+        name: 'stripe',
+        status: 'ONLINE',
+        vdevs: [
+          {
+            category: 'data',
+            name: 'sda2',
+            type: 'DISK',
+            status: 'ONLINE',
+            disk: 'sda',
+            devices: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns [] for a system with no pools', async () => {
+    const { ctx } = fakeSystem({ ['pool.query']: [] });
+    expect(await poolTopology.handler(ctx, {})).toEqual([]);
   });
 });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -315,7 +315,12 @@ describe('storage_pool_topology', () => {
     });
     const [result] = (await poolTopology.handler(ctx, {})) as Record<string, unknown>[];
     expect(Object.keys(result)).toEqual(['name', 'status', 'vdevs']);
-    const [vdev] = result['vdevs'] as MappedVdev[];
+    const vdevs = result['vdevs'] as MappedVdev[];
+    // The category a later release adds is dropped whole, rather than carried
+    // through as a second vdev alongside the mirror: the tool walks the six
+    // roles it names, not the payload's own keys.
+    expect(vdevs.map((v) => v.category)).toEqual(['data']);
+    const [vdev] = vdevs;
     expect(Object.keys(vdev)).toEqual(['category', 'name', 'type', 'status', 'disk', 'devices']);
     expect(Object.keys(vdev.devices[0])).toEqual(['name', 'type', 'status', 'disk', 'devices']);
   });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -86,9 +86,9 @@ describe('storage_pool_status', () => {
 
 /** The shape `storage_pool_topology` returns, for the assertions below. */
 interface MappedDevice {
-  name: string;
-  type: string;
-  status: string;
+  name: string | null;
+  type: string | null;
+  status: string | null;
   disk: string | null;
   devices: MappedDevice[];
 }
@@ -377,18 +377,21 @@ describe('storage_pool_topology', () => {
   it('reports a pool with no topology, and one whose keys are absent', async () => {
     // `topology` is null on a pool the middleware could not read the layout of;
     // a middleware older than a category omits its key, and one that reports a
-    // leaf without `children` omits that. None is an error, and none may take
-    // the rest of the pools down with it.
+    // leaf without `children` or without `status` omits those. None is an
+    // error, and none may take the rest of the pools down with it: an omitted
+    // field is reported as null, so the caller meets the shape the description
+    // promised with a value missing rather than a key missing.
     const { ctx } = fakeSystem({
       ['pool.query']: [
         pool(null, { name: 'unimported' }),
         pool(
-          { data: [without('children', node({ name: 'sda2', disk: 'sda' }))] },
+          { data: [without('status', without('children', node({ name: 'sda2', disk: 'sda' })))] },
           { name: 'stripe' },
         ),
       ],
     });
-    expect(await poolTopology.handler(ctx, {})).toEqual([
+    const results = (await poolTopology.handler(ctx, {})) as MappedPool[];
+    expect(results).toEqual([
       { name: 'unimported', status: 'ONLINE', vdevs: [] },
       {
         name: 'stripe',
@@ -398,13 +401,16 @@ describe('storage_pool_topology', () => {
             category: 'data',
             name: 'sda2',
             type: 'DISK',
-            status: 'ONLINE',
+            status: null,
             disk: 'sda',
             devices: [],
           },
         ],
       },
     ]);
+    // `toEqual` reads an absent key and an undefined one alike, so the key
+    // itself is asserted: that is what the normalization above buys.
+    expect(Object.keys(results[1].vdevs[0])).toContain('status');
   });
 
   it('returns [] for a system with no pools', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -299,8 +299,11 @@ describe('storage_pool_topology', () => {
       { name: 'sdf2', type: 'DISK', status: 'REMOVED', disk: null, devices: [] },
       { name: 'sdg2', type: 'DISK', status: 'UNAVAIL', disk: null, devices: [] },
     ]);
-    // `toEqual` treats an absent key and an undefined one alike, so the null
-    // itself is asserted separately — that is the whole claim being made here.
+    // Expecting null above is what enforces the normalization: `toEqual` reads
+    // an absent key and an undefined one alike, so a `disk` that stopped being
+    // normalized would arrive as undefined and fail against that null. These
+    // two say the same thing more plainly — `Object.keys` lists a key holding
+    // undefined as well, so the first is the weaker of them.
     expect(Object.keys(mirror.devices[1])).toContain('disk');
     expect(mirror.devices[1].disk).toBeNull();
   });
@@ -408,8 +411,10 @@ describe('storage_pool_topology', () => {
         ],
       },
     ]);
-    // `toEqual` reads an absent key and an undefined one alike, so the key
-    // itself is asserted: that is what the normalization above buys.
+    // Expecting null rather than undefined above is what catches a dropped
+    // `status`: `toEqual` reads an absent key and an undefined one alike, so
+    // an unnormalized field fails against that null. This restates it in the
+    // terms the caller sees — the key is present in the response object.
     expect(Object.keys(results[1].vdevs[0])).toContain('status');
   });
 


### PR DESCRIPTION
Fixes #16

`storage_pool_status` reports a pool as one unit, so it can say a pool is
DEGRADED and not which device made it so. `storage_pool_topology` walks the vdev
tree that holds the answer.

## What it returns

One object per pool — `name`, `status`, and `vdevs`. Each vdev carries the role
it serves in the pool and the same node shape at every depth:

```jsonc
{
  "name": "tank",
  "status": "DEGRADED",
  "vdevs": [
    {
      "category": "data",             // data | special | dedup | log | cache | spare
      "name": "mirror-0",
      "type": "MIRROR",
      "status": "DEGRADED",
      "disk": null,                   // null on a vdev that groups other devices,
                                      // and on a device with no disk left to name
      "devices": [
        { "name": "sda2", "type": "DISK", "status": "ONLINE",  "disk": "sda", "devices": [] },
        { "name": "sdf2", "type": "DISK", "status": "FAULTED", "disk": "sdf", "devices": [] }
      ]
    }
  ]
}
```

Every field above is always present. A field the middleware omits is reported as
null rather than dropped, through one `orNull` helper: `undefined` serializes to
no key at all, which would hand the caller a shape the description never
mentioned instead of a value it can see is absent.

Against the acceptance criteria:

- **Vdev tree, per-vdev status, member devices** — every node carries `name`,
  `type`, `status` and `disk`, and `devices` holds its members.
- **A non-ONLINE device is filterable** — `status` is the ZFS state as an enum,
  not prose, on every vdev and every device. The tool description names the
  failing states rather than defining them by exclusion, because a `spare` vdev
  has two non-ONLINE states of its own (AVAIL for an idle spare, INUSE for one
  swapped in) that are not failures. Any *other* status on a spare is a failing
  spare, and the description says so — a spare can itself go UNAVAIL.
- **Spares, cache and log are labelled** — `category` comes from a fixed list
  this file names, so a cache device is never read as one holding data.
- **Only named fields survive** — the allowlist runs at both levels: the six
  categories are iterated from that list rather than from the payload's keys, so
  a category a later release adds is dropped whole, and each node is rebuilt from
  five named fields. The node level is asserted with `Object.keys`; the category
  level by asserting the categories the response actually carries.

- **`createDefaultCatalog()`**, the exact-list assertion, the README's
  "Read-only family" line, and `src/index.ts` are all updated.

## Decisions worth flagging

- **The tree is kept, not flattened.** Mid-resilver the middleware reports a
  `replacing` vdev holding the outgoing and incoming disks, and a draid's
  distributed spare nests the same way. Flattening would present both members as
  peers of the mirror they sit under, with nothing saying which two share a slot.
- **A device the system cannot resolve to a disk reports `disk: null`, and is
  not named.** When a disk is pulled or dies outright the middleware sends
  `unavail_disk` in place of `disk`; that block is dropped with the rest of the
  per-node detail, so such a device is located by its position in the tree and
  by `name` — what ZFS calls that slot — rather than matched against
  `disks_list`. The description says this rather than promising an
  identification the response cannot make. Surfacing `unavail_disk` would mean
  passing through a block whose shape the pinned client's types do not describe
  (every topology category is erased to `unknown[]`), which is the one thing
  this file's allowlist exists to avoid; it is a ticket, not this one.
- **`extra: { flat: false }` is not passed.** The ticket flagged it unconfirmed.
  `flat` appears nowhere in the pinned client's types — not on `pool.query`, not
  anywhere — so there is no such option to pass here; `topology` is part of a
  pool row as it stands. The spec asserts the call is made as bare `pool.query`
  with no filters and no options, so if that turns out to be wrong the assertion
  is where it will be changed.
- **Per-vdev I/O statistics are dropped.** `stats` (read/write/checksum error
  counts, ops, bytes) is repeated on every node of a tree with one leaf per disk,
  and `status` is the middleware's own verdict on the same question. Surfacing
  error counts for a device that is still ONLINE is a real signal and a real
  ticket; it is not this one.
- **`VDEV_CATEGORIES` is ordered for a reader, not after the payload.**
  `PoolTopology` declares the six as data, log, cache, spare, special, dedup;
  this file groups `special` and `dedup` up beside `data` because those three
  hold pool data and the other three do not.
- **`app/CLAUDE.md` does not exist** in this repository, so there was no project
  map to follow. Nothing here introduces a convention a later cycle could not
  read off `disks.ts` or `apps.ts`, so this PR does not add one.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
locally — the four the CI workflow gates on. `pools.ts` is at 100% statements
and branches; measured global branch coverage moved from 96.17% to 96.62%
against the 96% threshold, and statements sit at 97.92% against 97%, so neither
threshold in `vitest.config.ts` needed touching. That threshold did real work
this time: normalizing each field with its own `??` left three unexercised
branches and took global branches to 95.81%, which is what pushed the
normalization into the single shared helper it is now.

`yarn smoke` needs a live TrueNAS system and was not run.

The local review ran the project's own reviewer — same rubric, threshold and
parser as the required check — and the last round returned nothing at MEDIUM or
above.

## Rounds

The first review round found one MEDIUM and it was correct: the
`future_category` fixture had no assertion observing it, so the category-level
allowlist was fixture-only and swapping the implementation for a walk over
`Object.keys(pool.topology)` would have left every assertion passing. That is
now asserted directly.

Two further rounds were spent on the same defect in two shapes — the tool
description promising the caller more than the response delivers. First that a
null `disk` meant only "this groups other devices", when a pulled or dead device
reads the same way; then, in the fix for that, that `name` identifies such a
device, when the identifier is in the `unavail_disk` block this tool drops. Both
claims are now the narrower true ones, and the field normalization that makes
the description's promises structurally hold went in alongside.

## Findings left unfixed

All LOW, recorded rather than acted on so the diff stops changing:

- **`pools.ts` splits the pool family across two modules**, with `poolStatus`
  still in `storage.ts` and no stated rule for where the next pool tool goes.
  The file is where the ticket asked for it. A rule belongs in `app/CLAUDE.md`,
  which does not exist yet. Raised in three separate rounds, so it is a real
  question — and one for the ticket that creates that file, since #17 adds to
  `pools.ts` too and the answer should be written once.
- **`TopologyNode`'s field names are hand-restated** behind a cast, because the
  client's generated types erase every topology category to `unknown[]`. A
  misspelled field name would ship green against hand-written fixtures. This is
  the same exposure `storage.ts` carries for `ZfsProperty`, and only a smoke run
  against a live system closes it.
- **No optional `pool` argument** to narrow the response, unlike
  `storage_list_datasets`, so a caller chasing one degraded pool fetches every
  pool's tree. The ticket asked for the layout of each pool and did not ask for
  a filter; on a system with a handful of pools the difference is small, and
  adding an argument nobody specified is the kind of guess that outlives the
  ticket.
- **The description explains every returned field except `type`**, and describes
  the replacement case without naming the REPLACING type that identifies it. The
  code comment on `type` covers both; the tool description does not, and it is
  the description the model reads.
- **The spec's local `MappedDevice`/`MappedVdev` types are reached through `as`
  casts**, so they document the response shape rather than check it against the
  tool's own `TopologyDevice`.
- **The dropped future category is explained twice within ten lines** of the
  spec, in the fixture comment and again above the assertion.
