### PR TITLE
feat(tools): add replication_status, each replication task's state, last run and last error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
-  `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`.
+  `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
+  `replication_status`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,5 +70,6 @@ export {
   appsList,
   alertsList,
   snapshotsList,
+  replicationStatus,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,11 +3,12 @@ import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
+import { replicationStatus } from '@/tools/replication';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 
-/** The sketch's catalog: ten read-only tools plus one mutating tool. */
+/** The sketch's catalog: eleven read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -20,6 +21,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(appsList);
   catalog.register(alertsList);
   catalog.register(snapshotsList);
+  catalog.register(replicationStatus);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -33,6 +35,7 @@ export {
   poolStatus,
   poolTopology,
   quotaReport,
+  replicationStatus,
   scrubHistory,
   snapshotsList,
   systemInfo,

--- a/src/tools/replication.ts
+++ b/src/tools/replication.ts
@@ -1,0 +1,225 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Replication family: the replication tasks that exist and how their last run
+ * went.
+ *
+ * `snapshots_list` shows the snapshots a system holds, which is what a task
+ * replicates and not whether it did. Replication is the difference between a
+ * snapshot and a backup, and a task that has been failing quietly for weeks
+ * looks, from the source system alone, exactly like one that is working — the
+ * snapshots are all there either way. The task's own state record is the only
+ * place that difference is visible.
+ */
+
+/**
+ * The two states that describe a run that has ENDED, and so the only two under
+ * which the recorded time is a finish time.
+ *
+ * The system holds one state record per task, carrying the state and the
+ * instant that state was recorded. Under `RUNNING` that instant is when the
+ * current run began, and under `PENDING` or `HOLD` it is when the task entered
+ * that state — reporting any of them as `finished_at` would name a real
+ * timestamp as something it is not, which is worse than reporting none.
+ */
+const ENDED_STATES = new Set(['FINISHED', 'ERROR']);
+
+/**
+ * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
+ * than answering, so one absurd recorded time would otherwise take the whole
+ * listing down with it — the same guard `snapshots.ts` applies to a creation
+ * time.
+ */
+const MAX_TIME_MS = 8.64e15;
+
+/**
+ * The state record a replication task carries, restated with every field
+ * optional and untyped.
+ *
+ * The client declares `state` as `{ [k: string]: unknown }` — an open record
+ * naming nothing — so every field of it arrives as `unknown`, the same way a
+ * ZFS property does in `storage.ts` and a scan record does in `pools.ts`. Only
+ * the three fields read here are named.
+ */
+interface RunState {
+  state?: unknown;
+  datetime?: unknown;
+  error?: unknown;
+}
+
+/**
+ * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
+ * which is the only date representation the client's own types declare
+ * (`TrueNasDate`). Restated with `$date` untyped because it arrives inside an
+ * open record.
+ */
+interface MiddlewareDate {
+  $date?: unknown;
+}
+
+/**
+ * The task's state record, or null where the row carries nothing to read it
+ * from.
+ *
+ * Guarded rather than asserted: the record arrives as `unknown`, and a row that
+ * sends something other than an object is exactly the case an assertion would
+ * have got wrong.
+ */
+function runState(state: unknown): RunState | null {
+  return typeof state === 'object' && state !== null ? (state as RunState) : null;
+}
+
+/**
+ * The instant a state was recorded, in milliseconds since the epoch, or null
+ * where the system reported no time this tool can read.
+ *
+ * A bare number is accepted beside the `{ "$date": … }` envelope because the
+ * envelope exists only to tag a number as a date in transit; both are epoch
+ * milliseconds. Anything else — a formatted string, a date in another shape —
+ * is not read rather than guessed at, because guessing wrong about a timezone
+ * produces a timestamp that is confidently off by hours.
+ */
+function stateMillis(datetime: unknown): number | null {
+  const raw =
+    typeof datetime === 'object' && datetime !== null
+      ? (datetime as MiddlewareDate).$date
+      : datetime;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+  return Math.abs(raw) <= MAX_TIME_MS ? raw : null;
+}
+
+/**
+ * The state of the task's last run: the system's own state string, or
+ * `NEVER_RUN`, or null.
+ *
+ * `NEVER_RUN` is what the tool exists to keep separate from a failure. A task
+ * the system has never run reports `PENDING` with no time recorded against it,
+ * because the state record is created with the task and nothing has replaced it
+ * — so the absence of a recorded time is the evidence, and a task that is
+ * pending *again* after running carries the time it entered that state. That is
+ * a reading of what the system sends rather than a guarantee it makes: the
+ * field is untyped, so `PENDING` with a time is reported as plain `PENDING`,
+ * which is true either way.
+ *
+ * Null is neither of those. It is a task whose state could not be read at all —
+ * no record, or a record naming no state — and it must not read as a task that
+ * has never run, which is a fact about the task rather than about this tool.
+ *
+ * Any other state is passed through as the system spelled it, so a state a
+ * later TrueNAS release adds reaches the caller rather than being flattened
+ * into one of these.
+ */
+function lastRunState(state: RunState | null): string | null {
+  if (state === null) return null;
+  const reported = state.state;
+  if (typeof reported !== 'string' || reported.length === 0) return null;
+  return reported === 'PENDING' && state.datetime == null ? 'NEVER_RUN' : reported;
+}
+
+/**
+ * When the last run ended, as an ISO 8601 UTC timestamp, or null where nothing
+ * this tool can read says a run ended.
+ *
+ * The state must be one that describes an ended run — see {@link ENDED_STATES}
+ * — before the recorded time is read as a finish time at all.
+ */
+function finishedAt(state: RunState | null, reported: string | null): string | null {
+  if (state === null || reported === null || !ENDED_STATES.has(reported)) return null;
+  const millis = stateMillis(state.datetime);
+  return millis === null ? null : new Date(millis).toISOString();
+}
+
+/**
+ * The error text recorded with the state, or null where none was recorded.
+ *
+ * An empty string is read as no text rather than as an error message of no
+ * characters: it names nothing a caller could act on, and reporting it beside
+ * an `ERROR` state would suggest the reason is available when it is not.
+ */
+function errorText(state: RunState | null): string | null {
+  const error = state?.error;
+  return typeof error === 'string' && error.length > 0 ? error : null;
+}
+
+/**
+ * The datasets a task replicates from, as the strings among whatever the system
+ * sent.
+ *
+ * The client types this a non-empty tuple of strings, which the middleware
+ * enforces on creation; the guard is for a row that does not honour it, where
+ * an entry that is not a dataset name is not a dataset and an absent list
+ * leaves nothing to report rather than taking the listing down.
+ */
+function sourceDatasets(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string') : [];
+}
+
+export const replicationStatus: ReadOnlyTool = {
+  name: 'replication_status',
+  description:
+    'Every replication task on the system and how its last run went. `name` ' +
+    "is the task's own name and `id` its numeric identity. `direction` is " +
+    '`PUSH`, replicating from this system outwards, or `PULL`, replicating ' +
+    'onto it; `source_datasets` are the datasets replicated from and ' +
+    '`target_dataset` the one replicated to, so on a `PUSH` the sources are ' +
+    'local and on a `PULL` the target is. `transport` is how the data travels ' +
+    '— `SSH`, `SSH+NETCAT` or `LOCAL`. `enabled` is whether the task is ' +
+    'switched on, and is null where the system reported no value; a disabled ' +
+    'task is still listed, because a task nobody switched back on is exactly ' +
+    'the one worth finding. `state` is one of: `FINISHED`, a run that ' +
+    'completed; `ERROR`, one that failed; `RUNNING`, one going on now; ' +
+    '`PENDING`, one waiting to run; `HOLD`, one the system is holding back; ' +
+    '`NEVER_RUN`, a task the system holds no record of having run; and null, ' +
+    'a task whose state could not be read at all. Those last two are ' +
+    'different answers and neither is a failure: `NEVER_RUN` is a task that ' +
+    'has not replicated anything yet, while null says only that this tool ' +
+    'could not tell — a task in either state has not been shown to be ' +
+    'working. A state a later TrueNAS release adds is passed through as the ' +
+    'system spelled it, so `state` is not limited to that list. `finished_at` ' +
+    'is when the last run ended, as an ISO 8601 UTC timestamp. It is reported ' +
+    'only under `FINISHED` and `ERROR`, the two states that describe a run ' +
+    'that ended, and is null under every other state including `RUNNING` — ' +
+    'the system records one time per task, and under `RUNNING` that time is ' +
+    'when the current run started rather than when anything finished. ' +
+    '`error` is the error text recorded with the state and is null where none ' +
+    'was recorded, so it carries the reason a task in `ERROR` failed. A task ' +
+    'in `ERROR` with a null `error` failed for a reason the system did not ' +
+    'record; it has not succeeded.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: a system holds tens of replication tasks at
+    // most, and the state record this tool reads is part of a task row as it
+    // stands — there is no option that changes how it is nested and no volume
+    // to bound.
+    const tasks = await firstValueFrom(system.client.api.query('replication.query'));
+    return tasks.map((task) => {
+      const state = runState(task.state);
+      // Read once and passed to `finishedAt`, so that the state reported and
+      // the decision about whether the recorded time is a finish time cannot
+      // be made from two different readings of the same record.
+      const reported = lastRunState(state);
+      return {
+        id: task.id,
+        name: task.name,
+        direction: task.direction,
+        transport: task.transport,
+        // Optional on the client's own type, so a middleware that omits it
+        // reports null rather than handing the caller an object missing a
+        // field the description promises — as `orNull` does in `pools.ts`.
+        // Not defaulted to true or false: a task whose switch cannot be read
+        // must not be presented as one that is definitely on or definitely
+        // off.
+        enabled: task.enabled ?? null,
+        source_datasets: sourceDatasets(task.source_datasets),
+        target_dataset: task.target_dataset,
+        state: reported,
+        finished_at: finishedAt(state, reported),
+        error: errorText(state),
+      };
+    });
+  },
+};

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -12,6 +12,7 @@ import {
   poolStatus,
   poolTopology,
   quotaReport,
+  replicationStatus,
   scrubHistory,
   snapshotsList,
 } from '@/tools/index';
@@ -35,7 +36,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the eleven sketch tools', () => {
+  it('registers the twelve sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -47,6 +48,7 @@ describe('createDefaultCatalog', () => {
       'apps_list',
       'alerts_list',
       'snapshots_list',
+      'replication_status',
       'snapshots_create',
     ]);
   });
@@ -84,6 +86,12 @@ describe('createDefaultCatalog', () => {
   it('advertises snapshots_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'snapshots_list',
+    );
+  });
+
+  it('advertises replication_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'replication_status',
     );
   });
 });
@@ -1583,5 +1591,189 @@ describe('snapshots_create', () => {
       { dataset: 'tank/media', name: 'before', recursive: false },
     ]);
     expect(result).toEqual({ created: 'tank/media@before' });
+  });
+});
+
+describe('replication_status', () => {
+  /**
+   * A replication task as `replication.query` reports one. `recursive`, `auto`,
+   * `retention_policy`, `periodic_snapshot_tasks`, `has_encrypted_dataset_keys`
+   * and `job` are here to be dropped: they are fields of the real payload the
+   * tool does not name.
+   */
+  const task = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'nightly-to-backup',
+    direction: 'PUSH',
+    transport: 'SSH',
+    enabled: true,
+    source_datasets: ['tank/media'],
+    target_dataset: 'backup/media',
+    recursive: true,
+    auto: true,
+    retention_policy: 'SOURCE',
+    periodic_snapshot_tasks: [],
+    has_encrypted_dataset_keys: false,
+    state: { state: 'FINISHED', datetime: { $date: 1756346400000 }, error: null },
+    job: null,
+    ...over,
+  });
+
+  const statuses = async (tasks: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['replication.query']: tasks });
+    return (await replicationStatus.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  /** One task, differing only in the state record the system holds for it. */
+  const forState = async (state: unknown): Promise<Record<string, unknown>> =>
+    (await statuses([task({ state })]))[0];
+
+  it('maps a task to its endpoints, transport and last run', async () => {
+    expect(await statuses([task()])).toEqual([
+      {
+        id: 1,
+        name: 'nightly-to-backup',
+        direction: 'PUSH',
+        transport: 'SSH',
+        enabled: true,
+        source_datasets: ['tank/media'],
+        target_dataset: 'backup/media',
+        state: 'FINISHED',
+        finished_at: '2025-08-28T02:00:00.000Z',
+        error: null,
+      },
+    ]);
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const rows = await statuses([task({ future_field: 'added by a later TrueNAS release' })]);
+    expect(Object.keys(rows[0])).toEqual([
+      'id',
+      'name',
+      'direction',
+      'transport',
+      'enabled',
+      'source_datasets',
+      'target_dataset',
+      'state',
+      'finished_at',
+      'error',
+    ]);
+  });
+
+  it('asks for every task, with no filters and no options', async () => {
+    const { ctx, query } = fakeSystem({ ['replication.query']: [task()] });
+    await replicationStatus.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('replication.query');
+  });
+
+  it('returns [] for a system with no replication tasks', async () => {
+    expect(await statuses([])).toEqual([]);
+  });
+
+  it('marks a task that has never run rather than omitting it or failing it', async () => {
+    // What the system holds for a task created and not yet run: pending, with
+    // no time recorded against it.
+    const row = await forState({ state: 'PENDING' });
+    expect(row['state']).toBe('NEVER_RUN');
+    expect(row['finished_at']).toBeNull();
+    expect(row['error']).toBeNull();
+  });
+
+  it('reads a task pending again after running as PENDING, not as never run', async () => {
+    // The recorded time is the evidence that something has happened to this
+    // task before; it is not a finish time, so it is not reported as one.
+    const row = await forState({ state: 'PENDING', datetime: { $date: 1756346400000 } });
+    expect(row['state']).toBe('PENDING');
+    expect(row['finished_at']).toBeNull();
+  });
+
+  it('reports a state it cannot read as null rather than as never run', async () => {
+    // A task nothing can be said about must not read as one known to have
+    // never replicated: that is a fact about the task, not about this tool.
+    for (const unreadable of [undefined, null, 'FINISHED', 42, {}, { state: null }, { state: '' }]) {
+      const row = await forState(unreadable);
+      expect(row['state']).toBeNull();
+      expect(row['finished_at']).toBeNull();
+      expect(row['error']).toBeNull();
+    }
+  });
+
+  it('distinguishes a running task from a finished one, and gives it no finish time', async () => {
+    // The system records one time per task, and under RUNNING it is when the
+    // current run started — reporting it as `finished_at` would name a real
+    // timestamp as something it is not.
+    const running = await forState({ state: 'RUNNING', datetime: { $date: 1756346400000 } });
+    expect(running['state']).toBe('RUNNING');
+    expect(running['finished_at']).toBeNull();
+    const held = await forState({ state: 'HOLD', datetime: { $date: 1756346400000 } });
+    expect(held['state']).toBe('HOLD');
+    expect(held['finished_at']).toBeNull();
+  });
+
+  it('passes through a state a later release adds', async () => {
+    const row = await forState({ state: 'SUSPENDED', datetime: { $date: 1756346400000 } });
+    expect(row['state']).toBe('SUSPENDED');
+    // Not one of the two states that describe an ended run, so no finish time.
+    expect(row['finished_at']).toBeNull();
+  });
+
+  it('reports the finish time of a run that ended, in either shape the time arrives in', async () => {
+    const enveloped = await forState({ state: 'ERROR', datetime: { $date: 1756346400000 } });
+    expect(enveloped['state']).toBe('ERROR');
+    expect(enveloped['finished_at']).toBe('2025-08-28T02:00:00.000Z');
+    // The envelope only tags a number as a date; a bare one is the same instant.
+    const bare = await forState({ state: 'FINISHED', datetime: 1756346400000 });
+    expect(bare['finished_at']).toBe('2025-08-28T02:00:00.000Z');
+  });
+
+  it('reports a finish time it cannot read as null rather than as the epoch', async () => {
+    const finished = async (datetime: unknown): Promise<unknown> =>
+      (await forState({ state: 'FINISHED', datetime }))['finished_at'];
+    expect(await finished('2025-08-28T02:00:00Z')).toBeNull();
+    expect(await finished({ $date: '1756346400000' })).toBeNull();
+    expect(await finished({})).toBeNull();
+    expect(await finished(null)).toBeNull();
+    expect(await finished(Number.NaN)).toBeNull();
+    expect(await finished(Number.POSITIVE_INFINITY)).toBeNull();
+    // Beyond what a Date can hold, where `toISOString` throws rather than
+    // answering — one absurd row must not take the whole listing down.
+    expect(await finished({ $date: 8.64e15 + 1 })).toBeNull();
+    expect(await finished({ $date: -8.64e15 - 1 })).toBeNull();
+    expect(await finished({ $date: 0 })).toBe('1970-01-01T00:00:00.000Z');
+  });
+
+  it('carries the error text of a failed run, and reads an empty one as none', async () => {
+    const failed = await forState({
+      state: 'ERROR',
+      datetime: { $date: 1756346400000 },
+      error: 'ssh connection refused',
+    });
+    expect(failed['error']).toBe('ssh connection refused');
+    // An empty string names nothing a caller could act on; the ERROR state is
+    // what says the run failed either way.
+    for (const none of ['', null, undefined, 42, { message: 'nope' }]) {
+      const row = await forState({ state: 'ERROR', error: none });
+      expect(row['state']).toBe('ERROR');
+      expect(row['error']).toBeNull();
+    }
+  });
+
+  it('lists a disabled task, and reports a switch it cannot read as null', async () => {
+    const [disabled] = await statuses([task({ enabled: false })]);
+    expect(disabled['enabled']).toBe(false);
+    // Not defaulted either way: a task whose switch is unreadable must not be
+    // presented as definitely on or definitely off.
+    const [unreported] = await statuses([task({ enabled: undefined })]);
+    expect(unreported['enabled']).toBeNull();
+  });
+
+  it('reports the source datasets, keeping only the names among them', async () => {
+    const sources = async (value: unknown): Promise<unknown> =>
+      (await statuses([task({ source_datasets: value })]))[0]['source_datasets'];
+    expect(await sources(['tank/media', 'tank/docs'])).toEqual(['tank/media', 'tank/docs']);
+    expect(await sources(['tank/media', 7, null])).toEqual(['tank/media']);
+    expect(await sources(undefined)).toEqual([]);
+    expect(await sources('tank/media')).toEqual([]);
   });
 });


### PR DESCRIPTION
Adds `replication_status`, a read-only tool reporting every replication task on
a system and how its last run went. Closes #20.

## Why

Replication is the difference between a snapshot and a backup. From the source
system alone a task that has been failing quietly for weeks looks exactly like
one that is working — the snapshots are all there either way. The task's own
state record is the only place that difference is visible, and nothing in the
catalog could read it.

## What it returns

One object per task, carrying only fields named here:

| field | |
|---|---|
| `id`, `name` | the task's numeric identity and its own name |
| `direction` | `PUSH` (replicating outwards) or `PULL` (replicating onto this system) |
| `source_datasets`, `target_dataset` | what is replicated from and to |
| `transport` | `SSH`, `SSH+NETCAT` or `LOCAL` |
| `enabled` | whether the task is switched on; null where the system reported no value |
| `state` | the state of the last run — see below |
| `finished_at` | when the last run ended, ISO 8601 UTC |
| `error` | the error text recorded with the state |

`replication.query` types `state` and `job` as open records
(`{ [k: string]: unknown }`), so every field of the last-run detail arrives as
`unknown`. It is restated and guarded here the way `storage.ts` restates a ZFS
property and `pools.ts` restates a scan record. A disabled task is still
listed: a task nobody switched back on is exactly the one worth finding.

## Three readings taken deliberately

**`NEVER_RUN` is separate both from a failure and from an unreadable state.** A
task the system has never run reports `PENDING` with no time recorded against
it, so the absence of a recorded time is the evidence. A task pending *again*
after running carries the time it entered that state and reports plain
`PENDING`. A state that could not be read at all is null — which says only that
this tool could not tell, not that the task has never replicated. Neither is a
failure and neither is evidence the task works.

**`finished_at` is reported only under `FINISHED` and `ERROR`.** The system
records one time per task, and under `RUNNING`, `PENDING` or `HOLD` that time is
when the state began rather than when anything finished. Reporting it as a
finish time would name a real timestamp as something it is not, so it is null in
every other state — `RUNNING` included, which is also what distinguishes a
running task from a finished one.

**A state the system spells any other way is passed through** rather than
flattened into one of the documented values, so a state a future release
introduces reaches the caller as the system spelled it.

Time is read from `{ "$date": <epoch ms> }`, the client's own `TrueNasDate`
shape, and from a bare number of milliseconds — the envelope only tags a number
as a date. A formatted string is not read rather than guessed at: guessing wrong
about a timezone produces a timestamp that is confidently off by hours. The
`Date` range is bounded, since `toISOString` throws beyond it and one absurd row
must not take the whole listing down.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run
locally and pass. 167 tests; `src/tools/replication.ts` is at 100% statements,
branches and functions, and the global floors read 98.46 statements / 97.93
branches against floors of 97 / 96.

The shared review from `iXsystems/ux-github-workflows@master` ran locally — the
same reviewer, rubric and threshold as the required check — and returned nothing
at or above MEDIUM.

## Not changed, and why

The local review returned four LOW findings. Each is left for this PR's review
and a later ticket rather than fixed, because every fix is a new diff and a new
diff reopens the review loop:

- **`NEVER_RUN` has a second possible cause.** `PENDING` with no recorded time
  is also what a middleware that lost its state store would report. The reading
  is stated as a reading in `lastRunState`'s comment, and the alternative —
  reporting null there — would lose the common case to protect the rare one.
- **The five documented states are not exhaustive by construction.** The
  client's `JobState` separately declares `WAITING`, `FAILED`, `ABORTED`,
  `SUCCESS` and `LOCKED`; those are job states rather than the zettarepl task
  states this field carries, but the description's "a later release may add
  others" understates how open the field already is.
- **`ssh_credentials` is not in the spec fixture's list of dropped fields.** It
  is dropped by construction like every other unnamed field — the shape
  assertion checks the exact key list — but naming it would make that assertion
  read as the credential-isolation test it also is.
- **`source_datasets` is runtime-guarded while `name`, `direction`, `transport`,
  `target_dataset` and `id` pass through raw.** The guard is there because that
  field is a list and an entry that is not a string is not a dataset name; the
  scalar fields follow `storage.ts` and `pools.ts`, which pass typed-required
  fields through. The asymmetry is real and worth one convention rather than one
  file's fix.
