### PR TITLE
feat(tools): add storage_scrub_history, the last scrub on each pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
-  `storage_list_datasets`, `disks_list`, `apps_list`, `alerts_list`.
+  `storage_scrub_history`, `storage_list_datasets`, `disks_list`, `apps_list`,
+  `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
   systemInfo,
   poolStatus,
   poolTopology,
+  scrubHistory,
   listDatasets,
   disksList,
   appsList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,17 +2,18 @@ import { ToolCatalog } from '@/catalog/catalog';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
-import { poolTopology } from '@/tools/pools';
+import { poolTopology, scrubHistory } from '@/tools/pools';
 import { createSnapshot } from '@/tools/snapshots';
 import { listDatasets, poolStatus } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: seven read-only tools plus one mutating tool. */
+/** The sketch's catalog: eight read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
+  catalog.register(scrubHistory);
   catalog.register(listDatasets);
   catalog.register(disksList);
   catalog.register(appsList);
@@ -29,5 +30,6 @@ export {
   listDatasets,
   poolStatus,
   poolTopology,
+  scrubHistory,
   systemInfo,
 };

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -175,8 +175,12 @@ interface ScanRecord {
  * decision is made is the handler, so that a row's state and its fields cannot
  * disagree about whether they are describing a scrub.
  */
-function scrubState(topology: unknown, scan: ScanRecord | null, scrub: ScanRecord | null) {
-  if (!topology) return 'UNKNOWN';
+function scrubState(
+  readable: boolean,
+  scan: ScanRecord | null,
+  scrub: ScanRecord | null,
+): string | null {
+  if (!readable) return 'UNKNOWN';
   if (!scan) return 'NEVER_SCRUBBED';
   if (!scrub) return 'UNKNOWN';
   // A paused scrub reports SCANNING with the time it was paused, and stays
@@ -221,10 +225,10 @@ export const scrubHistory: ReadOnlyTool = {
     '`duration_seconds` is the difference between the two, and is null ' +
     'whenever either is missing or is not a timestamp this tool can read. ' +
     '`errors` is the number of errors that scrub found, and is a running ' +
-    'count while one is still going. Those four fields are null exactly when ' +
-    '`state` is `NEVER_SCRUBBED` or `UNKNOWN`, because the record then ' +
-    'describes a resilver, or nothing at all, rather than a scrub; a null ' +
-    '`state` still carries them, because a scrub is on record either way. ' +
+    'count while one is still going. All four are null whenever `state` is ' +
+    '`NEVER_SCRUBBED` or `UNKNOWN`, because the record then describes a ' +
+    'resilver, or nothing at all, rather than a scrub; a null `state` still ' +
+    'carries them, because a scrub is on record either way. ' +
     '`pool` matches `name` in `storage_pool_status`.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
@@ -235,17 +239,20 @@ export const scrubHistory: ReadOnlyTool = {
     // pool is scheduled under, and carries no outcome, no time and no errors.
     const pools = await firstValueFrom(system.client.api.query('pool.query'));
     return pools.map((pool) => {
-      const scan: ScanRecord | null = pool.scan ?? null;
+      // `topology` is what says the system is reading this pool at all: it is
+      // null on one that is not imported, whose absent scan record is then an
+      // absence of evidence rather than evidence of no scrub. Whatever such a
+      // pool does carry is dropped here rather than below, so that the state
+      // and the four fields under it cannot tell different stories.
+      const readable = Boolean(pool.topology);
+      const scan: ScanRecord | null = (readable ? pool.scan : null) ?? null;
       // The scan is only this tool's subject when it is a scrub. A resilver's
       // times and error count are read through `null` rather than reported,
       // so that no field of a resilver is ever presented as one of a scrub.
       const scrub = scan?.function === 'SCRUB' ? scan : null;
       return {
         pool: pool.name,
-        // `topology` is what says the system is reading this pool at all: it
-        // is null on one that is not imported, whose absent scan record is
-        // then an absence of evidence rather than evidence of no scrub.
-        state: scrubState(pool.topology, scan, scrub),
+        state: scrubState(readable, scan, scrub),
         started_at: orNull(scrub?.start_time),
         finished_at: orNull(scrub?.end_time),
         duration_seconds: scrubDuration(scrub),

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -154,23 +154,35 @@ interface ScanRecord {
 }
 
 /**
- * The state of a pool's last scrub, from the scan the pool reports.
+ * The state of a pool's last scrub: ZFS's own state for it, or one of the two
+ * states ZFS does not have, or null.
  *
- * The two states ZFS does not have are the ones that matter here. A pool with
- * no scan at all has never been scanned, and "never verified" is the answer
- * this tool exists to give rather than a gap to leave blank. A pool whose last
- * scan was a RESILVER is the awkward one: the resilver overwrote the record of
- * whatever scrub preceded it, so its last scrub is not recoverable — which is
- * not the same as never having had one, and must not read as either a clean
- * scrub or a missing one.
+ * Those two are what the tool is for. A pool the system can read and holds no
+ * scan for has never been scanned, and "never verified" is an answer rather
+ * than a gap to leave blank. `UNKNOWN` is every way the last scrub cannot be
+ * read at all: a pool whose last scan was a RESILVER, which overwrote the
+ * record of whatever scrub preceded it, and a pool the system reports no
+ * layout for — one it is not currently reading, whose scan record is absent
+ * because there is nothing to read it from rather than because none was ever
+ * made. Neither may report as a pool that has never been scrubbed, and neither
+ * may report as a clean one.
+ *
+ * Null is the third case and is not one of those: a scrub IS on record and the
+ * system reported no state for it, so its times and error count still stand.
+ * `orNull` is what says that, here as everywhere else in this file.
+ *
+ * `scrub` is the scan once it is known to be one — the single place that
+ * decision is made is the handler, so that a row's state and its fields cannot
+ * disagree about whether they are describing a scrub.
  */
-function scrubState(scan: ScanRecord | null): string {
+function scrubState(topology: unknown, scan: ScanRecord | null, scrub: ScanRecord | null) {
+  if (!topology) return 'UNKNOWN';
   if (!scan) return 'NEVER_SCRUBBED';
-  if (scan.function !== 'SCRUB') return 'UNKNOWN';
+  if (!scrub) return 'UNKNOWN';
   // A paused scrub reports SCANNING with the time it was paused, and stays
   // that way indefinitely. Read as SCANNING it would look like progress.
-  if (scan.state === 'SCANNING' && scan.pause) return 'PAUSED';
-  return scan.state ?? 'UNKNOWN';
+  if (scrub.state === 'SCANNING' && scrub.pause) return 'PAUSED';
+  return orNull(scrub.state);
 }
 
 /**
@@ -197,20 +209,23 @@ export const scrubHistory: ReadOnlyTool = {
     'completion; `SCANNING`, one running now; `PAUSED`, one started and ' +
     'paused before it finished, which stays paused until it is resumed; ' +
     '`CANCELED`, one stopped before it completed; `NEVER_SCRUBBED`, a pool ' +
-    'the system reports no scan of any kind for; and `UNKNOWN`, a pool whose ' +
-    'most recent scan was a resilver rather than a scrub, or whose scan the ' +
-    'system reported without a state. A resilver replaces the record of the ' +
-    'scrub before it, so `UNKNOWN` means the last scrub cannot be read here — ' +
-    'it is not evidence that the pool has never been scrubbed. `started_at` ' +
-    'and `finished_at` are timestamps as the system reports them; ' +
-    '`finished_at` is null for a scrub that has not ended. ' +
+    'the system holds no scan of any kind for; `UNKNOWN`, a pool whose last ' +
+    'scrub cannot be read; and null, a scrub the system reported no state ' +
+    'for. `UNKNOWN` covers a pool whose most recent scan was a resilver, ' +
+    'which replaces the record of the scrub before it, and a pool the system ' +
+    'reports no layout for — one it is not currently reading, so that no ' +
+    'scan record is available to read. Neither is evidence that the pool has ' +
+    'never been scrubbed, and neither is evidence that it is clean. ' +
+    '`started_at` and `finished_at` are timestamps as the system reports ' +
+    'them; `finished_at` is null for a scrub that has not ended. ' +
     '`duration_seconds` is the difference between the two, and is null ' +
     'whenever either is missing or is not a timestamp this tool can read. ' +
     '`errors` is the number of errors that scrub found, and is a running ' +
-    'count while one is still going. Everything but `pool` and `state` is ' +
-    'null when `state` is `NEVER_SCRUBBED` or `UNKNOWN`, because the figures ' +
-    'on record then describe a resilver or nothing at all rather than a ' +
-    'scrub. `pool` matches `name` in `storage_pool_status`.',
+    'count while one is still going. Those four fields are null exactly when ' +
+    '`state` is `NEVER_SCRUBBED` or `UNKNOWN`, because the record then ' +
+    'describes a resilver, or nothing at all, rather than a scrub; a null ' +
+    '`state` still carries them, because a scrub is on record either way. ' +
+    '`pool` matches `name` in `storage_pool_status`.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
@@ -227,7 +242,10 @@ export const scrubHistory: ReadOnlyTool = {
       const scrub = scan?.function === 'SCRUB' ? scan : null;
       return {
         pool: pool.name,
-        state: scrubState(scan),
+        // `topology` is what says the system is reading this pool at all: it
+        // is null on one that is not imported, whose absent scan record is
+        // then an absence of evidence rather than evidence of no scrub.
+        state: scrubState(pool.topology, scan, scrub),
         started_at: orNull(scrub?.start_time),
         finished_at: orNull(scrub?.end_time),
         duration_seconds: scrubDuration(scrub),

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -2,8 +2,8 @@ import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
 
-/** Pool internals: the vdev tree beneath each pool, and the state of every
- * device in it.
+/** Pool internals: the vdev tree beneath each pool, the state of every device
+ * in it, and the outcome of the last scrub that verified it.
  *
  * `storage_pool_status` reports a pool as one unit, so it can say a pool is
  * DEGRADED and not which device made it so. The vdev tree is where that answer
@@ -58,7 +58,8 @@ interface TopologyDevice {
  * would hand the caller an object missing one the description promises — a
  * shape it has not been told about, rather than a value it can see is absent.
  * Unlike `pool` in `disks.ts`, absent and null have nothing to keep apart on a
- * topology node: each field has one intended meaning, and "not reported" is it.
+ * topology node or a scan record: each field has one intended meaning, and
+ * "not reported" is it.
  */
 const orNull = (value: string | null | undefined): string | null => value ?? null;
 
@@ -130,5 +131,108 @@ export const poolTopology: ReadOnlyTool = {
         })),
       ),
     }));
+  },
+};
+
+/**
+ * The scan record a pool row carries, restated with every field optional.
+ *
+ * ZFS records one scan per pool — the last one that ran, of either kind — and
+ * the middleware reports it as `scan` on the pool row. The generated types
+ * declare its fields required, which is what the current middleware sends; an
+ * older one that omits a key would then hand the mapping an `undefined` typed
+ * as present, which is precisely the case the normalization below exists for.
+ * Only the fields read here are named.
+ */
+interface ScanRecord {
+  function?: string;
+  state?: string;
+  start_time?: string | null;
+  end_time?: string | null;
+  errors?: number | null;
+  pause?: string | null;
+}
+
+/**
+ * The state of a pool's last scrub, from the scan the pool reports.
+ *
+ * The two states ZFS does not have are the ones that matter here. A pool with
+ * no scan at all has never been scanned, and "never verified" is the answer
+ * this tool exists to give rather than a gap to leave blank. A pool whose last
+ * scan was a RESILVER is the awkward one: the resilver overwrote the record of
+ * whatever scrub preceded it, so its last scrub is not recoverable — which is
+ * not the same as never having had one, and must not read as either a clean
+ * scrub or a missing one.
+ */
+function scrubState(scan: ScanRecord | null): string {
+  if (!scan) return 'NEVER_SCRUBBED';
+  if (scan.function !== 'SCRUB') return 'UNKNOWN';
+  // A paused scrub reports SCANNING with the time it was paused, and stays
+  // that way indefinitely. Read as SCANNING it would look like progress.
+  if (scan.state === 'SCANNING' && scan.pause) return 'PAUSED';
+  return scan.state ?? 'UNKNOWN';
+}
+
+/**
+ * How long the scrub took, in seconds, or null if that cannot be said: a scrub
+ * still running has no end time, and a timestamp in a format `Date.parse` does
+ * not accept yields no duration rather than a `NaN` the caller has to detect.
+ */
+function scrubDuration(scan: ScanRecord | null): number | null {
+  if (!scan?.start_time || !scan.end_time) return null;
+  const started = Date.parse(scan.start_time);
+  const finished = Date.parse(scan.end_time);
+  if (Number.isNaN(started) || Number.isNaN(finished)) return null;
+  return Math.round((finished - started) / 1000);
+}
+
+export const scrubHistory: ReadOnlyTool = {
+  name: 'storage_scrub_history',
+  description:
+    'The outcome and age of the most recent scrub on each ZFS pool, one entry ' +
+    'per pool. A scrub is what reads every block back and checks it against ' +
+    'its checksum, so a pool whose last scrub is old or absent is one whose ' +
+    'data has not been verified recently, however healthy it reports ' +
+    'elsewhere. `state` is one of: `FINISHED`, a scrub that ran to ' +
+    'completion; `SCANNING`, one running now; `PAUSED`, one started and ' +
+    'paused before it finished, which stays paused until it is resumed; ' +
+    '`CANCELED`, one stopped before it completed; `NEVER_SCRUBBED`, a pool ' +
+    'the system reports no scan of any kind for; and `UNKNOWN`, a pool whose ' +
+    'most recent scan was a resilver rather than a scrub, or whose scan the ' +
+    'system reported without a state. A resilver replaces the record of the ' +
+    'scrub before it, so `UNKNOWN` means the last scrub cannot be read here — ' +
+    'it is not evidence that the pool has never been scrubbed. `started_at` ' +
+    'and `finished_at` are timestamps as the system reports them; ' +
+    '`finished_at` is null for a scrub that has not ended. ' +
+    '`duration_seconds` is the difference between the two, and is null ' +
+    'whenever either is missing or is not a timestamp this tool can read. ' +
+    '`errors` is the number of errors that scrub found, and is a running ' +
+    'count while one is still going. Everything but `pool` and `state` is ' +
+    'null when `state` is `NEVER_SCRUBBED` or `UNKNOWN`, because the figures ' +
+    'on record then describe a resilver or nothing at all rather than a ' +
+    'scrub. `pool` matches `name` in `storage_pool_status`.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // `scan` is part of a pool row as it stands. `pool.scrub.query` is a
+    // neighbouring verb and not this one: it lists the periodic scrub tasks a
+    // pool is scheduled under, and carries no outcome, no time and no errors.
+    const pools = await firstValueFrom(system.client.api.query('pool.query'));
+    return pools.map((pool) => {
+      const scan: ScanRecord | null = pool.scan ?? null;
+      // The scan is only this tool's subject when it is a scrub. A resilver's
+      // times and error count are read through `null` rather than reported,
+      // so that no field of a resilver is ever presented as one of a scrub.
+      const scrub = scan?.function === 'SCRUB' ? scan : null;
+      return {
+        pool: pool.name,
+        state: scrubState(scan),
+        started_at: orNull(scrub?.start_time),
+        finished_at: orNull(scrub?.end_time),
+        duration_seconds: scrubDuration(scrub),
+        errors: scrub?.errors ?? null,
+      };
+    });
   },
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -458,6 +458,8 @@ describe('storage_scrub_history', () => {
     name: 'tank',
     status: 'ONLINE',
     healthy: true,
+    // Present on every pool the system is reading, and null on one it is not.
+    topology: { data: [{ name: 'sda2', type: 'DISK' }] },
     scan: scan({}),
     ...over,
   });
@@ -614,9 +616,32 @@ describe('storage_scrub_history', () => {
     ]);
   });
 
+  it('does not claim a pool the system is not reading has never been scrubbed', async () => {
+    // A pool that is not imported carries no topology and no scan, and the
+    // missing scan is then an absence of evidence: the record it would be read
+    // from is not there. Reported as NEVER_SCRUBBED it would raise the one
+    // alarm this tool exists to raise, about a pool nobody can answer for.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [pool({ name: 'exported', topology: null, scan: null })],
+    });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([
+      {
+        pool: 'exported',
+        state: 'UNKNOWN',
+        started_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        errors: null,
+      },
+    ]);
+  });
+
   it('normalizes a scan whose keys the middleware did not send', async () => {
     // An omitted field is reported as null, so the caller meets the shape the
     // description promised with a value missing rather than a key missing.
+    // A scrub with no state of its own is still a scrub on record, so its
+    // times and error count stand: a null state says only that ZFS's own word
+    // for the outcome is missing, where UNKNOWN says the scrub is unreadable.
     const { ctx } = fakeSystem({
       ['pool.query']: [
         pool({
@@ -628,9 +653,7 @@ describe('storage_scrub_history', () => {
     expect(results).toEqual([
       {
         pool: 'tank',
-        // A scan with no state is one this tool cannot read an outcome from,
-        // which is what UNKNOWN says — the same as for a resilver.
-        state: 'UNKNOWN',
+        state: null,
         started_at: null,
         finished_at: '2026-08-20T04:30:00+00:00',
         duration_seconds: null,
@@ -643,6 +666,7 @@ describe('storage_scrub_history', () => {
     // the same thing in the terms the caller sees.
     expect(Object.keys(results[0])).toContain('started_at');
     expect(Object.keys(results[0])).toContain('errors');
+    expect(Object.keys(results[0])).toContain('state');
   });
 
   it('gives no duration for a timestamp it cannot read', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -674,10 +674,11 @@ describe('storage_scrub_history', () => {
         errors: null,
       },
     ]);
-    // Expecting null rather than undefined above is what enforces the
-    // normalization: `toEqual` reads an absent key and an undefined one alike,
-    // so an unnormalized field would arrive as undefined and pass. This says
-    // the same thing in the terms the caller sees.
+    // Expecting null above is what enforces the normalization: `toEqual`
+    // reads an absent key and an undefined one alike, so a field that stopped
+    // being normalized would arrive as undefined and fail against that null.
+    // The keys below restate it in the terms the caller sees, and are the
+    // weaker of the two — `Object.keys` lists a key holding undefined as well.
     expect(Object.keys(results[0])).toContain('started_at');
     expect(Object.keys(results[0])).toContain('errors');
     expect(Object.keys(results[0])).toContain('state');

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -621,12 +621,26 @@ describe('storage_scrub_history', () => {
     // missing scan is then an absence of evidence: the record it would be read
     // from is not there. Reported as NEVER_SCRUBBED it would raise the one
     // alarm this tool exists to raise, about a pool nobody can answer for.
+    // The second pool is the same case carrying a stale scan anyway: the
+    // record cannot be read as current, so the state and the four fields agree
+    // that nothing is known rather than reporting a scrub the state denies.
     const { ctx } = fakeSystem({
-      ['pool.query']: [pool({ name: 'exported', topology: null, scan: null })],
+      ['pool.query']: [
+        pool({ name: 'exported', topology: null, scan: null }),
+        pool({ name: 'stale', topology: null }),
+      ],
     });
     expect(await scrubHistory.handler(ctx, {})).toEqual([
       {
         pool: 'exported',
+        state: 'UNKNOWN',
+        started_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        errors: null,
+      },
+      {
+        pool: 'stale',
         state: 'UNKNOWN',
         started_at: null,
         finished_at: null,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -11,6 +11,7 @@ import {
   listDatasets,
   poolStatus,
   poolTopology,
+  scrubHistory,
 } from '@/tools/index';
 
 /**
@@ -32,11 +33,12 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the eight sketch tools', () => {
+  it('registers the nine sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
       'storage_pool_topology',
+      'storage_scrub_history',
       'storage_list_datasets',
       'disks_list',
       'apps_list',
@@ -60,6 +62,12 @@ describe('createDefaultCatalog', () => {
   it('advertises storage_pool_topology to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'storage_pool_topology',
+    );
+  });
+
+  it('advertises storage_scrub_history to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'storage_scrub_history',
     );
   });
 });
@@ -421,6 +429,262 @@ describe('storage_pool_topology', () => {
   it('returns [] for a system with no pools', async () => {
     const { ctx } = fakeSystem({ ['pool.query']: [] });
     expect(await poolTopology.handler(ctx, {})).toEqual([]);
+  });
+});
+
+describe('storage_scrub_history', () => {
+  // Every field a scan record carries, so the assertions below show what the
+  // tool drops as well as what it keeps. `bytes_to_process`, `bytes_processed`,
+  // `bytes_issued`, `percentage` and `total_secs_left` are the progress
+  // counters, and are here to be dropped: they describe how far a scrub got,
+  // where this tool answers what it found and how long ago.
+  const scan = (over: Record<string, unknown>) => ({
+    function: 'SCRUB',
+    state: 'FINISHED',
+    start_time: '2026-08-20T01:00:00+00:00',
+    end_time: '2026-08-20T04:30:00+00:00',
+    percentage: 100,
+    bytes_to_process: 4000787030016,
+    bytes_processed: 4000787030016,
+    bytes_issued: 4000787030016,
+    pause: null,
+    errors: 0,
+    total_secs_left: null,
+    ...over,
+  });
+
+  const pool = (over: Record<string, unknown>) => ({
+    id: 1,
+    name: 'tank',
+    status: 'ONLINE',
+    healthy: true,
+    scan: scan({}),
+    ...over,
+  });
+
+  /** A pool or scan row from a middleware that did not send one of the keys. */
+  const without = (key: string, row: Record<string, unknown>): Record<string, unknown> => {
+    const copy = { ...row };
+    delete copy[key];
+    return copy;
+  };
+
+  it('reports the outcome and age of the last finished scrub', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.query']: [pool({})] });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([
+      {
+        pool: 'tank',
+        state: 'FINISHED',
+        started_at: '2026-08-20T01:00:00+00:00',
+        finished_at: '2026-08-20T04:30:00+00:00',
+        duration_seconds: 12600,
+        errors: 0,
+      },
+    ]);
+    // `scan` is part of a pool row as it stands, so the tool asks for the pool
+    // list with no filters and no options.
+    expect(query.mock.calls).toEqual([['pool.query']]);
+  });
+
+  it('keeps a scrub that found errors apart from a clean one', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({ name: 'tank' }),
+        pool({ name: 'vault', scan: scan({ errors: 3 }) }),
+      ],
+    });
+    const result = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(result.map((p) => [p['pool'], p['errors']])).toEqual([
+      ['tank', 0],
+      ['vault', 3],
+    ]);
+  });
+
+  it('distinguishes a scrub in progress from a finished one', async () => {
+    // A running scrub has no end time, so it has no duration either — the
+    // alternative is a duration measured against now, which would read as a
+    // finished scrub of that length.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [pool({ scan: scan({ state: 'SCANNING', end_time: null, percentage: 40 }) })],
+    });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([
+      {
+        pool: 'tank',
+        state: 'SCANNING',
+        started_at: '2026-08-20T01:00:00+00:00',
+        finished_at: null,
+        duration_seconds: null,
+        errors: 0,
+      },
+    ]);
+  });
+
+  it('distinguishes a paused scrub from one that is still running', async () => {
+    // ZFS reports a paused scrub as SCANNING with the time it was paused, and
+    // it stays that way until someone resumes it. Reported as SCANNING it
+    // would read as a verification in progress when nothing is progressing.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({ name: 'running', scan: scan({ state: 'SCANNING', end_time: null }) }),
+        pool({
+          name: 'paused',
+          scan: scan({
+            state: 'SCANNING',
+            end_time: null,
+            pause: '2026-08-20T02:00:00+00:00',
+          }),
+        }),
+      ],
+    });
+    const result = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(result.map((p) => [p['pool'], p['state']])).toEqual([
+      ['running', 'SCANNING'],
+      ['paused', 'PAUSED'],
+    ]);
+  });
+
+  it('reports a cancelled scrub as CANCELED rather than as a completed one', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({
+          scan: scan({ state: 'CANCELED', end_time: '2026-08-20T01:30:00+00:00', percentage: 12 }),
+        }),
+      ],
+    });
+    const [result] = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(result['state']).toBe('CANCELED');
+    expect(result['duration_seconds']).toBe(1800);
+  });
+
+  it('reports a pool that has never been scanned instead of omitting it', async () => {
+    // An absent pool reads as a pool with nothing wrong, and never-scrubbed is
+    // the finding this tool exists for. `scan` is null on a pool ZFS has never
+    // scanned; an older middleware sends no `scan` key at all.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({ name: 'fresh', scan: null }),
+        without('scan', pool({ name: 'silent' })),
+      ],
+    });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([
+      {
+        pool: 'fresh',
+        state: 'NEVER_SCRUBBED',
+        started_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        errors: null,
+      },
+      {
+        pool: 'silent',
+        state: 'NEVER_SCRUBBED',
+        started_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        errors: null,
+      },
+    ]);
+  });
+
+  it('does not present the resilver that replaced a scrub as a scrub', async () => {
+    // A pool records one scan, so a resilver overwrites the scrub before it.
+    // Passing its times and error count through would report a scrub that
+    // never ran — and on a pool that resilvered because a disk failed, which
+    // is exactly when a stale scrub matters most.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({
+          scan: scan({
+            function: 'RESILVER',
+            end_time: '2026-08-27T09:00:00+00:00',
+            errors: 5,
+          }),
+        }),
+      ],
+    });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([
+      {
+        pool: 'tank',
+        state: 'UNKNOWN',
+        started_at: null,
+        finished_at: null,
+        duration_seconds: null,
+        errors: null,
+      },
+    ]);
+  });
+
+  it('normalizes a scan whose keys the middleware did not send', async () => {
+    // An omitted field is reported as null, so the caller meets the shape the
+    // description promised with a value missing rather than a key missing.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({
+          scan: without('errors', without('state', without('start_time', scan({})))),
+        }),
+      ],
+    });
+    const results = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(results).toEqual([
+      {
+        pool: 'tank',
+        // A scan with no state is one this tool cannot read an outcome from,
+        // which is what UNKNOWN says — the same as for a resilver.
+        state: 'UNKNOWN',
+        started_at: null,
+        finished_at: '2026-08-20T04:30:00+00:00',
+        duration_seconds: null,
+        errors: null,
+      },
+    ]);
+    // Expecting null rather than undefined above is what enforces the
+    // normalization: `toEqual` reads an absent key and an undefined one alike,
+    // so an unnormalized field would arrive as undefined and pass. This says
+    // the same thing in the terms the caller sees.
+    expect(Object.keys(results[0])).toContain('started_at');
+    expect(Object.keys(results[0])).toContain('errors');
+  });
+
+  it('gives no duration for a timestamp it cannot read', async () => {
+    // The middleware's own types call these strings, so a value that is not a
+    // timestamp is a shape this tool was not told about. It yields no duration
+    // rather than a NaN the caller would have to detect.
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({ name: 'bad-start', scan: scan({ start_time: 'not a timestamp' }) }),
+        pool({ name: 'bad-end', scan: scan({ end_time: 'not a timestamp' }) }),
+      ],
+    });
+    const result = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(result.map((p) => [p['pool'], p['duration_seconds']])).toEqual([
+      ['bad-start', null],
+      ['bad-end', null],
+    ]);
+  });
+
+  it('surfaces neither the progress counters nor a field a later release adds', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.query']: [
+        pool({
+          scan: scan({ future_field: 'added by a later TrueNAS release' }),
+          future_field: 'added by a later TrueNAS release',
+        }),
+      ],
+    });
+    const [result] = (await scrubHistory.handler(ctx, {})) as Record<string, unknown>[];
+    expect(Object.keys(result)).toEqual([
+      'pool',
+      'state',
+      'started_at',
+      'finished_at',
+      'duration_seconds',
+      'errors',
+    ]);
+  });
+
+  it('returns [] for a system with no pools', async () => {
+    const { ctx } = fakeSystem({ ['pool.query']: [] });
+    expect(await scrubHistory.handler(ctx, {})).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Adds `storage_scrub_history`, a read-only tool reporting the outcome and age of the most recent scrub on each ZFS pool. Nothing in the catalog could previously say when a pool's data was last actually verified — a pool unscrubbed for months reports as perfectly healthy everywhere else.

Fixes #17

## Where the data comes from

The ticket's design notes flagged `pool.scrub.query` as unconfirmed twice. Both are now answered, and the answer is different from what either note assumed:

- **`pool.scrub.query` does exist** in the pinned client — `ApiCallDirectory` declares it, and it is in the curated `ApiCallDirectoryBase` list too.
- **It is not the right verb.** It returns `PoolScrubEntry` — `pool`, `pool_name`, `threshold`, `schedule`, `enabled`, `id`. That is the periodic scrub *task* a pool is scheduled under: no outcome, no times, no error count. Nothing in it answers this ticket.
- **The outcome lives on the pool row.** `pool.query` carries `scan`, typed `PoolScan | null`: `function` (`SCRUB` or `RESILVER`), `state` (`SCANNING` / `FINISHED` / `CANCELED`), `start_time`, `end_time`, `errors`, `pause`, and progress counters. That is what this tool reads, and it needs no second call.

## The two states ZFS does not have

ZFS records **one** scan per pool — the last one that ran, of either kind — so two cases have no ZFS state of their own and both must be visible rather than silently blank:

| `state` | Means |
|---|---|
| `NEVER_SCRUBBED` | The system is reading the pool and holds no scan for it at all |
| `UNKNOWN` | The last scrub cannot be read: the most recent scan was a **resilver**, which replaced the record of whatever scrub preceded it, or the system reports **no layout** for the pool (one it is not currently reading) |
| `null` | A scrub *is* on record and the system reported no state for it — its times and errors still stand |

`UNKNOWN` is not evidence a pool has never been scrubbed, and neither `UNKNOWN` nor `NEVER_SCRUBBED` is evidence a pool is clean. The description says so in those words.

`PAUSED` is the fourth judgement call: ZFS reports a paused scrub as `SCANNING` with a `pause` timestamp, and it stays that way until someone resumes it. Passed through as `SCANNING` it reads as verification in progress when nothing is progressing.

A resilver's times and error count are never reported as a scrub's — the fields are read through `null` when the record is not a scrub's, which is what makes the description's guarantee ("all four are null whenever `state` is `NEVER_SCRUBBED` or `UNKNOWN`") true rather than approximate.

## Shape

```jsonc
[{ "pool": "tank", "state": "FINISHED",
   "started_at": "2026-08-20T01:00:00+00:00",
   "finished_at": "2026-08-20T04:30:00+00:00",
   "duration_seconds": 12600, "errors": 0 }]
```

Six named fields, as in `storage_pool_topology`: the progress counters (`percentage`, `bytes_to_process`, `bytes_processed`, `bytes_issued`, `total_secs_left`) are dropped, since they describe how far a scrub got where this tool answers what it found and how long ago. A field a later TrueNAS release adds does not appear without a change here, and a test asserts the exact key list.

`duration_seconds` is `finished_at` minus `started_at`, and null when either is missing or is not a timestamp `Date.parse` accepts — a running scrub has no duration rather than one measured against now.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all run clean locally. Coverage: `src/tools/pools.ts` 100% statements / 100% branches; global 98.03 / 97.00 against floors of 97 / 96. All 119 tests pass, 13 of them new. Nothing in this project's CI needs anything this machine does not have.

## Review

Three rounds of the project's own shared review ran locally (`local-review.py`, exit 0/1 — the same reviewer, rubric and threshold as the required check), $5.12 total. Two MEDIUMs in round 1 and one in round 2, all fixed:

1. **A pool the system is not reading was reported `NEVER_SCRUBBED`.** An unimported pool carries no topology and no scan, and its missing scan is an absence of evidence — reporting it as never verified raises the one alarm this tool exists to raise, about a pool nobody can answer for. It is `UNKNOWN` now, and the scan of such a pool is dropped where readability is decided, so the state and the four fields cannot tell different stories.
2. **A scrub the middleware sent no state for broke the description's own guarantee** — it kept its times and errors while reading `UNKNOWN`. That case is a null `state` now, which is what `orNull` says everywhere else in this file, and the guarantee holds.
3. **"Exactly when" was an overclaim.** A running scrub is `SCANNING` with a null `finished_at` and null duration, so the null-fields rule is stated one-directionally.

Round 3 returned nothing at MEDIUM or above. It named two LOWs, left unfixed and recorded here:

- **`storage_pool_status`, `storage_pool_topology` and this tool each issue an unfiltered `pool.query`**, so a caller asking one storage-health question can pull three full pool listings, topology tree included. Real, and larger than this ticket: the fix is shared retrieval across the pool family, not a change to any one tool.
- **The spec's `without` helper is duplicated** across the topology, scrub and disks blocks (`withoutPool` is a third variant). Worth folding into one module-level helper when a fourth appears.

One LOW *was* fixed, after the clean round and without re-reviewing, because it made the diff state something untrue: a comment claimed an unnormalized field "would arrive as undefined and pass", where expecting null is exactly what makes it fail, and credited the `Object.keys` assertions with catching what they cannot. Prose only — no assertion and no executable line changed.

## Not confirmed against a live system

`start_time` and `end_time` are passed through as the system reports them, on the strength of the client's own types (`string`), the same way `alerts_list` passes `datetime` through. No live TrueNAS was available to this cycle. If a deployment reports those as something other than a parseable timestamp string, `duration_seconds` reads null rather than misreporting — the failure is visible, not silent.

Relatedly, the pinned client's newest directory types some scan timestamps as epoch numbers on a different surface. `pool.query` on the pinned version types them as strings and this compiles against that; a client major bump (#11 is open for 3.x) is where that wants re-checking.
