### PR TITLE
feat(tools): add snapshots_list, the snapshots that exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
-  `disks_list`, `apps_list`, `alerts_list`.
+  `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,5 +69,6 @@ export {
   disksList,
   appsList,
   alertsList,
+  snapshotsList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,11 +3,11 @@ import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
-import { createSnapshot } from '@/tools/snapshots';
+import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: nine read-only tools plus one mutating tool. */
+/** The sketch's catalog: ten read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -19,6 +19,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(disksList);
   catalog.register(appsList);
   catalog.register(alertsList);
+  catalog.register(snapshotsList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -33,5 +34,6 @@ export {
   poolTopology,
   quotaReport,
   scrubHistory,
+  snapshotsList,
   systemInfo,
 };

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -272,8 +272,8 @@ function byNewestFirst(a: { created: number | null }, b: { created: number | nul
 export const snapshotsList: ReadOnlyTool = {
   name: 'snapshots_list',
   description:
-    'Lists the ZFS snapshots that exist, newest first, optionally for one ' +
-    'dataset. Each entry carries `name`, the full `dataset@snapshot` name; ' +
+    'Lists the ZFS snapshots that exist, optionally for one dataset, newest ' +
+    'first. Each entry carries `name`, the full `dataset@snapshot` name; ' +
     '`dataset`, the dataset the snapshot was taken of, which matches `id` in ' +
     '`storage_list_datasets`; `created`, when it was taken, as an ISO 8601 ' +
     'UTC timestamp; and `referenced_bytes`, the data that snapshot ' +
@@ -286,11 +286,14 @@ export const snapshotsList: ReadOnlyTool = {
     'than that it is not there. The result is bounded: `snapshots` holds at ' +
     'most `limit` entries — 100 by default and 1000 at most, and the `limit` ' +
     'returned is the bound actually applied — while `truncated` is true when ' +
-    'the system holds more snapshots than were returned. The system is asked ' +
-    'for the most recent ones first, so a truncated list holds the newest ' +
-    'snapshots rather than an arbitrary window; it is still not the whole set, ' +
-    'so narrow it with `dataset`, or raise `limit`, before concluding from a ' +
-    'truncated list that some snapshot does not exist.',
+    'the system holds more snapshots than were returned. The newest-first ' +
+    'order applies to the entries returned. Which snapshots those are, when ' +
+    '`truncated` is true, is the system\'s own choice and is not necessarily ' +
+    'the newest ones it holds — so a truncated list is evidence about the ' +
+    'snapshots it names and about nothing else: it cannot show that a ' +
+    'snapshot is absent. Narrow it with `dataset`, or raise `limit`, until ' +
+    '`truncated` is false, and only then read the list as everything that ' +
+    'exists.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -320,15 +323,20 @@ export const snapshotsList: ReadOnlyTool = {
         'pool.snapshot.query',
         dataset === null ? [] : [['dataset', '=', dataset]],
         {
-          // The bound is applied by the system, so what it is asked to order by
-          // decides WHICH snapshots a truncated list holds — sorting here after
-          // it has already cut the list only orders the window it chose, and
-          // that window would be the oldest snapshots on the system rather than
-          // the newest. `createtxg` is the ZFS transaction group the snapshot
-          // was created in and only ever increases, so descending it is
-          // newest-first without depending on a clock or a property lookup.
-          order_by: ['-createtxg'],
-          // One more than the bound. That extra row is what says the system
+          // No `order_by`, deliberately. The system applies the bound, so what
+          // it is asked to sort on would decide WHICH snapshots a truncated
+          // list holds — and no field of a snapshot row orders it in time
+          // soundly. `createtxg` is a string, so a pool whose transaction
+          // groups have crossed a digit boundary sorts 999999 after 1000000;
+          // it is also the transaction group on the system holding the
+          // snapshot, so on a replication target it orders by when each
+          // snapshot was RECEIVED rather than when it was taken. The creation
+          // time itself is nested inside `properties` behind a dotted path.
+          // Asking for an order that is wrong in those cases would be worse
+          // than asking for none: the description could then claim a truncated
+          // list holds the newest snapshots, and on those systems it would not.
+          //
+          // One more row than the bound. That extra row is what says the system
           // held more than fit; it is counted and then dropped.
           limit: limit + 1,
           // Only the two properties this tool reports. A snapshot row
@@ -358,11 +366,10 @@ export const snapshotsList: ReadOnlyTool = {
       };
     });
     return {
-      // The order the rows are returned in is this tool's own, taken on the
-      // creation time it reports rather than left to the field the system was
-      // asked to sort on: the two agree, and only one of them is a field the
-      // caller can see. It is also what puts a snapshot whose creation time
-      // could not be read last rather than wherever the system placed it.
+      // The order is this tool's own, taken on the creation time it reports,
+      // so that what a caller reads is ordered by a field it can see. It
+      // orders the window rather than choosing it — which is why the
+      // description scopes the ordering to the entries returned.
       snapshots: rows.sort(byNewestFirst).map((entry) => entry.row),
       truncated: snapshots.length > limit,
       limit,

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -196,9 +196,28 @@ function propertyBytes(property: unknown): number | null {
  * A field the middleware sent as a string, or null where it sent something
  * else. Both fields read this way name the snapshot rather than measure it, so
  * there is nothing to coerce: a name that is not a string is not a name.
+ *
+ * Named for what it does rather than `orNull`, which `pools.ts` already uses
+ * for a different reading — that one takes an already-typed `string | null |
+ * undefined` and defaults it, where this one is the guard that decides whether
+ * an `unknown` is a string at all.
  */
-function orNull(value: unknown): string | null {
+function stringOrNull(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+/**
+ * One entry of a snapshot's `properties` map, or undefined where the row
+ * carries no map to read it from.
+ *
+ * Guarded rather than asserted: `properties` arrives as `unknown` and a row
+ * that sends something other than an object is exactly the case the assertion
+ * would have got wrong.
+ */
+function snapshotProperty(properties: unknown, name: string): unknown {
+  return typeof properties === 'object' && properties !== null
+    ? (properties as Record<string, unknown>)[name]
+    : undefined;
 }
 
 /**
@@ -267,20 +286,24 @@ export const snapshotsList: ReadOnlyTool = {
     'than that it is not there. The result is bounded: `snapshots` holds at ' +
     'most `limit` entries — 100 by default and 1000 at most, and the `limit` ' +
     'returned is the bound actually applied — while `truncated` is true when ' +
-    'the system held more snapshots than were returned. The bound is applied ' +
-    'by the system before the newest-first ordering, so the snapshots missing ' +
-    'from a truncated list are not necessarily the oldest: narrow it with ' +
-    '`dataset`, or raise `limit`, rather than reading a truncated list as ' +
-    'everything that exists.',
+    'the system holds more snapshots than were returned. The system is asked ' +
+    'for the most recent ones first, so a truncated list holds the newest ' +
+    'snapshots rather than an arbitrary window; it is still not the whole set, ' +
+    'so narrow it with `dataset`, or raise `limit`, before concluding from a ' +
+    'truncated list that some snapshot does not exist.',
   inputSchema: {
     type: 'object',
     properties: {
       dataset: {
         type: 'string',
+        minLength: 1,
         description: 'Only list snapshots of this dataset, e.g. "tank/media".',
       },
       limit: {
         type: 'number',
+        minimum: 1,
+        maximum: 1000,
+        default: 100,
         description: 'Return at most this many snapshots. Default 100, maximum 1000.',
       },
     },
@@ -297,6 +320,14 @@ export const snapshotsList: ReadOnlyTool = {
         'pool.snapshot.query',
         dataset === null ? [] : [['dataset', '=', dataset]],
         {
+          // The bound is applied by the system, so what it is asked to order by
+          // decides WHICH snapshots a truncated list holds — sorting here after
+          // it has already cut the list only orders the window it chose, and
+          // that window would be the oldest snapshots on the system rather than
+          // the newest. `createtxg` is the ZFS transaction group the snapshot
+          // was created in and only ever increases, so descending it is
+          // newest-first without depending on a clock or a property lookup.
+          order_by: ['-createtxg'],
           // One more than the bound. That extra row is what says the system
           // held more than fit; it is counted and then dropped.
           limit: limit + 1,
@@ -314,19 +345,24 @@ export const snapshotsList: ReadOnlyTool = {
       await assertDatasetExists(ctx, dataset);
     }
     const rows = snapshots.slice(0, limit).map((snapshot) => {
-      const properties = snapshot['properties'] as Record<string, unknown> | null | undefined;
-      const created = creationMillis(properties?.['creation']);
+      const properties = snapshot['properties'];
+      const created = creationMillis(snapshotProperty(properties, 'creation'));
       return {
         created,
         row: {
-          name: orNull(snapshot['name']),
-          dataset: orNull(snapshot['dataset']),
+          name: stringOrNull(snapshot['name']),
+          dataset: stringOrNull(snapshot['dataset']),
           created: created === null ? null : new Date(created).toISOString(),
-          referenced_bytes: propertyBytes(properties?.['referenced']),
+          referenced_bytes: propertyBytes(snapshotProperty(properties, 'referenced')),
         },
       };
     });
     return {
+      // The order the rows are returned in is this tool's own, taken on the
+      // creation time it reports rather than left to the field the system was
+      // asked to sort on: the two agree, and only one of them is a field the
+      // caller can see. It is also what puts a snapshot whose creation time
+      // could not be read last rather than wherever the system placed it.
       snapshots: rows.sort(byNewestFirst).map((entry) => entry.row),
       truncated: snapshots.length > limit,
       limit,

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -1,7 +1,9 @@
 import type { CallParams } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ApiSurface, MutatingTool, ToolContext } from '@/catalog/tool';
+import { ApiSurface, MutatingTool, ReadOnlyTool, ToolContext } from '@/catalog/tool';
+
+/** Snapshots family: the snapshots that exist, and taking a new one. */
 
 /**
  * The one mutating tool in the sketch — exists to exercise the two-phase
@@ -39,10 +41,17 @@ function createParams(args: SnapshotArgs): CallParams<ApiSurface, 'pool.snapshot
 }
 
 /**
- * Plan-time existence check. Advisory by design: execute deliberately does
- * not re-check (the "pure function of (args, system)" contract), so a dataset
- * deleted between approval and confirm surfaces as a safe API error at
- * execute time.
+ * Existence check for a dataset the caller named. Both tools in this family
+ * use it, for different reasons.
+ *
+ * For `snapshots_create` it is a plan-time check and advisory by design:
+ * execute deliberately does not re-check (the "pure function of (args,
+ * system)" contract), so a dataset deleted between approval and confirm
+ * surfaces as a safe API error at execute time.
+ *
+ * For `snapshots_list` it is what separates a dataset that does not exist from
+ * one that simply holds no snapshots, and it runs only once the listing has
+ * come back empty.
  */
 async function assertDatasetExists(ctx: ToolContext, dataset: string): Promise<void> {
   const matches = await firstValueFrom(
@@ -105,5 +114,222 @@ export const createSnapshot: MutatingTool = {
       ctx.system.client.api.call('pool.snapshot.create', createParams(args)),
     );
     return { created: snapshot['name'] };
+  },
+};
+
+/**
+ * How many snapshots `snapshots_list` returns when the caller names no bound,
+ * and the most it returns however large a bound is asked for.
+ *
+ * A nightly task on a dozen datasets holds tens of thousands of snapshots
+ * within a year, and the whole set is neither answerable inside a model's
+ * context nor useful once it is there. Both numbers are stated in the tool's
+ * description, and the bound actually applied comes back with the result, so a
+ * caller never has to infer which one was in force.
+ */
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1000;
+
+/**
+ * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
+ * than answering, so one absurd creation time would otherwise take the whole
+ * listing down with it.
+ */
+const MAX_TIME_MS = 8.64e15;
+
+/**
+ * A ZFS property as a snapshot row carries it. `pool.snapshot.query` answers
+ * rows typed `Record<string, unknown>`, so every field of a property arrives as
+ * `unknown` and is restated here — the same way `storage.ts` restates a
+ * dataset's properties.
+ */
+interface SnapshotProperty {
+  rawvalue?: unknown;
+  parsed?: unknown;
+}
+
+/**
+ * When the snapshot was taken, in milliseconds since the epoch, or null where
+ * the system reported no time this tool can read.
+ *
+ * ZFS reports `creation` as whole seconds since the epoch and `rawvalue` is
+ * that number as ZFS itself states it, so the raw value is what is read here.
+ * `parsed` is the middleware's own rendering of the same instant, whose format
+ * has differed between releases; converting the raw seconds once is what lets
+ * the description promise one timestamp format rather than pass a string
+ * through.
+ *
+ * Milliseconds rather than the formatted string, because this is also what
+ * orders the result — a snapshot has no second field that places it in time.
+ */
+function creationMillis(property: unknown): number | null {
+  const raw = (property as SnapshotProperty | undefined)?.rawvalue;
+  // Digits or nothing: `Number('')` is 0, which would report a snapshot whose
+  // creation time is an empty string as one taken at the epoch.
+  const seconds =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && /^-?\d+$/.test(raw)
+        ? Number(raw)
+        : null;
+  if (seconds === null || !Number.isFinite(seconds)) return null;
+  const millis = seconds * 1000;
+  return Number.isFinite(millis) && Math.abs(millis) <= MAX_TIME_MS ? millis : null;
+}
+
+/**
+ * The numeric value of a byte-count property, or null where the middleware
+ * reported none.
+ *
+ * The same reading `storage.ts` applies to a dataset's properties, and null for
+ * the same reason: a snapshot whose size could not be read must not report as
+ * one holding nothing. Local to this file, as `orNull` is to `pools.ts` — the
+ * two families read different payloads that happen to share ZFS's property
+ * shape, and sharing two lines would couple them.
+ */
+function propertyBytes(property: unknown): number | null {
+  const parsed = (property as SnapshotProperty | undefined)?.parsed;
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * A field the middleware sent as a string, or null where it sent something
+ * else. Both fields read this way name the snapshot rather than measure it, so
+ * there is nothing to coerce: a name that is not a string is not a name.
+ */
+function orNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * The dataset to restrict the listing to, or null for every dataset.
+ *
+ * Strict where {@link effectiveLimit} is lenient. A `dataset` argument that is
+ * not a dataset name cannot be read as "all of them" without answering a
+ * question nobody asked — the caller asked about one dataset, and a system-wide
+ * list is a wrong answer rather than a broad one.
+ */
+function requestedDataset(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error('"dataset" must be a non-empty string');
+  }
+  return raw;
+}
+
+/**
+ * The bound actually applied, from whatever the caller asked for.
+ *
+ * Lenient where {@link requestedDataset} is strict, and what the argument
+ * decides is the difference: a misread `dataset` would quietly answer about the
+ * wrong snapshots, while a misread `limit` only changes how many of the right
+ * ones come back — and the number applied is returned beside them, so a caller
+ * can see that its argument was not taken.
+ */
+function effectiveLimit(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_LIMIT;
+  // Rounded down because a fractional limit reaches the middleware as one, and
+  // floored at 1 because a limit of zero or less would return nothing while
+  // reporting the system as holding more — true, and not an answer.
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(raw)));
+}
+
+/** Newest first; a snapshot whose creation time could not be read goes last. */
+function byNewestFirst(a: { created: number | null }, b: { created: number | null }): number {
+  if (a.created === null) return b.created === null ? 0 : 1;
+  if (b.created === null) return -1;
+  return b.created - a.created;
+}
+
+/**
+ * The snapshots that exist.
+ *
+ * `snapshots_create` can make a snapshot and nothing in the catalog could see
+ * one, which is a safety gap as much as a capability gap: the plan/confirm flow
+ * shows the call about to run, and neither the user nor the model could check
+ * whether last night's snapshot is there or whether the name collides with one
+ * already taken.
+ */
+export const snapshotsList: ReadOnlyTool = {
+  name: 'snapshots_list',
+  description:
+    'Lists the ZFS snapshots that exist, newest first, optionally for one ' +
+    'dataset. Each entry carries `name`, the full `dataset@snapshot` name; ' +
+    '`dataset`, the dataset the snapshot was taken of, which matches `id` in ' +
+    '`storage_list_datasets`; `created`, when it was taken, as an ISO 8601 ' +
+    'UTC timestamp; and `referenced_bytes`, the data that snapshot ' +
+    'references. Each of the four is null where the system reported no value ' +
+    'this tool can read, and null is not zero: a snapshot referencing nothing ' +
+    'reports `referenced_bytes: 0`. A snapshot with no readable `created` is ' +
+    'ordered last rather than first. Pass `dataset` to list only that ' +
+    "dataset's snapshots; a dataset that does not exist is an error naming " +
+    'it, so an empty list always means that dataset has no snapshots rather ' +
+    'than that it is not there. The result is bounded: `snapshots` holds at ' +
+    'most `limit` entries — 100 by default and 1000 at most, and the `limit` ' +
+    'returned is the bound actually applied — while `truncated` is true when ' +
+    'the system held more snapshots than were returned. The bound is applied ' +
+    'by the system before the newest-first ordering, so the snapshots missing ' +
+    'from a truncated list are not necessarily the oldest: narrow it with ' +
+    '`dataset`, or raise `limit`, rather than reading a truncated list as ' +
+    'everything that exists.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      dataset: {
+        type: 'string',
+        description: 'Only list snapshots of this dataset, e.g. "tank/media".',
+      },
+      limit: {
+        type: 'number',
+        description: 'Return at most this many snapshots. Default 100, maximum 1000.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler(ctx, args) {
+    const dataset = requestedDataset(args['dataset']);
+    const limit = effectiveLimit(args['limit']);
+    const snapshots = await firstValueFrom(
+      // Filters and options are inlined so the call's own parameter types
+      // apply, as in `storage.ts`.
+      ctx.system.client.api.query(
+        'pool.snapshot.query',
+        dataset === null ? [] : [['dataset', '=', dataset]],
+        {
+          // One more than the bound. That extra row is what says the system
+          // held more than fit; it is counted and then dropped.
+          limit: limit + 1,
+          // Only the two properties this tool reports. A snapshot row
+          // otherwise carries every ZFS property of the snapshot, on every row.
+          extra: { properties: ['creation', 'referenced'] },
+        },
+      ),
+    );
+    // Only when the listing is empty, and only when a dataset was named: the
+    // query answers an empty list for a dataset that does not exist exactly as
+    // it does for one that has never been snapshotted, and those are different
+    // answers. A dataset that has snapshots still costs one call.
+    if (snapshots.length === 0 && dataset !== null) {
+      await assertDatasetExists(ctx, dataset);
+    }
+    const rows = snapshots.slice(0, limit).map((snapshot) => {
+      const properties = snapshot['properties'] as Record<string, unknown> | null | undefined;
+      const created = creationMillis(properties?.['creation']);
+      return {
+        created,
+        row: {
+          name: orNull(snapshot['name']),
+          dataset: orNull(snapshot['dataset']),
+          created: created === null ? null : new Date(created).toISOString(),
+          referenced_bytes: propertyBytes(properties?.['referenced']),
+        },
+      };
+    });
+    return {
+      snapshots: rows.sort(byNewestFirst).map((entry) => entry.row),
+      truncated: snapshots.length > limit,
+      limit,
+    };
   },
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1344,15 +1344,16 @@ describe('snapshots_list', () => {
     ]);
   });
 
-  it('asks the system for the newest rows, one more than the bound, and two properties', async () => {
+  it('asks for one more row than the bound, and for only the two properties it reports', async () => {
     const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
     await snapshotsList.handler(ctx, {});
-    // The ordering is what decides WHICH snapshots a truncated list holds —
-    // the system applies the bound, so sorting only after it has cut the list
-    // would order the oldest window rather than choose the newest one. The
-    // extra row is what tells a complete list from a truncated one.
+    // No `order_by`: the system applies the bound, so an order asked for here
+    // would choose which snapshots a truncated list holds, and no field of a
+    // snapshot row orders it in time soundly — `createtxg` is a string, and it
+    // counts transaction groups on the system holding the snapshot rather than
+    // the one that took it. The extra row is what tells a complete list from a
+    // truncated one.
     expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
-      order_by: ['-createtxg'],
       limit: 101,
       extra: { properties: ['creation', 'referenced'] },
     });
@@ -1362,7 +1363,6 @@ describe('snapshots_list', () => {
     const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
     await snapshotsList.handler(ctx, { dataset: 'tank/media' });
     expect(query).toHaveBeenCalledWith('pool.snapshot.query', [['dataset', '=', 'tank/media']], {
-      order_by: ['-createtxg'],
       limit: 101,
       extra: { properties: ['creation', 'referenced'] },
     });
@@ -1406,6 +1406,9 @@ describe('snapshots_list', () => {
   });
 
   it('bounds the list and says so when the system holds more', async () => {
+    // Which two come back is the system's choice — the bound is applied there,
+    // and this tool orders that window rather than choosing it. `truncated` is
+    // what says the list is not the whole set.
     const result = await listing(
       [snapshot({ name: 'a' }), snapshot({ name: 'b' }), snapshot({ name: 'c' })],
       { limit: 2 },
@@ -1428,7 +1431,6 @@ describe('snapshots_list', () => {
       // The bound reported and the bound asked of the middleware are the same
       // number, so a caller reading `limit` is reading what actually applied.
       expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
-        order_by: ['-createtxg'],
         limit: result.limit + 1,
         extra: { properties: ['creation', 'referenced'] },
       });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1344,11 +1344,15 @@ describe('snapshots_list', () => {
     ]);
   });
 
-  it('asks for one more row than the bound, and for only the two properties it reports', async () => {
+  it('asks the system for the newest rows, one more than the bound, and two properties', async () => {
     const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
     await snapshotsList.handler(ctx, {});
-    // The extra row is what tells a complete list from a truncated one.
+    // The ordering is what decides WHICH snapshots a truncated list holds —
+    // the system applies the bound, so sorting only after it has cut the list
+    // would order the oldest window rather than choose the newest one. The
+    // extra row is what tells a complete list from a truncated one.
     expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
+      order_by: ['-createtxg'],
       limit: 101,
       extra: { properties: ['creation', 'referenced'] },
     });
@@ -1357,11 +1361,11 @@ describe('snapshots_list', () => {
   it('passes a dataset filter to the query', async () => {
     const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
     await snapshotsList.handler(ctx, { dataset: 'tank/media' });
-    expect(query).toHaveBeenCalledWith(
-      'pool.snapshot.query',
-      [['dataset', '=', 'tank/media']],
-      { limit: 101, extra: { properties: ['creation', 'referenced'] } },
-    );
+    expect(query).toHaveBeenCalledWith('pool.snapshot.query', [['dataset', '=', 'tank/media']], {
+      order_by: ['-createtxg'],
+      limit: 101,
+      extra: { properties: ['creation', 'referenced'] },
+    });
     // The dataset plainly exists — it has snapshots — so nothing else is asked.
     expect(query).toHaveBeenCalledTimes(1);
   });
@@ -1424,6 +1428,7 @@ describe('snapshots_list', () => {
       // The bound reported and the bound asked of the middleware are the same
       // number, so a caller reading `limit` is reading what actually applied.
       expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
+        order_by: ['-createtxg'],
         limit: result.limit + 1,
         extra: { properties: ['creation', 'referenced'] },
       });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -13,6 +13,7 @@ import {
   poolTopology,
   quotaReport,
   scrubHistory,
+  snapshotsList,
 } from '@/tools/index';
 
 /**
@@ -34,7 +35,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the ten sketch tools', () => {
+  it('registers the eleven sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -45,6 +46,7 @@ describe('createDefaultCatalog', () => {
       'disks_list',
       'apps_list',
       'alerts_list',
+      'snapshots_list',
       'snapshots_create',
     ]);
   });
@@ -76,6 +78,12 @@ describe('createDefaultCatalog', () => {
   it('advertises datasets_quota_report to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'datasets_quota_report',
+    );
+  });
+
+  it('advertises snapshots_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'snapshots_list',
     );
   });
 });
@@ -1267,6 +1275,252 @@ describe('alerts_list', () => {
   it('returns [] for a system with no alerts', async () => {
     const { ctx } = fakeSystem({ ['alert.list']: [] });
     expect(await alertsList.handler(ctx, {})).toEqual([]);
+  });
+});
+
+describe('snapshots_list', () => {
+  /**
+   * A snapshot row as `pool.snapshot.query` reports one. `id`, `pool`,
+   * `snapshot_name`, `type` and `createtxg` are here to be dropped: they are
+   * fields of the real payload the tool does not name.
+   */
+  const snapshot = (over: Record<string, unknown> = {}) => ({
+    id: 'tank/media@nightly-1',
+    name: 'tank/media@nightly-1',
+    dataset: 'tank/media',
+    pool: 'tank',
+    snapshot_name: 'nightly-1',
+    type: 'SNAPSHOT',
+    createtxg: '12345',
+    properties: {
+      creation: { value: 'Thu Aug 28 02:00 2025', rawvalue: '1756346400', parsed: 1756346400 },
+      referenced: { value: '96K', rawvalue: '98304', parsed: 98304 },
+    },
+    ...over,
+  });
+
+  /** The tool's own envelope, for the assertions below. */
+  interface Listing {
+    snapshots: Record<string, unknown>[];
+    truncated: boolean;
+    limit: number;
+  }
+
+  const listing = async (
+    snapshots: unknown[],
+    args: Record<string, unknown> = {},
+    datasets: unknown[] = [],
+  ): Promise<Listing> => {
+    const { ctx } = fakeSystem({
+      ['pool.snapshot.query']: snapshots,
+      ['pool.dataset.query']: datasets,
+    });
+    return (await snapshotsList.handler(ctx, args)) as unknown as Listing;
+  };
+
+  it('maps a snapshot to its name, dataset, creation time and referenced size', async () => {
+    const result = await listing([snapshot()]);
+    expect(result).toEqual({
+      snapshots: [
+        {
+          name: 'tank/media@nightly-1',
+          dataset: 'tank/media',
+          created: '2025-08-28T02:00:00.000Z',
+          referenced_bytes: 98304,
+        },
+      ],
+      truncated: false,
+      limit: 100,
+    });
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const result = await listing([snapshot({ future_field: 'added by a later TrueNAS release' })]);
+    expect(Object.keys(result.snapshots[0])).toEqual([
+      'name',
+      'dataset',
+      'created',
+      'referenced_bytes',
+    ]);
+  });
+
+  it('asks for one more row than the bound, and for only the two properties it reports', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
+    await snapshotsList.handler(ctx, {});
+    // The extra row is what tells a complete list from a truncated one.
+    expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
+      limit: 101,
+      extra: { properties: ['creation', 'referenced'] },
+    });
+  });
+
+  it('passes a dataset filter to the query', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
+    await snapshotsList.handler(ctx, { dataset: 'tank/media' });
+    expect(query).toHaveBeenCalledWith(
+      'pool.snapshot.query',
+      [['dataset', '=', 'tank/media']],
+      { limit: 101, extra: { properties: ['creation', 'referenced'] } },
+    );
+    // The dataset plainly exists — it has snapshots — so nothing else is asked.
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a dataset that exists and holds no snapshots as an empty list', async () => {
+    expect(await listing([], { dataset: 'tank/empty' }, [{ id: 'tank/empty' }])).toEqual({
+      snapshots: [],
+      truncated: false,
+      limit: 100,
+    });
+  });
+
+  it('distinguishes a dataset that does not exist from one with no snapshots', async () => {
+    // Same empty snapshot list as above; the dataset query is what differs.
+    await expect(listing([], { dataset: 'tank/ghost' }, [])).rejects.toThrow(
+      /Dataset "tank\/ghost" does not exist/,
+    );
+  });
+
+  it('does not check for the dataset when none was named', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [] });
+    await expect(snapshotsList.handler(ctx, {})).resolves.toEqual({
+      snapshots: [],
+      truncated: false,
+      limit: 100,
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a dataset argument that is not a dataset name', async () => {
+    // Ignoring it would answer with every snapshot on the system, which is a
+    // wrong answer to the question asked rather than a broad one.
+    for (const bad of [123, '', true, {}]) {
+      await expect(listing([snapshot()], { dataset: bad })).rejects.toThrow(
+        /"dataset" must be a non-empty string/,
+      );
+    }
+  });
+
+  it('bounds the list and says so when the system holds more', async () => {
+    const result = await listing(
+      [snapshot({ name: 'a' }), snapshot({ name: 'b' }), snapshot({ name: 'c' })],
+      { limit: 2 },
+    );
+    expect(result.snapshots.map((row) => row['name'])).toEqual(['a', 'b']);
+    expect(result.truncated).toBe(true);
+    expect(result.limit).toBe(2);
+  });
+
+  it('is not truncated when the system holds exactly the bound', async () => {
+    const result = await listing([snapshot({ name: 'a' }), snapshot({ name: 'b' })], { limit: 2 });
+    expect(result.snapshots).toHaveLength(2);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('clamps the bound, and reports the one it applied', async () => {
+    const applied = async (limit: unknown): Promise<number> => {
+      const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [] });
+      const result = (await snapshotsList.handler(ctx, { limit })) as unknown as Listing;
+      // The bound reported and the bound asked of the middleware are the same
+      // number, so a caller reading `limit` is reading what actually applied.
+      expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
+        limit: result.limit + 1,
+        extra: { properties: ['creation', 'referenced'] },
+      });
+      return result.limit;
+    };
+    expect(await applied(5000)).toBe(1000);
+    // Zero would return nothing while reporting the system as holding more.
+    expect(await applied(0)).toBe(1);
+    expect(await applied(-3)).toBe(1);
+    expect(await applied(2.7)).toBe(2);
+    // Not a number, so not a bound: the default stands.
+    expect(await applied('50')).toBe(100);
+    expect(await applied(Number.NaN)).toBe(100);
+    expect(await applied(undefined)).toBe(100);
+  });
+
+  it('orders newest first, and puts an unreadable creation time last', async () => {
+    const result = await listing([
+      snapshot({ name: 'older', properties: { creation: { rawvalue: '1000' } } }),
+      snapshot({ name: 'unreadable', properties: { creation: { rawvalue: 'whenever' } } }),
+      snapshot({ name: 'newest', properties: { creation: { rawvalue: '3000' } } }),
+      snapshot({ name: 'middle', properties: { creation: { rawvalue: '2000' } } }),
+      snapshot({ name: 'also-unreadable', properties: {} }),
+    ]);
+    expect(result.snapshots.map((row) => row['name'])).toEqual([
+      'newest',
+      'middle',
+      'older',
+      // Both unreadable, in the order the system sent them.
+      'unreadable',
+      'also-unreadable',
+    ]);
+  });
+
+  it('reads the creation time ZFS reports rather than the middleware rendering', async () => {
+    // `parsed` disagrees with `rawvalue` here: only a tool reading the raw
+    // epoch seconds answers with the second timestamp.
+    const result = await listing([
+      snapshot({
+        properties: { creation: { rawvalue: '1756346400', parsed: 'Aug 27 2019, sometime' } },
+      }),
+    ]);
+    expect(result.snapshots[0]['created']).toBe('2025-08-28T02:00:00.000Z');
+  });
+
+  it('reports a creation time it cannot read as null rather than as the epoch', async () => {
+    const unreadable = async (creation: unknown): Promise<unknown> => {
+      const result = await listing([snapshot({ properties: { creation } })]);
+      return result.snapshots[0]['created'];
+    };
+    // `Number('')` is 0, which would date every one of these to 1970.
+    expect(await unreadable({ rawvalue: '' })).toBeNull();
+    expect(await unreadable({ rawvalue: 'whenever' })).toBeNull();
+    expect(await unreadable({ rawvalue: '17e8' })).toBeNull();
+    expect(await unreadable({ rawvalue: null })).toBeNull();
+    expect(await unreadable({})).toBeNull();
+    expect(await unreadable(null)).toBeNull();
+    expect(await unreadable(1756346400)).toBeNull();
+    // Beyond what a Date can hold, where `toISOString` throws rather than
+    // answering — one absurd row must not take the whole listing down.
+    expect(await unreadable({ rawvalue: '999999999999999' })).toBeNull();
+    expect(await unreadable({ rawvalue: '-999999999999999' })).toBeNull();
+    expect(await unreadable({ rawvalue: Number.POSITIVE_INFINITY })).toBeNull();
+    // A number the system did send, in the form it sends strings in.
+    expect(await unreadable({ rawvalue: 1756346400 })).toBe('2025-08-28T02:00:00.000Z');
+    expect(await unreadable({ rawvalue: '-1' })).toBe('1969-12-31T23:59:59.000Z');
+  });
+
+  it('reports an unreadable referenced size as null rather than as nothing referenced', async () => {
+    const referenced = async (property: unknown): Promise<unknown> => {
+      const result = await listing([
+        snapshot({ properties: { creation: { rawvalue: '1' }, referenced: property } }),
+      ]);
+      return result.snapshots[0]['referenced_bytes'];
+    };
+    expect(await referenced({ parsed: 0 })).toBe(0);
+    expect(await referenced({ parsed: Number.NaN })).toBeNull();
+    expect(await referenced({ parsed: '98304' })).toBeNull();
+    expect(await referenced({})).toBeNull();
+    expect(await referenced(undefined)).toBeNull();
+    expect(await referenced(98304)).toBeNull();
+  });
+
+  it('reports a name or dataset that is not a string as null', async () => {
+    const result = await listing([snapshot({ name: 12345, dataset: null })]);
+    expect(result.snapshots[0]['name']).toBeNull();
+    expect(result.snapshots[0]['dataset']).toBeNull();
+  });
+
+  it('survives a row whose properties are not an object', async () => {
+    const result = await listing([snapshot({ properties: 'unset' })]);
+    expect(result.snapshots[0]).toEqual({
+      name: 'tank/media@nightly-1',
+      dataset: 'tank/media',
+      created: null,
+      referenced_bytes: null,
+    });
   });
 });
 


### PR DESCRIPTION
Adds `snapshots_list`, a read-only tool returning the snapshots that exist, optionally for one dataset. `snapshots_create` was the only tool in the family, so the catalog could make a snapshot and could not see one.

Fixes #19

## What it returns

An object rather than a bare list, because the bound has to be visible:

```
{ snapshots: [ { name, dataset, created, referenced_bytes } ], truncated, limit }
```

`name` is the full `dataset@snapshot`, `created` an ISO 8601 UTC timestamp, `referenced_bytes` the data that snapshot references. Each field is mapped by name, so nothing a later TrueNAS release adds to the row appears without a change here, and each is null where the system reported no value the tool can read — null being distinct from `0`, which is a snapshot that really references nothing.

`created` is read from `properties.creation.rawvalue`, ZFS's own epoch seconds, rather than from `parsed`, whose rendering has differed between middleware releases. Converting the raw seconds once is what lets the description promise one timestamp format.

## The design note in the ticket, corrected

The ticket recorded `pool.snapshot.query` as **(unconfirmed)** and absent from the pinned client's endpoint enum. It is present: `node_modules/@truenas/api-client/dist/index.d.ts` declares it in the call directory as `params: [filters?, options?]` with `entity: PoolSnapshotEntry`, and lists it in `ApiCallDirectoryBase`, so it is on the default (oldest-supported) surface the tools are written against. `PoolSnapshotEntry` is `Record<string, unknown>`, exactly as `pool.dataset.query`'s rows are, so the fields are restated in the tool the way `storage.ts` restates a dataset's properties.

## The bound, and what a truncated list does and does not say

A system holds tens of thousands of snapshots, so the query is bounded: `limit + 1` rows are requested, the extra one is counted and dropped, and `truncated` reports it. `limit` defaults to 100, is capped at 1000, and the effective bound comes back with the result.

**The query asks for no ordering, deliberately, and the first two review rounds are why.** Round one caught that sorting newest-first here only orders the window the middleware already cut — so a truncated list was the *oldest* snapshots under a description promising the newest. Round two caught that the fix, `order_by: ['-createtxg']`, was itself unsound twice over: `createtxg` is a string on the row, so a pool whose transaction groups have crossed a digit boundary sorts `999999` after `1000000`; and it counts transaction groups on the system *holding* the snapshot, so a replication target would have been ordered by when each snapshot was received rather than when it was taken. No field of a snapshot row orders it in time soundly — the creation time is nested inside `properties` — so the tool asks for no order rather than one that is wrong on those systems.

What that costs is stated in the description rather than papered over: the newest-first ordering is scoped to the entries returned, and a truncated list is evidence about the snapshots it names and about nothing else — it cannot show that a snapshot is absent. Narrowing with `dataset`, or raising `limit` until `truncated` is false, is what answers that question.

## A dataset that does not exist

`pool.snapshot.query` answers an empty list for a dataset that is not there exactly as it does for one never snapshotted. When a `dataset` was named and the listing came back empty — and only then, so a dataset with snapshots still costs one call — the tool reuses `assertDatasetExists`, already in this file for `snapshots_create`'s plan phase, and the missing dataset surfaces as an error naming it. An empty list therefore always means "no snapshots".

A `dataset` argument that is not a non-empty string is rejected rather than ignored: reading it as "every dataset" would answer a question nobody asked. `limit` is lenient the other way — clamped to 1..1000 and floored — because a misread limit only changes how many of the right snapshots come back, and the number applied is returned beside them.

## Verification

`yarn typecheck`, `yarn lint` and `yarn test:coverage` all pass locally. Coverage is 98.36% statements / 97.68% branches globally, above the 97/96 floors; `src/tools/snapshots.ts` is 100% statements and 98.61% branches, its one uncovered branch being pre-existing (`snapshots_create`'s recursive description). 18 tests were added, including the fan-out-visible distinction between a missing dataset and an empty one, the clamping of every out-of-range bound, and each way a creation time or a referenced size can be unreadable.

Nothing here needs a live system, so no check was skipped for want of one.

## Review

Three rounds of the project's own reviewer ran locally before this was pushed (`local-review.py`, exit 0 on the third — the same rubric, threshold and parser as the required check). The first two rounds are described above. The third returned four LOW findings and nothing at or above MEDIUM.

**LOWs not fixed**, deliberately, since each fix is a new diff and a new review round:

- `Number.isFinite(millis)` in `creationMillis` is a dead conjunct — `seconds` is already finite and the `Math.abs` bound rejects infinities — so it leaves a branch that cannot be covered. Correct, and harmless.
- `propertyBytes` and the property interface restate `storage.ts:90` verbatim, now the third file reading ZFS's property shape. Extracting a shared helper touches two other tool families, so it belongs in its own ticket rather than in this diff; `pools.ts` sets the local-helper precedent this followed.
- `requestedDataset` treats `dataset: null` as absent while `''`, `123`, `true` and `{}` throw. An explicit null is how several LLM providers spell "not supplied", so that is the intent; it is stated in neither the helper's JSDoc nor the tool description, and no test pins it.
- The description opens with "newest first" and scopes it a paragraph later. Both statements are true of what the tool returns; whether the ordering claim should lead is a judgement about how an LLM reads a long description.
