### PR TITLE
feat(tools): add datasets_quota_report, quota limits and headroom per dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
-  `storage_scrub_history`, `storage_list_datasets`, `disks_list`, `apps_list`,
-  `alerts_list`.
+  `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
+  `disks_list`, `apps_list`, `alerts_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export {
   poolTopology,
   scrubHistory,
   listDatasets,
+  quotaReport,
   disksList,
   appsList,
   alertsList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,10 +4,10 @@ import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { createSnapshot } from '@/tools/snapshots';
-import { listDatasets, poolStatus } from '@/tools/storage';
+import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: eight read-only tools plus one mutating tool. */
+/** The sketch's catalog: nine read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -15,6 +15,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
   catalog.register(listDatasets);
+  catalog.register(quotaReport);
   catalog.register(disksList);
   catalog.register(appsList);
   catalog.register(alertsList);
@@ -30,6 +31,7 @@ export {
   listDatasets,
   poolStatus,
   poolTopology,
+  quotaReport,
   scrubHistory,
   systemInfo,
 };

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -76,3 +76,159 @@ export const listDatasets: ReadOnlyTool = {
     }));
   },
 };
+
+/**
+ * How close each dataset is to a limit it has been given.
+ *
+ * `storage_list_datasets` reports used and available bytes, which describe a
+ * dataset's share of its pool rather than its own ceiling: a dataset can sit in
+ * a pool that is nearly empty and still be one write away from a quota. Those
+ * are different questions and only the second is asked here.
+ *
+ * ZFS enforces two limits, against two different measurements, and pairing
+ * either limit with the other measurement gives a percentage that is wrong
+ * rather than merely imprecise:
+ *
+ *     quota     caps `used`       — the dataset with its descendants and snapshots
+ *     refquota  caps `referenced` — the data the dataset itself holds, alone
+ *
+ * A parent whose children are large can therefore sit at its quota while its
+ * refquota is barely touched, which is why each limit is reported beside the
+ * usage it actually caps rather than both against one number.
+ */
+
+/**
+ * The numeric value of a ZFS property, or null where the middleware reported
+ * none.
+ *
+ * Every property this tool reads is a byte count, and the generated types erase
+ * the property object to `{}`, so `parsed` arrives as `unknown`: a value that
+ * is not a finite number is not a byte count, whatever else it may be. Null
+ * rather than a coerced zero, because a dataset whose usage could not be read
+ * must not report as one using nothing.
+ */
+function propertyBytes(property: unknown): number | null {
+  const parsed = (property as ZfsProperty | undefined)?.parsed;
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * A quota as ZFS reports it: the limit in bytes, `0` where no limit of that
+ * kind is set, or null where the property could not be read at all.
+ *
+ * The last two are the distinction this tool exists to keep. A dataset with no
+ * quota is unconstrained; one whose quota could not be read may already be over
+ * a limit nobody can see, and reporting either as the other is the failure
+ * worth avoiding.
+ *
+ * `0` is what ZFS itself reports for "no limit" rather than a sentinel chosen
+ * here, and the client types the same field `number | (0 | null)` on the
+ * dataset payload — so an explicit null is that same spelling and is reported
+ * as `0`. Only a property that is absent, or that carries no `parsed` value at
+ * all, is unreadable.
+ */
+function quotaLimit(property: unknown): number | null {
+  const value = property as ZfsProperty | undefined;
+  if (!value || !('parsed' in value)) return null;
+  if (value.parsed === null) return 0;
+  return propertyBytes(value);
+}
+
+/**
+ * Usage as a percentage of a limit, to one decimal place, or null where no
+ * percentage can be stated — an unreadable usage, an unreadable limit, or no
+ * limit at all, since nothing is a percentage of unlimited.
+ *
+ * Not capped at 100: a refquota can be lowered below what a dataset already
+ * references, and a dataset past its limit is precisely the one a caller
+ * asking this question is looking for.
+ */
+function usedPercent(used: number | null, limit: number | null): number | null {
+  if (used === null || limit === null || limit <= 0) return null;
+  return Math.round((used / limit) * 1000) / 10;
+}
+
+export const quotaReport: ReadOnlyTool = {
+  name: 'datasets_quota_report',
+  description:
+    'Quota limits on each ZFS dataset and how close it is to them. ZFS ' +
+    'enforces two separate limits, and each is reported beside the usage it ' +
+    'caps: `quota` caps `used_bytes`, the dataset together with its ' +
+    'descendants and snapshots, while `refquota` caps `referenced_bytes`, the ' +
+    'data the dataset itself holds alone. A parent with large children can ' +
+    'therefore sit at its quota while its refquota is barely touched. ' +
+    '`quota_bytes` and `refquota_bytes` are the limits in bytes. `0` means no ' +
+    'limit of that kind is set, which is what ZFS itself reports and is not ' +
+    'the same as null: null means the limit could not be read, so an ' +
+    'unconstrained dataset stays distinct from one that may already be over a ' +
+    'limit that cannot be seen. `quota_used_percent` and ' +
+    '`refquota_used_percent` are the usage as a percentage of the matching ' +
+    'limit, to one decimal place, and each is null whenever no percentage can ' +
+    'be stated — no limit set, a limit that could not be read, or a usage ' +
+    'that could not be read. Neither is capped at 100: a limit lowered below ' +
+    'what a dataset already holds reads above it, and that is the dataset ' +
+    'worth finding. `threshold_percent` restricts the result to datasets at ' +
+    'or above that percentage of either limit; a dataset with no percentage ' +
+    'at all is not returned when it is given. `id` and `pool` match the ' +
+    'fields of the same names in `storage_list_datasets`.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      threshold_percent: {
+        type: 'number',
+        description:
+          'Only report datasets using at least this percentage of a quota or ' +
+          'refquota. Omitted, every dataset is reported.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    const datasets = await firstValueFrom(
+      // Filters and options are inlined so the call's own parameter types
+      // apply, as above.
+      system.client.api.query('pool.dataset.query', [], {
+        extra: {
+          retrieve_children: true,
+          // `referenced` is a core ZFS property and the one `refquota` caps,
+          // but the generated entry type does not declare it — that type is an
+          // allowlist of the fields the generator saw, with an index signature
+          // for everything else. It is requested by name like the others, and
+          // a middleware that does not return it leaves the refquota
+          // percentage null rather than computing a wrong one against `used`.
+          properties: ['used', 'referenced', 'quota', 'refquota'],
+        },
+      }),
+    );
+    // Top-level entries only, as in `storage_list_datasets`: every dataset is
+    // already one, and each additionally nests its descendants under
+    // `children`, so walking those would report every dataset twice or more.
+    const rows = datasets.map((dataset) => {
+      const quota = quotaLimit(dataset['quota']);
+      const refquota = quotaLimit(dataset['refquota']);
+      const used = propertyBytes(dataset['used']);
+      const referenced = propertyBytes(dataset['referenced']);
+      return {
+        id: dataset['id'],
+        pool: dataset['pool'],
+        quota_bytes: quota,
+        used_bytes: used,
+        quota_used_percent: usedPercent(used, quota),
+        refquota_bytes: refquota,
+        referenced_bytes: referenced,
+        refquota_used_percent: usedPercent(referenced, refquota),
+      };
+    });
+    // Filtered here rather than in the query: the percentage is computed from
+    // two properties the middleware has no notion of comparing, so there is no
+    // filter that could express it.
+    const threshold = args['threshold_percent'];
+    if (typeof threshold !== 'number') return rows;
+    return rows.filter(
+      (row) =>
+        (row.quota_used_percent !== null && row.quota_used_percent >= threshold) ||
+        (row.refquota_used_percent !== null && row.refquota_used_percent >= threshold),
+    );
+  },
+};

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -102,11 +102,14 @@ function propertyBytes(property: unknown): number | null {
  * worth avoiding.
  *
  * `0` is what ZFS itself reports for "no limit" rather than a sentinel chosen
- * here, and the client types the same field `number | (0 | null)` on the
- * dataset payload. So a null is that same spelling wherever it appears — as
- * the property itself, or as its `parsed` value — and both report as `0`. Only
- * a property that is absent, that is not an object at all, or that carries no
- * `parsed` value is unreadable.
+ * here. Null is read as that same "no limit" wherever it appears — as the
+ * property itself, or as its `parsed` value — on the evidence that the client
+ * types this field `number | (0 | null)` on the dataset create and update
+ * payloads: the API treats the two as one meaning on the side it does type.
+ * The query response is typed `Record<string, unknown>` and settles nothing
+ * either way, so this is a reading rather than a guarantee. Only a property
+ * that is absent, that is not an object at all, or that carries no `parsed`
+ * value is unreadable.
  */
 function quotaLimit(property: unknown): number | null {
   if (property === null) return 0;
@@ -195,12 +198,13 @@ export const quotaReport: ReadOnlyTool = {
       system.client.api.query('pool.dataset.query', [], {
         extra: {
           retrieve_children: true,
-          // `referenced` is a core ZFS property and the one `refquota` caps,
-          // but the generated entry type does not declare it — that type is an
-          // allowlist of the fields the generator saw, with an index signature
-          // for everything else. It is requested by name like the others, and
-          // a middleware that does not return it leaves the refquota
-          // percentage null rather than computing a wrong one against `used`.
+          // `referenced` is a core ZFS property and the one `refquota` caps.
+          // The client declares no dataset field at all — `pool.dataset.query`
+          // answers `Record<string, unknown>` — so asking for it by name is no
+          // less grounded than asking for `used`, and equally unconfirmed
+          // against a live middleware. One that does not return it leaves the
+          // refquota percentage null rather than computing a wrong one against
+          // `used`, which caps nothing of the sort.
           properties: ['used', 'referenced', 'quota', 'refquota'],
         },
       }),

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -78,26 +78,6 @@ export const listDatasets: ReadOnlyTool = {
 };
 
 /**
- * How close each dataset is to a limit it has been given.
- *
- * `storage_list_datasets` reports used and available bytes, which describe a
- * dataset's share of its pool rather than its own ceiling: a dataset can sit in
- * a pool that is nearly empty and still be one write away from a quota. Those
- * are different questions and only the second is asked here.
- *
- * ZFS enforces two limits, against two different measurements, and pairing
- * either limit with the other measurement gives a percentage that is wrong
- * rather than merely imprecise:
- *
- *     quota     caps `used`       — the dataset with its descendants and snapshots
- *     refquota  caps `referenced` — the data the dataset itself holds, alone
- *
- * A parent whose children are large can therefore sit at its quota while its
- * refquota is barely touched, which is why each limit is reported beside the
- * usage it actually caps rather than both against one number.
- */
-
-/**
  * The numeric value of a ZFS property, or null where the middleware reported
  * none.
  *
@@ -123,15 +103,20 @@ function propertyBytes(property: unknown): number | null {
  *
  * `0` is what ZFS itself reports for "no limit" rather than a sentinel chosen
  * here, and the client types the same field `number | (0 | null)` on the
- * dataset payload — so an explicit null is that same spelling and is reported
- * as `0`. Only a property that is absent, or that carries no `parsed` value at
- * all, is unreadable.
+ * dataset payload. So a null is that same spelling wherever it appears — as
+ * the property itself, or as its `parsed` value — and both report as `0`. Only
+ * a property that is absent, that is not an object at all, or that carries no
+ * `parsed` value is unreadable.
  */
 function quotaLimit(property: unknown): number | null {
-  const value = property as ZfsProperty | undefined;
-  if (!value || !('parsed' in value)) return null;
-  if (value.parsed === null) return 0;
-  return propertyBytes(value);
+  if (property === null) return 0;
+  // The row arrives as `unknown` and this is the only guard between it and the
+  // `in` below, which throws a TypeError on a primitive rather than answering
+  // false. A property the middleware sends as a bare number or string is not
+  // the object shape this tool reads, so it is unreadable rather than fatal.
+  if (typeof property !== 'object') return null;
+  if (!('parsed' in property)) return null;
+  return (property as ZfsProperty).parsed === null ? 0 : propertyBytes(property);
 }
 
 /**
@@ -148,6 +133,25 @@ function usedPercent(used: number | null, limit: number | null): number | null {
   return Math.round((used / limit) * 1000) / 10;
 }
 
+/**
+ * How close each dataset is to a limit it has been given.
+ *
+ * `storage_list_datasets` reports used and available bytes, which describe a
+ * dataset's share of its pool rather than its own ceiling: a dataset can sit in
+ * a pool that is nearly empty and still be one write away from a quota. Those
+ * are different questions and only the second is asked here.
+ *
+ * ZFS enforces two limits, against two different measurements, and pairing
+ * either limit with the other measurement gives a percentage that is wrong
+ * rather than merely imprecise:
+ *
+ *     quota     caps `used`       — the dataset with its descendants and snapshots
+ *     refquota  caps `referenced` — the data the dataset itself holds, alone
+ *
+ * A parent whose children are large can therefore sit at its quota while its
+ * refquota is barely touched, which is why each limit is reported beside the
+ * usage it actually caps rather than both against one number.
+ */
 export const quotaReport: ReadOnlyTool = {
   name: 'datasets_quota_report',
   description:

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -942,8 +942,15 @@ describe('datasets_quota_report', () => {
   });
 
   it('ignores a threshold that is not a number', async () => {
-    const rows = await rowsFrom([dataset({ used: { parsed: 1 } })], { threshold_percent: '50' });
-    expect(rows).toHaveLength(1);
+    // Both percentages sit below the threshold — 0.3% of quota and 2.5% of
+    // refquota — so the dataset survives only because the filter never runs.
+    // A comparison against the string would coerce it and keep any dataset at
+    // or above 50 on either limit, which is what makes this row the one that
+    // tells the two paths apart.
+    const rows = await rowsFrom([dataset({ used: { parsed: 1 }, referenced: { parsed: 1 } })], {
+      threshold_percent: '50',
+    });
+    expect(rows.map((row) => row['id'])).toEqual(['tank/media']);
   });
 
   it('asks the middleware for the two limits and the two usages they cap', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -11,6 +11,7 @@ import {
   listDatasets,
   poolStatus,
   poolTopology,
+  quotaReport,
   scrubHistory,
 } from '@/tools/index';
 
@@ -33,13 +34,14 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the nine sketch tools', () => {
+  it('registers the ten sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
       'storage_list_datasets',
+      'datasets_quota_report',
       'disks_list',
       'apps_list',
       'alerts_list',
@@ -68,6 +70,12 @@ describe('createDefaultCatalog', () => {
   it('advertises storage_scrub_history to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'storage_scrub_history',
+    );
+  });
+
+  it('advertises datasets_quota_report to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'datasets_quota_report',
     );
   });
 });
@@ -762,6 +770,179 @@ describe('storage_list_datasets', () => {
       [['pool', '=', 'tank']],
       { extra: { retrieve_children: true, properties: ['used', 'available'] } },
     );
+  });
+});
+
+describe('datasets_quota_report', () => {
+  // Deliberately asymmetric: `used` against `quota` and `referenced` against
+  // `refquota` give 25% and 50%, and every other pairing of the four gives
+  // neither — so a test that passes has paired each limit with the usage ZFS
+  // actually caps with it rather than with the other one.
+  const dataset = (over: Record<string, unknown> = {}) => ({
+    id: 'tank/media',
+    pool: 'tank',
+    type: 'FILESYSTEM',
+    mountpoint: '/mnt/tank/media',
+    used: { parsed: 75 },
+    referenced: { parsed: 20 },
+    quota: { parsed: 300 },
+    refquota: { parsed: 40 },
+    children: [],
+    ...over,
+  });
+
+  /** A row from a system that did not report one of the properties at all. */
+  const without = (row: Record<string, unknown>, key: string): Record<string, unknown> => {
+    const copy = { ...row };
+    delete copy[key];
+    return copy;
+  };
+
+  const rowsFrom = async (
+    datasets: unknown[],
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['pool.dataset.query']: datasets });
+    return (await quotaReport.handler(ctx, args)) as Record<string, unknown>[];
+  };
+
+  it('pairs each limit with the usage it caps', async () => {
+    expect(await rowsFrom([dataset()])).toEqual([
+      {
+        id: 'tank/media',
+        pool: 'tank',
+        quota_bytes: 300,
+        used_bytes: 75,
+        quota_used_percent: 25,
+        refquota_bytes: 40,
+        referenced_bytes: 20,
+        refquota_used_percent: 50,
+      },
+    ]);
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const [row] = await rowsFrom([
+      dataset({ future_field: 'added by a later TrueNAS release' }),
+    ]);
+    expect(Object.keys(row)).toEqual([
+      'id',
+      'pool',
+      'quota_bytes',
+      'used_bytes',
+      'quota_used_percent',
+      'refquota_bytes',
+      'referenced_bytes',
+      'refquota_used_percent',
+    ]);
+  });
+
+  it('reports a dataset with no quota as 0, and one whose quota is unreadable as null', async () => {
+    // The distinction the tool exists for: the first is unconstrained, the
+    // second may already be over a limit that cannot be seen.
+    const [none, unreadable] = await rowsFrom([
+      dataset({ id: 'tank/none', quota: { parsed: 0 } }),
+      without(dataset({ id: 'tank/unreadable' }), 'quota'),
+    ]);
+    expect(none['quota_bytes']).toBe(0);
+    expect(unreadable['quota_bytes']).toBeNull();
+    // Neither yields a percentage, and for different reasons — nothing is a
+    // percentage of unlimited, and nothing is a percentage of unknown.
+    expect(none['quota_used_percent']).toBeNull();
+    expect(unreadable['quota_used_percent']).toBeNull();
+  });
+
+  it('reads an explicitly null limit as no limit rather than as unreadable', async () => {
+    // The client types the same field `number | (0 | null)`, so null here is
+    // ZFS spelling "no limit" the other of its two ways.
+    const [row] = await rowsFrom([dataset({ refquota: { parsed: null } })]);
+    expect(row['refquota_bytes']).toBe(0);
+    expect(row['refquota_used_percent']).toBeNull();
+  });
+
+  it('treats a property carrying no parsed value as unreadable', async () => {
+    const [row] = await rowsFrom([dataset({ quota: {}, refquota: { parsed: 'unlimited' } })]);
+    expect(row['quota_bytes']).toBeNull();
+    expect(row['refquota_bytes']).toBeNull();
+  });
+
+  it('reports an unreadable usage as null rather than as nothing used', async () => {
+    const [row] = await rowsFrom([dataset({ used: { parsed: Number.NaN }, referenced: {} })]);
+    expect(row['used_bytes']).toBeNull();
+    expect(row['referenced_bytes']).toBeNull();
+    expect(row['quota_used_percent']).toBeNull();
+    expect(row['refquota_used_percent']).toBeNull();
+  });
+
+  it('states a percentage to one decimal place', async () => {
+    const [row] = await rowsFrom([dataset({ used: { parsed: 1 }, quota: { parsed: 3 } })]);
+    expect(row['quota_used_percent']).toBe(33.3);
+  });
+
+  it('does not cap a percentage at 100', async () => {
+    // A refquota lowered below what the dataset already references. Capping it
+    // would hide exactly the dataset this tool is asked to find.
+    const [row] = await rowsFrom([dataset({ referenced: { parsed: 60 }, refquota: { parsed: 40 } })]);
+    expect(row['refquota_used_percent']).toBe(150);
+  });
+
+  it('does not duplicate datasets nested under children of other entries', async () => {
+    // pool.dataset.query returns every dataset as a top-level entry while each
+    // entry also nests its descendants under `children`.
+    const child = dataset({ id: 'tank/media/movies' });
+    const rows = await rowsFrom([dataset({ id: 'tank/media', children: [child] }), child]);
+    expect(rows.map((row) => row['id'])).toEqual(['tank/media', 'tank/media/movies']);
+  });
+
+  it('returns every dataset when no threshold is given', async () => {
+    const rows = await rowsFrom([
+      dataset({ id: 'tank/idle' }),
+      dataset({ id: 'tank/none', quota: { parsed: 0 }, refquota: { parsed: 0 } }),
+    ]);
+    expect(rows.map((row) => row['id'])).toEqual(['tank/idle', 'tank/none']);
+  });
+
+  it('keeps a dataset at or above the threshold on either limit', async () => {
+    const rows = await rowsFrom(
+      [
+        // 25% of quota, 50% of refquota — kept on the refquota alone.
+        dataset({ id: 'tank/refquota-only' }),
+        // 90% of quota, no refquota — kept on the quota alone.
+        dataset({ id: 'tank/quota-only', used: { parsed: 90 }, quota: { parsed: 100 }, refquota: { parsed: 0 } }),
+        // Exactly at the threshold, which is "at or above".
+        dataset({ id: 'tank/exact', used: { parsed: 50 }, quota: { parsed: 100 }, refquota: { parsed: 0 } }),
+        // Below on both.
+        dataset({ id: 'tank/quiet', used: { parsed: 1 }, referenced: { parsed: 1 } }),
+        // No percentage at all, on either limit.
+        without(dataset({ id: 'tank/unreadable', refquota: { parsed: 0 } }), 'quota'),
+      ],
+      { threshold_percent: 50 },
+    );
+    expect(rows.map((row) => row['id'])).toEqual([
+      'tank/refquota-only',
+      'tank/quota-only',
+      'tank/exact',
+    ]);
+  });
+
+  it('ignores a threshold that is not a number', async () => {
+    const rows = await rowsFrom([dataset({ used: { parsed: 1 } })], { threshold_percent: '50' });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('asks the middleware for the two limits and the two usages they cap', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.dataset.query']: [] });
+    await quotaReport.handler(ctx, {});
+    // `referenced` is requested by name though the generated entry type does
+    // not declare it: it is the property `refquota` caps, and without it the
+    // refquota percentage could only be computed against `used`, which caps
+    // nothing of the sort.
+    expect(query).toHaveBeenCalledWith('pool.dataset.query', [], {
+      extra: {
+        retrieve_children: true,
+        properties: ['used', 'referenced', 'quota', 'refquota'],
+      },
+    });
   });
 });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -949,10 +949,9 @@ describe('datasets_quota_report', () => {
   it('asks the middleware for the two limits and the two usages they cap', async () => {
     const { ctx, query } = fakeSystem({ ['pool.dataset.query']: [] });
     await quotaReport.handler(ctx, {});
-    // `referenced` is requested by name though the generated entry type does
-    // not declare it: it is the property `refquota` caps, and without it the
-    // refquota percentage could only be computed against `used`, which caps
-    // nothing of the sort.
+    // `referenced` is requested by name because it is the property `refquota`
+    // caps; without it the refquota percentage could only be computed against
+    // `used`, which caps nothing of the sort.
     expect(query).toHaveBeenCalledWith('pool.dataset.query', [], {
       extra: {
         retrieve_children: true,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -853,17 +853,33 @@ describe('datasets_quota_report', () => {
   });
 
   it('reads an explicitly null limit as no limit rather than as unreadable', async () => {
-    // The client types the same field `number | (0 | null)`, so null here is
-    // ZFS spelling "no limit" the other of its two ways.
-    const [row] = await rowsFrom([dataset({ refquota: { parsed: null } })]);
-    expect(row['refquota_bytes']).toBe(0);
-    expect(row['refquota_used_percent']).toBeNull();
+    // The client types the same field `number | (0 | null)`, so null is ZFS
+    // spelling "no limit" the other of its two ways — in either position.
+    const [nullParsed, nullProperty] = await rowsFrom([
+      dataset({ id: 'tank/a', refquota: { parsed: null } }),
+      dataset({ id: 'tank/b', refquota: null }),
+    ]);
+    expect(nullParsed['refquota_bytes']).toBe(0);
+    expect(nullProperty['refquota_bytes']).toBe(0);
+    expect(nullParsed['refquota_used_percent']).toBeNull();
+    expect(nullProperty['refquota_used_percent']).toBeNull();
   });
 
   it('treats a property carrying no parsed value as unreadable', async () => {
     const [row] = await rowsFrom([dataset({ quota: {}, refquota: { parsed: 'unlimited' } })]);
     expect(row['quota_bytes']).toBeNull();
     expect(row['refquota_bytes']).toBeNull();
+  });
+
+  it('survives a limit the middleware sends as a bare value rather than a property', async () => {
+    // The row is `unknown` at this seam, and a primitive would throw on the
+    // `in` test that looks for `parsed` — taking the whole report down with it
+    // rather than losing the one field it could not read.
+    const [row] = await rowsFrom([dataset({ quota: 12345, refquota: 'none' })]);
+    expect(row['quota_bytes']).toBeNull();
+    expect(row['refquota_bytes']).toBeNull();
+    // The rest of the row still stands.
+    expect(row['used_bytes']).toBe(75);
   });
 
   it('reports an unreadable usage as null rather than as nothing used', async () => {


### PR DESCRIPTION
Adds `datasets_quota_report`, a read-only tool reporting each dataset's quota limits and how close it is to them.

Fixes #18

## Why two limits and two usages

`storage_list_datasets` returns used and available bytes, which describe a dataset's share of its pool rather than its own ceiling: a dataset can sit in a nearly empty pool and still be one write away from a quota.

ZFS enforces two limits, against two different measurements:

| limit | caps | which is |
|---|---|---|
| `quota` | `used_bytes` | the dataset with its descendants and snapshots |
| `refquota` | `referenced_bytes` | the data the dataset itself holds, alone |

Each limit is reported beside the usage it actually caps. Pairing either limit with the other measurement gives a percentage that is wrong rather than imprecise — a parent whose children are large sits at its quota while its refquota is barely touched. The unit tests use deliberately asymmetric fixtures (25% and 50%) so that a crossed pairing fails rather than coinciding.

## The three states of a limit

The ticket asks that a dataset with no quota stay distinguishable from one whose quota could not be read. `quota_bytes` and `refquota_bytes` carry all three states in ZFS's own vocabulary, so no key is ever absent:

- **a number** — the limit in bytes
- **`0`** — no limit of that kind is set, which is what ZFS itself reports
- **`null`** — the property could not be read, so the dataset may already be over a limit nobody can see

`quota_used_percent` and `refquota_used_percent` are null wherever no percentage can be stated (no limit, unreadable limit, unreadable usage), and are **not capped at 100** — a limit lowered below what a dataset already holds is exactly the case worth finding.

`threshold_percent` keeps datasets at or above that percentage of *either* limit. A dataset with no percentage at all is not returned when a threshold is given.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run locally and pass. `src/tools/storage.ts` is at 100% statements and 100% branches; the global floors (branches 96, statements 97) sit at 97.26 and 98.17.

The shared review (`local-review.py`) ran here as the real check — same reviewer, rubric and threshold — over three rounds. Round 1 returned a HIGH, round 3 a MEDIUM; rounds 2 and 4 returned nothing at or above MEDIUM.

## What the reviews found, and what changed

**Round 1, HIGH — `quotaLimit` could take down the whole report.** It reached the `in` operator with a value typed `unknown`, which throws a `TypeError` on a primitive rather than answering false, so a middleware sending `quota` as a bare number or string would have lost every row rather than the one field it could not read. Guarded on `typeof`, with a test covering it. The same round noted the tool's rationale JSDoc was orphaned about seventy lines above the tool; it now sits on `quotaReport` itself.

**Round 2, two LOWs — a factual error in my comments.** Both cited `PoolDatasetEntryInput` as the shape `pool.dataset.query` returns, when that verb answers `PoolDatasetEntry`, which the client declares as a bare `Record<string, unknown>`. Fixed in `ca86168`; comments only, no executable code changed.

**Round 3, MEDIUM — the non-numeric-threshold test could not fail.** `ignores a threshold that is not a number` left the fixture at `referenced: 20` against `refquota: 40`, so `refquota_used_percent` was exactly `50`, and the filter would have evaluated `50 >= '50'` — JS coerces the string operand, the row survives, and `toHaveLength(1)` held whether or not the handler's `typeof threshold !== 'number'` guard was there. The guard was unobserved.

Fixed in `6862581` by setting `referenced: { parsed: 1 }` alongside `used: { parsed: 1 }`, which puts both percentages below the threshold — 0.3% of quota and 2.5% of refquota — so the unguarded filter drops the row while the guarded handler returns it. Verified by weakening the guard and watching the test fail, then restoring it. The assertion now names the surviving `id` rather than counting rows. Test only; the handler is unchanged.

## Not changed, and why

Round 4 came back clean and returned three LOWs, none of them fixed. Each is a design question rather than a defect, and every fix would be a new diff needing another review round.

> Tool name `datasets_quota_report` invents a one-member family, breaking the `family_tool_name` convention documented on `ToolBase.name`; sibling dataset tools use the `storage_` prefix.

Fair — `storage_dataset_quotas` would fit the existing family. But #18 specifies the catalog name `datasets_quota_report` verbatim, twice, and an acceptance criterion asserts it, so renaming it is the ticket's call rather than mine. Several sibling tickets in this batch (#19 `snapshots_list`, #23 `tasks_recent_runs`, #24 `shares_list`) name families the same way, so it is a batch-wide decision worth its own ticket rather than a one-tool slip.

> `listDatasets` keeps its inline `ZfsProperty` cast while `quotaReport` normalizes the same shape via `propertyBytes`, so `used` and `used_bytes` spell an unreadable value differently across two tools in one file.

True, and worth settling. Changing `listDatasets` means changing a tool this ticket does not own and altering what an already-shipped tool returns for an unreadable property, which is a behaviour change disguised as a tidy-up. Better as its own ticket.

> `threshold_percent` drops a dataset whose limit could not be read — the one case the rest of the file argues hardest to keep visible.

This is the sharpest of the three. `quotaLimit`'s doc says an unreadable quota "may already be over a limit nobody can see", and under a threshold that dataset is absent exactly like an idle one. It is documented behaviour rather than a contradiction — the tool description states that a dataset with no percentage at all is not returned when a threshold is given — but whether the filter should instead let an unreadable limit through, so the caller sees the gap rather than an empty answer, is a real product question. Worth a follow-up.

> `datasets_quota_report` takes no `pool` argument unlike `storage_list_datasets`, so every call queries every dataset on every targeted system with no middleware-side way to narrow.

#18 specifies `threshold_percent` as the only argument. A `pool` filter would be a genuine addition to the tool's surface, not a fix, and it belongs in whichever ticket decides the argument shape across this batch.

## Unconfirmed against a live system

The ticket flagged the ZFS property names as unconfirmed, and they remain so — every test here mocks the middleware.

`referenced` is the one worth naming: it is the property `refquota` caps, it is a core ZFS property, but the client declares no dataset field at all, so requesting it is no better grounded than requesting `used`. If a middleware does not return it, `refquota_used_percent` is null rather than wrong — the failure is a missing answer, not a misleading one. The same is true of reading a null property as "no limit", which rests on the create/update payloads typing the field `number | (0 | null)`; that is a reading, and the code comment says so.
