### PR TITLE
feat(tools): add snapshot_tasks_list, the periodic snapshot tasks and their schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
-  `replication_status`.
+  `replication_status`, `snapshot_tasks_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,5 +71,6 @@ export {
   alertsList,
   snapshotsList,
   replicationStatus,
+  snapshotTasksList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,8 +7,9 @@ import { replicationStatus } from '@/tools/replication';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
+import { snapshotTasksList } from '@/tools/tasks';
 
-/** The sketch's catalog: eleven read-only tools plus one mutating tool. */
+/** The sketch's catalog: twelve read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -22,6 +23,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(alertsList);
   catalog.register(snapshotsList);
   catalog.register(replicationStatus);
+  catalog.register(snapshotTasksList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -38,5 +40,6 @@ export {
   replicationStatus,
   scrubHistory,
   snapshotsList,
+  snapshotTasksList,
   systemInfo,
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,0 +1,291 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Tasks family: the work a system does to itself on a schedule, with nobody
+ * asking.
+ *
+ * `snapshots_list` says what protection exists; this says what protection is
+ * automatic. The two are not visible in each other: a dataset with a month of
+ * snapshots and no periodic task is protected up to the last manual action and
+ * no further, and a snapshot taken by hand looks exactly like one a schedule
+ * took. The task is the only place the difference is recorded.
+ */
+
+/**
+ * A schedule as a task row carries one, restated with every field optional and
+ * untyped.
+ *
+ * The client types these as optional strings, and the guards below hold anyway:
+ * the reading has to survive a row that does not honour the type, and a cron
+ * field that is not a string is not a cron field.
+ */
+interface Cron {
+  minute?: unknown;
+  hour?: unknown;
+  dom?: unknown;
+  month?: unknown;
+  dow?: unknown;
+  begin?: unknown;
+  end?: unknown;
+}
+
+/** The seven cron fields as this tool reports them: a string, or null. */
+interface Schedule {
+  minute: string | null;
+  hour: string | null;
+  dom: string | null;
+  month: string | null;
+  dow: string | null;
+  begin: string | null;
+  end: string | null;
+}
+
+/**
+ * The daily window a task carries when nothing restricts it. Rendering it into
+ * the description would add "between 00:00 and 23:59" to every task on the
+ * system, which says only that the task is not restricted — the case worth
+ * naming in words is the one where it is.
+ */
+const FULL_DAY_BEGIN = '00:00';
+const FULL_DAY_END = '23:59';
+
+/** Sunday first, which is how cron numbers the days. */
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const DAY_ABBREVIATIONS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+/**
+ * The task's schedule, or null where the row carries nothing to read one from.
+ *
+ * Guarded rather than asserted: a row that sends something other than an object
+ * is exactly the case an assertion would have got wrong, as it is for a state
+ * record in `replication.ts`.
+ */
+function cronOf(schedule: unknown): Cron | null {
+  return typeof schedule === 'object' && schedule !== null ? (schedule as Cron) : null;
+}
+
+/**
+ * One cron field, or null where the system reported nothing this tool can read.
+ *
+ * An empty string is read as no value rather than as a field of no characters:
+ * it constrains nothing, and passing it through would put a value in `schedule`
+ * that a caller cannot act on and that {@link describeSchedule} could not
+ * render anyway.
+ */
+function fieldOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** `2` as `"02"`, so an hour and a minute read as a clock time. */
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/** `"a"`, `"a and b"`, `"a, b and c"`. Never called with an empty list. */
+function joinWords(parts: string[]): string {
+  return parts.length === 1
+    ? parts[0]
+    : `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+}
+
+/**
+ * The whole numbers a cron field lists, or null where it is not a plain
+ * comma-separated list of numbers within range.
+ *
+ * Range-checked rather than passed through, because a field out of range is a
+ * field this tool has misread — an hour of 47 is not an hour, and rendering it
+ * as one would state a time the task never runs at.
+ */
+function numberList(field: string, min: number, max: number): number[] | null {
+  const values: number[] = [];
+  for (const part of field.split(',')) {
+    if (!/^\d{1,2}$/.test(part)) return null;
+    const value = Number(part);
+    if (value < min || value > max) return null;
+    values.push(value);
+  }
+  return values;
+}
+
+/**
+ * The step of a stepped field — the N of `every N` — or null where the field is
+ * not a stepped one, or names a step outside what the unit holds.
+ */
+function everyStep(field: string, max: number): number | null {
+  const match = /^\*\/(\d{1,2})$/.exec(field);
+  if (match === null) return null;
+  const step = Number(match[1]);
+  return step >= 1 && step <= max ? step : null;
+}
+
+/** `every 4 hours`, and `every hour` rather than `every 1 hours`. */
+function everyPhrase(step: number, unit: string): string {
+  return step === 1 ? `every ${unit}` : `every ${step} ${unit}s`;
+}
+
+/** The full name of a cron day-of-week token, or null where it is not one. */
+function dayName(token: string): string | null {
+  const lower = token.toLowerCase();
+  // Cron numbers Sunday as both 0 and 7.
+  if (/^[0-7]$/.test(lower)) return DAY_NAMES[Number(lower) % 7];
+  const index = DAY_ABBREVIATIONS.indexOf(lower);
+  return index === -1 ? null : DAY_NAMES[index];
+}
+
+/**
+ * When in the day the task runs, in words, or null where `minute` and `hour`
+ * are in a shape this tool does not render.
+ *
+ * Four shapes, which are the ones the TrueNAS scheduler produces: a fixed
+ * minute of every hour, a fixed minute every N hours, a fixed minute of listed
+ * hours, and every N minutes. Anything else is not guessed at — a wrong
+ * rendering would be restated by a model as fact, where a null sends it to
+ * `schedule`, which is always there and always exact.
+ */
+function timePhrase(minute: string, hour: string): string | null {
+  const minutes = numberList(minute, 0, 59);
+  if (minutes !== null && minutes.length === 1) {
+    const past = pad(minutes[0]);
+    if (hour === '*') return `every hour at :${past}`;
+    const step = everyStep(hour, 23);
+    if (step !== null) return `${everyPhrase(step, 'hour')} at :${past}`;
+    const hours = numberList(hour, 0, 23);
+    return hours === null ? null : `at ${joinWords(hours.map((value) => `${pad(value)}:${past}`))}`;
+  }
+  const step = everyStep(minute, 59);
+  return step !== null && hour === '*' ? everyPhrase(step, 'minute') : null;
+}
+
+/**
+ * Which days the task runs on, in words, or null where the three day fields are
+ * in a shape this tool does not render.
+ *
+ * A month other than every month is not rendered, and neither is a day of the
+ * month set alongside a day of the week: cron runs a task on the union of those
+ * two, which reads as an intersection in every plain-English phrasing of it.
+ */
+function dayPhrase(dom: string, month: string, dow: string): string | null {
+  if (month !== '*') return null;
+  if (dow === '*') {
+    if (dom === '*') return 'every day';
+    const days = numberList(dom, 1, 31);
+    if (days === null) return null;
+    return `on ${days.length === 1 ? 'day' : 'days'} ${joinWords(days.map(String))} of each month`;
+  }
+  if (dom !== '*') return null;
+  const names: string[] = [];
+  for (const token of dow.split(',')) {
+    const name = dayName(token);
+    if (name === null) return null;
+    names.push(name);
+  }
+  return `on ${joinWords(names)}`;
+}
+
+/**
+ * The daily window, where there is one worth naming. Empty when either end is
+ * missing — half a window is not a window, and reporting one end against an
+ * assumed other would state a restriction the task does not have.
+ */
+function windowPhrase(begin: string | null, end: string | null): string {
+  if (begin === null || end === null) return '';
+  return begin === FULL_DAY_BEGIN && end === FULL_DAY_END ? '' : `, between ${begin} and ${end}`;
+}
+
+/**
+ * The schedule in words, or null where any of the five cron fields is missing
+ * or in a shape this tool does not render.
+ *
+ * A bare crontab line is a format a model has to decode before it can answer
+ * with it, and one it can decode wrongly without anything saying so. This is
+ * the same schedule stated so that restating it is reading rather than
+ * decoding — and null wherever that cannot be done exactly.
+ */
+function describeSchedule(schedule: Schedule): string | null {
+  const { minute, hour, dom, month, dow } = schedule;
+  if (minute === null || hour === null || dom === null || month === null || dow === null) {
+    return null;
+  }
+  const time = timePhrase(minute, hour);
+  const days = dayPhrase(dom, month, dow);
+  if (time === null || days === null) return null;
+  return `${time}, ${days}${windowPhrase(schedule.begin, schedule.end)}`;
+}
+
+export const snapshotTasksList: ReadOnlyTool = {
+  name: 'snapshot_tasks_list',
+  description:
+    'Every periodic snapshot task on the system and the schedule it runs on. ' +
+    '`id` is the task\'s numeric identity and `dataset` the dataset it ' +
+    'snapshots, which matches `id` in `storage_list_datasets`. `recursive` is ' +
+    "whether it snapshots that dataset's children too, and `enabled` whether " +
+    'the task is switched on. A disabled task is listed and reported ' +
+    '`enabled: false` rather than omitted, because a task nobody switched back ' +
+    'on is exactly the one worth finding. Both are null where the system ' +
+    'reported no value, which is not the same answer as false. ' +
+    '`lifetime_value` and `lifetime_unit` are the retention — how long a ' +
+    'snapshot this task takes is kept — as a number and one of `HOUR`, `DAY`, ' +
+    '`WEEK`, `MONTH` or `YEAR`, so `2` and `WEEK` means its snapshots are ' +
+    'destroyed a fortnight after they are taken. Each is null where the system ' +
+    'reported no value, and a task whose retention could not be read is not a ' +
+    'task that keeps its snapshots forever. `schedule` carries the cron fields ' +
+    'as the system holds them: `minute`, `hour`, `dom` (day of the month), ' +
+    '`month`, `dow` (day of the week), and `begin` and `end`, the daily window ' +
+    'the task may run within. Each field is null where the system reported no ' +
+    'value, and `schedule` itself is null where the task carries no readable ' +
+    'schedule at all. `schedule_description` restates those fields in words — ' +
+    '`at 02:00, every day`, or `every 4 hours at :00, every day, between 09:00 ' +
+    'and 17:00`. It is null where the schedule is in a shape this tool does ' +
+    'not render in words, and a null there says nothing about the task: it is ' +
+    'a limit of this tool rather than a task without a schedule, and ' +
+    '`schedule` is the exact account of when the task runs either way. This ' +
+    'tool reports what is scheduled, not what happened — whether the last run ' +
+    'of a task succeeded is not among these fields.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: a system holds tens of snapshot tasks at most,
+    // and every field this tool reads is part of a task row as it stands —
+    // there is nothing to bound and no option that changes how it arrives.
+    const tasks = await firstValueFrom(system.client.api.query('pool.snapshottask.query'));
+    return tasks.map((task) => {
+      const cron = cronOf(task.schedule);
+      // Named field by field rather than passed through, so that a field a
+      // later TrueNAS release adds to the schedule does not reach the caller
+      // without a change here — the same rule the row itself is built under.
+      const schedule: Schedule | null =
+        cron === null
+          ? null
+          : {
+              minute: fieldOrNull(cron.minute),
+              hour: fieldOrNull(cron.hour),
+              dom: fieldOrNull(cron.dom),
+              month: fieldOrNull(cron.month),
+              dow: fieldOrNull(cron.dow),
+              begin: fieldOrNull(cron.begin),
+              end: fieldOrNull(cron.end),
+            };
+      return {
+        id: task.id,
+        dataset: task.dataset,
+        // Optional on the client's own type, so a middleware that omits either
+        // reports null rather than a default. Not defaulted to false: a task
+        // whose switch cannot be read must not be presented as one that is
+        // definitely off, and one whose recursion cannot be read must not be
+        // presented as protecting only the dataset it names.
+        enabled: task.enabled ?? null,
+        recursive: task.recursive ?? null,
+        schedule,
+        // Rendered from the normalized fields rather than from the row, so
+        // that what is described and what is reported cannot be two different
+        // readings of the same schedule.
+        schedule_description: schedule === null ? null : describeSchedule(schedule),
+        lifetime_value: task.lifetime_value ?? null,
+        lifetime_unit: task.lifetime_unit ?? null,
+      };
+    });
+  },
+};

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -111,13 +111,19 @@ function numberList(field: string, min: number, max: number): number[] | null {
 
 /**
  * The step of a stepped field — the N of `every N` — or null where the field is
- * not a stepped one, or names a step outside what the unit holds.
+ * not a stepped one, or names a step this tool will not state as an interval.
+ *
+ * A step counts from the start of its unit and then stops rather than wrapping,
+ * so it is a true interval only where it divides the unit exactly. An hour
+ * field stepping by 5 runs at 00, 05, 10, 15 and 20 and then waits four hours
+ * for midnight — "every 5 hours" would name an interval the task does not keep,
+ * once a day, which is worse than naming none.
  */
-function everyStep(field: string, max: number): number | null {
+function everyStep(field: string, period: number): number | null {
   const match = /^\*\/(\d{1,2})$/.exec(field);
   if (match === null) return null;
   const step = Number(match[1]);
-  return step >= 1 && step <= max ? step : null;
+  return step >= 1 && step <= period && period % step === 0 ? step : null;
 }
 
 /** `every 4 hours`, and `every hour` rather than `every 1 hours`. */
@@ -140,7 +146,8 @@ function dayName(token: string): string | null {
  *
  * Four shapes, which are the ones the TrueNAS scheduler produces: a fixed
  * minute of every hour, a fixed minute every N hours, a fixed minute of listed
- * hours, and every N minutes. Anything else is not guessed at — a wrong
+ * hours, and every N minutes — the two intervals only for an N that divides its
+ * unit, per {@link everyStep}. Anything else is not guessed at: a wrong
  * rendering would be restated by a model as fact, where a null sends it to
  * `schedule`, which is always there and always exact.
  */
@@ -149,12 +156,12 @@ function timePhrase(minute: string, hour: string): string | null {
   if (minutes !== null && minutes.length === 1) {
     const past = pad(minutes[0]);
     if (hour === '*') return `every hour at :${past}`;
-    const step = everyStep(hour, 23);
+    const step = everyStep(hour, 24);
     if (step !== null) return `${everyPhrase(step, 'hour')} at :${past}`;
     const hours = numberList(hour, 0, 23);
     return hours === null ? null : `at ${joinWords(hours.map((value) => `${pad(value)}:${past}`))}`;
   }
-  const step = everyStep(minute, 59);
+  const step = everyStep(minute, 60);
   return step !== null && hour === '*' ? everyPhrase(step, 'minute') : null;
 }
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -15,6 +15,7 @@ import {
   replicationStatus,
   scrubHistory,
   snapshotsList,
+  snapshotTasksList,
 } from '@/tools/index';
 
 /**
@@ -36,7 +37,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twelve sketch tools', () => {
+  it('registers the thirteen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -49,6 +50,7 @@ describe('createDefaultCatalog', () => {
       'alerts_list',
       'snapshots_list',
       'replication_status',
+      'snapshot_tasks_list',
       'snapshots_create',
     ]);
   });
@@ -92,6 +94,12 @@ describe('createDefaultCatalog', () => {
   it('advertises replication_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'replication_status',
+    );
+  });
+
+  it('advertises snapshot_tasks_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'snapshot_tasks_list',
     );
   });
 });
@@ -1775,5 +1783,233 @@ describe('replication_status', () => {
     expect(await sources(['tank/media', 7, null])).toEqual(['tank/media']);
     expect(await sources(undefined)).toEqual([]);
     expect(await sources('tank/media')).toEqual([]);
+  });
+});
+
+describe('snapshot_tasks_list', () => {
+  /**
+   * A periodic snapshot task as `pool.snapshottask.query` reports one.
+   * `exclude`, `naming_schema`, `allow_empty`, `vmware_sync` and `state` are
+   * here to be dropped: they are fields of the real payload the tool does not
+   * name.
+   */
+  const task = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    dataset: 'tank/media',
+    recursive: true,
+    enabled: true,
+    lifetime_value: 2,
+    lifetime_unit: 'WEEK',
+    schedule: {
+      minute: '0',
+      hour: '2',
+      dom: '*',
+      month: '*',
+      dow: '*',
+      begin: '00:00',
+      end: '23:59',
+    },
+    exclude: [],
+    naming_schema: 'auto-%Y-%m-%d_%H-%M',
+    allow_empty: true,
+    vmware_sync: false,
+    state: { state: 'FINISHED' },
+    ...over,
+  });
+
+  const listed = async (rows: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['pool.snapshottask.query']: rows });
+    return (await snapshotTasksList.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  /** One task, differing only in the schedule the system holds for it. */
+  const forSchedule = async (schedule: unknown): Promise<Record<string, unknown>> =>
+    (await listed([task({ schedule })]))[0];
+
+  /**
+   * The words one schedule is rendered into. The base is a daily 02:00 task
+   * with no window, so a case names only the fields it is about.
+   */
+  const described = async (over: Record<string, unknown>): Promise<unknown> =>
+    (await forSchedule({ minute: '0', hour: '2', dom: '*', month: '*', dow: '*', ...over }))[
+      'schedule_description'
+    ];
+
+  it('maps a task to its dataset, schedule and retention', async () => {
+    expect(await listed([task()])).toEqual([
+      {
+        id: 1,
+        dataset: 'tank/media',
+        enabled: true,
+        recursive: true,
+        schedule: {
+          minute: '0',
+          hour: '2',
+          dom: '*',
+          month: '*',
+          dow: '*',
+          begin: '00:00',
+          end: '23:59',
+        },
+        schedule_description: 'at 02:00, every day',
+        lifetime_value: 2,
+        lifetime_unit: 'WEEK',
+      },
+    ]);
+  });
+
+  it('surfaces no field a later release adds, at either level', async () => {
+    const rows = await listed([
+      task({
+        future_field: 'added by a later TrueNAS release',
+        schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*', timezone: 'UTC' },
+      }),
+    ]);
+    expect(Object.keys(rows[0])).toEqual([
+      'id',
+      'dataset',
+      'enabled',
+      'recursive',
+      'schedule',
+      'schedule_description',
+      'lifetime_value',
+      'lifetime_unit',
+    ]);
+    expect(Object.keys(rows[0]['schedule'] as object)).toEqual([
+      'minute',
+      'hour',
+      'dom',
+      'month',
+      'dow',
+      'begin',
+      'end',
+    ]);
+  });
+
+  it('asks for every task, with no filters and no options', async () => {
+    const { ctx, query } = fakeSystem({ ['pool.snapshottask.query']: [task()] });
+    await snapshotTasksList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('pool.snapshottask.query');
+  });
+
+  it('returns [] for a system with no snapshot tasks', async () => {
+    expect(await listed([])).toEqual([]);
+  });
+
+  it('lists a disabled task, and reports a switch it cannot read as null', async () => {
+    // A task that exists and is off is the case worth surfacing, so it is
+    // returned and marked rather than omitted.
+    const [disabled] = await listed([task({ enabled: false })]);
+    expect(disabled['enabled']).toBe(false);
+    // Not defaulted either way: a task whose switch is unreadable must not be
+    // presented as definitely on or definitely off.
+    const [unreported] = await listed([task({ enabled: undefined })]);
+    expect(unreported['enabled']).toBeNull();
+  });
+
+  it('reports recursion it cannot read as null rather than as flat', async () => {
+    expect((await listed([task({ recursive: false })]))[0]['recursive']).toBe(false);
+    expect((await listed([task({ recursive: undefined })]))[0]['recursive']).toBeNull();
+  });
+
+  it('reports the retention, and a retention it cannot read as null', async () => {
+    const [kept] = await listed([task({ lifetime_value: 6, lifetime_unit: 'MONTH' })]);
+    expect(kept['lifetime_value']).toBe(6);
+    expect(kept['lifetime_unit']).toBe('MONTH');
+    // Null rather than absent: a task whose retention could not be read is not
+    // one that keeps its snapshots forever.
+    const [unreported] = await listed([
+      task({ lifetime_value: undefined, lifetime_unit: undefined }),
+    ]);
+    expect(unreported['lifetime_value']).toBeNull();
+    expect(unreported['lifetime_unit']).toBeNull();
+  });
+
+  it('reports a schedule it cannot read at all as null, with no words for it', async () => {
+    for (const unreadable of [undefined, null, '0 2 * * *', 42]) {
+      const row = await forSchedule(unreadable);
+      expect(row['schedule']).toBeNull();
+      expect(row['schedule_description']).toBeNull();
+    }
+  });
+
+  it('reports a cron field it cannot read as null, and renders no words then', async () => {
+    const row = await forSchedule({ minute: '', hour: 2, dom: '*', dow: null });
+    expect(row['schedule']).toEqual({
+      minute: null,
+      hour: null,
+      dom: '*',
+      month: null,
+      dow: null,
+      begin: null,
+      end: null,
+    });
+    expect(row['schedule_description']).toBeNull();
+  });
+
+  it('states a fixed time of day in words', async () => {
+    expect(await described({ minute: '30', hour: '2' })).toBe('at 02:30, every day');
+    expect(await described({ minute: '0', hour: '0,12' })).toBe('at 00:00 and 12:00, every day');
+    expect(await described({ minute: '5', hour: '0,6,18' })).toBe(
+      'at 00:05, 06:05 and 18:05, every day',
+    );
+  });
+
+  it('states a recurring interval in words', async () => {
+    expect(await described({ minute: '0', hour: '*' })).toBe('every hour at :00, every day');
+    expect(await described({ minute: '15', hour: '*/4' })).toBe('every 4 hours at :15, every day');
+    // A step of one is every hour; "every 1 hours" is not English.
+    expect(await described({ minute: '0', hour: '*/1' })).toBe('every hour at :00, every day');
+    expect(await described({ minute: '*/15', hour: '*' })).toBe('every 15 minutes, every day');
+  });
+
+  it('states which days it runs on in words', async () => {
+    expect(await described({ dow: '1' })).toBe('at 02:00, on Monday');
+    expect(await described({ dow: '0,4' })).toBe('at 02:00, on Sunday and Thursday');
+    // Cron numbers Sunday as both 0 and 7.
+    expect(await described({ dow: '7' })).toBe('at 02:00, on Sunday');
+    expect(await described({ dow: 'mon,Thu' })).toBe('at 02:00, on Monday and Thursday');
+    expect(await described({ dom: '1' })).toBe('at 02:00, on day 1 of each month');
+    expect(await described({ dom: '1,15' })).toBe('at 02:00, on days 1 and 15 of each month');
+  });
+
+  it('names the daily window only where one restricts the task', async () => {
+    expect(await described({ begin: '09:00', end: '17:00' })).toBe(
+      'at 02:00, every day, between 09:00 and 17:00',
+    );
+    // The window a task carries when nothing restricts it, which is worth no
+    // words: it says only that the task is not restricted.
+    expect(await described({ begin: '00:00', end: '23:59' })).toBe('at 02:00, every day');
+    // Half a window is not a window, and the missing end must not be assumed.
+    expect(await described({ begin: '09:00' })).toBe('at 02:00, every day');
+    expect(await described({ end: '17:00' })).toBe('at 02:00, every day');
+  });
+
+  it('renders no words for a schedule shape it cannot state exactly', async () => {
+    for (const shape of [
+      // A list of minutes, which no shape here renders.
+      { minute: '0,30', hour: '2' },
+      // Stepped minutes against a fixed hour, which is not "every N minutes".
+      { minute: '*/15', hour: '2' },
+      // Out of range, so misread rather than merely unusual.
+      { minute: '61', hour: '2' },
+      { minute: '0', hour: '47' },
+      { minute: '0', hour: '*/40' },
+      { minute: '0', hour: '*/0' },
+      // Ranges and names this tool does not decode.
+      { minute: '0', hour: '1-5' },
+      { minute: '0', hour: 'H' },
+      // A month other than every month.
+      { month: '3' },
+      // A day of the month and a day of the week together, which cron runs on
+      // the union of and every plain phrasing reads as the intersection.
+      { dom: '1', dow: '1' },
+      { dom: '1-5' },
+      { dom: '0' },
+      { dow: 'weekdays' },
+      { dow: '8' },
+    ]) {
+      expect(await described(shape)).toBeNull();
+    }
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1961,6 +1961,23 @@ describe('snapshot_tasks_list', () => {
     // A step of one is every hour; "every 1 hours" is not English.
     expect(await described({ minute: '0', hour: '*/1' })).toBe('every hour at :00, every day');
     expect(await described({ minute: '*/15', hour: '*' })).toBe('every 15 minutes, every day');
+    // A step that fills its unit exactly: once a day, and once an hour.
+    expect(await described({ minute: '0', hour: '*/24' })).toBe('every 24 hours at :00, every day');
+    expect(await described({ minute: '*/60', hour: '*' })).toBe('every 60 minutes, every day');
+  });
+
+  it('states no interval for a step that does not divide its unit', async () => {
+    // A step counts from the start of its unit and stops rather than wrapping.
+    // Hours stepping by 5 run at 00, 05, 10, 15 and 20 and then wait four hours
+    // for midnight, so "every 5 hours" would name an interval the task breaks
+    // once a day.
+    expect(await described({ minute: '0', hour: '*/5' })).toBeNull();
+    expect(await described({ minute: '0', hour: '*/7' })).toBeNull();
+    expect(await described({ minute: '*/7', hour: '*' })).toBeNull();
+    expect(await described({ minute: '*/45', hour: '*' })).toBeNull();
+    // The ones that do divide are unaffected.
+    expect(await described({ minute: '0', hour: '*/8' })).toBe('every 8 hours at :00, every day');
+    expect(await described({ minute: '*/20', hour: '*' })).toBe('every 20 minutes, every day');
   });
 
   it('states which days it runs on in words', async () => {


### PR DESCRIPTION
Adds `snapshot_tasks_list`, a read-only tool over `pool.snapshottask.query`.

Fixes #21

## Why

`snapshots_list` says what protection exists; this says what protection is
automatic. A dataset with a month of snapshots and no periodic task is
protected up to the last manual action and no further, and nothing in the
catalog could see that difference — a snapshot taken by hand and one a schedule
took look identical from the snapshot alone.

## What it returns

One row per task: `id`, `dataset`, `enabled`, `recursive`, `schedule`,
`schedule_description`, `lifetime_value`, `lifetime_unit`.

- **A disabled task is returned and marked `enabled: false`**, not omitted: a
  task nobody switched back on is exactly the one worth finding. `enabled` and
  `recursive` are null where the system reported no value, which is not the same
  answer as false — a task whose switch cannot be read must not be presented as
  definitely off.
- **The schedule comes back twice.** `schedule` carries the cron fields as the
  system holds them (`minute`, `hour`, `dom`, `month`, `dow`, and the `begin`
  and `end` of the daily window), each null where the field could not be read
  and the object itself null where the row carries no readable schedule.
  `schedule_description` restates them in words — `at 02:00, every day`, or
  `every 4 hours at :15, every day, between 09:00 and 17:00`. The ticket asked
  for this: a bare crontab line forces a model to decode before it can answer,
  and it can decode wrongly with nothing saying so.
- **The rendering is deliberately partial.** Four time shapes (a fixed minute of
  every hour, a fixed minute every N hours, a fixed minute of listed hours,
  every N minutes) and three day shapes (every day, listed days of the week,
  listed days of the month). Anything else renders `null` rather than a guess,
  and `schedule` is then the only — and exact — account of when the task runs.
  The tool description says so, and says that a null there is a limit of the
  tool rather than a task without a schedule.
- **Every field is named explicitly**, at the row and inside `schedule`, so a
  field a later TrueNAS release adds does not reach the caller without a change
  here. Both levels are asserted on in the tests.

`state` is on the task row and is not reported. This tool says what is
scheduled, not how the last run went; the description says that too.

## Review

Two local rounds with `local-review.py`, which ran the same shared reviewer the
required check runs (`exit 0/1`, not a subagent brief), so a clean round here is
a strong prediction of the check.

Round 1 returned one HIGH, which was right and is fixed in the second commit: a
cron step counts from the start of its unit and stops rather than wrapping, so
`*/N` is an interval only where N divides the unit exactly. Hours stepping by 5
run at 00, 05, 10, 15 and 20 and then wait four hours for midnight — "every 5
hours" named an interval the task breaks once a day. `everyStep` now takes the
unit's period and requires the step to divide it; those shapes fall through to a
null description. Every step the TrueNAS scheduler produces (1, 2, 3, 4, 6, 8,
12, 24 hours; 5, 10, 15, 20, 30, 60 minutes) divides and is unaffected.

Round 2 returned nothing at or above MEDIUM.

### LOWs left unchanged

Reported and not acted on, because every fix is a new diff and a new diff needs
another review round. Recorded here so they survive:

- `windowPhrase` renders `begin`/`end` without the shape check the cron fields
  get, and suppresses the default window by exact equality on `00:00`/`23:59`.
  A system spelling either differently would read as restricted; a task whose
  fixed time falls outside its own window is described rather than nulled.
- `dow` is not deduplicated, so the legal spelling `0,7` renders as
  `on Sunday and Sunday`.
- `cronOf` casts the client-typed `PoolSnapshotTaskCron` through `unknown` to an
  all-`unknown` local interface, which drops the compile-time check a renamed
  cron field would trip on a client bump. The guard is deliberate — the row has
  to survive a middleware that does not honour the type — but it does cost that.
- The object-or-null and non-empty-string-or-null guards are now hand-rolled in
  `snapshots.ts`, `replication.ts` and here; a shared helper would state the
  rationale once.
- `joinWords` would return `" and undefined"` on an empty list. Unreachable —
  both callers build the list from a non-empty split — but held by construction
  rather than by the type.
- `everyPhrase`'s singular branch is tested through hours (`*/1`) and not
  through minutes.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
locally. `tasks.ts` is at 100% statements and branches; the global floors
(branches 96, statements 97) are unmoved.
