### PR TITLE
feat(tools): add cloudsync_tasks_list, the cloud sync tasks and their last run

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
-  `replication_status`, `snapshot_tasks_list`.
+  `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,5 +72,6 @@ export {
   snapshotsList,
   replicationStatus,
   snapshotTasksList,
+  cloudsyncTasksList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,9 +7,9 @@ import { replicationStatus } from '@/tools/replication';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
-import { snapshotTasksList } from '@/tools/tasks';
+import { cloudsyncTasksList, snapshotTasksList } from '@/tools/tasks';
 
-/** The sketch's catalog: twelve read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -24,6 +24,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(snapshotsList);
   catalog.register(replicationStatus);
   catalog.register(snapshotTasksList);
+  catalog.register(cloudsyncTasksList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -31,6 +32,7 @@ export function createDefaultCatalog(): ToolCatalog {
 export {
   alertsList,
   appsList,
+  cloudsyncTasksList,
   createSnapshot,
   disksList,
   listDatasets,

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -457,12 +457,15 @@ function jobError(run: LastRun | null): string | null {
  * One named string field of a record the pinned client's types do not describe
  * field by field, or null where the record or the field is not readable.
  *
- * Three of the four places a cloud sync row is read from are like that: the
- * task's `attributes` and its credential are open records, and `description` is
- * not declared on the row at all — the server sends it and the generated dump
- * omits it, the same way it omits a job's own `description`, which the client
- * corrects by hand for exactly that reason. Each is read as `unknown` because
- * nothing in the pinned types vouches for it.
+ * Each of the three places this is used needs it for its own reason. A task's
+ * `attributes` is an open record — the client types it `Record<string,
+ * unknown>`, so `bucket` and `folder` arrive as `unknown`. `description` is not
+ * declared on the row at all: the server sends it and the generated dump omits
+ * it, the same way it omits a job's own `description`, which the client
+ * corrects by hand for exactly that reason. A task's credential IS declared,
+ * with a `name` typed a string — but the middleware also sends the id-only
+ * form, so a row that does not honour the type is the case a direct read would
+ * have got wrong.
  */
 function stringField(record: unknown, field: string): string | null {
   if (typeof record !== 'object' || record === null) return null;
@@ -541,9 +544,10 @@ export const cloudsyncTasksList: ReadOnlyTool = {
     return tasks.map((task) => {
       const cron = cronOf(task.schedule);
       const schedule = cron === null ? null : cronFieldsOf(cron);
-      // Read once and passed to `jobFinishedAt`, so that the state reported and
-      // the decision about whether the recorded time is a finish time cannot be
-      // made from two different readings of the same record.
+      // Both derived from `task.job` rather than from each other, and the state
+      // reported is then passed to `jobFinishedAt` — so whether the recorded
+      // time counts as a finish time is decided from the state the caller is
+      // given, not from a second reading of the record.
       const run = lastRunOf(task.job);
       const reported = lastRunState(task.job);
       return {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -6,11 +6,16 @@ import { ReadOnlyTool } from '@/catalog/tool';
  * Tasks family: the work a system does to itself on a schedule, with nobody
  * asking.
  *
- * `snapshots_list` says what protection exists; this says what protection is
- * automatic. The two are not visible in each other: a dataset with a month of
- * snapshots and no periodic task is protected up to the last manual action and
- * no further, and a snapshot taken by hand looks exactly like one a schedule
- * took. The task is the only place the difference is recorded.
+ * `snapshots_list` says what protection exists; `snapshot_tasks_list` says what
+ * protection is automatic. The two are not visible in each other: a dataset
+ * with a month of snapshots and no periodic task is protected up to the last
+ * manual action and no further, and a snapshot taken by hand looks exactly like
+ * one a schedule took. The task is the only place the difference is recorded.
+ *
+ * `cloudsync_tasks_list` is the same argument one step further out. A snapshot
+ * is on the same hardware as what it protects, so the copy that survives losing
+ * the system is the one a cloud sync task made — and a task that stopped
+ * succeeding announces itself nowhere until someone needs the copy.
  */
 
 /**
@@ -31,16 +36,28 @@ interface Cron {
   end?: unknown;
 }
 
-/** The seven cron fields as this tool reports them: a string, or null. */
-interface Schedule {
+/** The five cron fields every scheduled task carries: a string, or null. */
+interface CronFields {
   minute: string | null;
   hour: string | null;
   dom: string | null;
   month: string | null;
   dow: string | null;
+}
+
+/**
+ * The daily window a periodic snapshot task carries and a cloud sync task does
+ * not — the client types the latter's schedule as the five cron fields alone.
+ * Kept separate so the difference between the two is in the types rather than
+ * in two null fields a cloud sync task would report on every call.
+ */
+interface DailyWindow {
   begin: string | null;
   end: string | null;
 }
+
+/** The seven cron fields a periodic snapshot task reports. */
+type Schedule = CronFields & DailyWindow;
 
 /**
  * The daily window a task carries when nothing restricts it. Rendering it into
@@ -209,8 +226,11 @@ function windowPhrase(begin: string | null, end: string | null): string {
  * with it, and one it can decode wrongly without anything saying so. This is
  * the same schedule stated so that restating it is reading rather than
  * decoding — and null wherever that cannot be done exactly.
+ *
+ * The window is optional because a cloud sync task has none, and a schedule
+ * without one is rendered exactly as one whose window restricts nothing.
  */
-function describeSchedule(schedule: Schedule): string | null {
+function describeSchedule(schedule: CronFields & Partial<DailyWindow>): string | null {
   const { minute, hour, dom, month, dow } = schedule;
   if (minute === null || hour === null || dom === null || month === null || dow === null) {
     return null;
@@ -218,7 +238,23 @@ function describeSchedule(schedule: Schedule): string | null {
   const time = timePhrase(minute, hour);
   const days = dayPhrase(dom, month, dow);
   if (time === null || days === null) return null;
-  return `${time}, ${days}${windowPhrase(schedule.begin, schedule.end)}`;
+  return `${time}, ${days}${windowPhrase(schedule.begin ?? null, schedule.end ?? null)}`;
+}
+
+/**
+ * The five cron fields of a schedule, normalized. Named field by field rather
+ * than spread from the row, so that a field a later TrueNAS release adds to the
+ * schedule does not reach the caller without a change here — the same rule the
+ * task rows themselves are built under.
+ */
+function cronFieldsOf(cron: Cron): CronFields {
+  return {
+    minute: fieldOrNull(cron.minute),
+    hour: fieldOrNull(cron.hour),
+    dom: fieldOrNull(cron.dom),
+    month: fieldOrNull(cron.month),
+    dow: fieldOrNull(cron.dow),
+  };
 }
 
 export const snapshotTasksList: ReadOnlyTool = {
@@ -260,18 +296,13 @@ export const snapshotTasksList: ReadOnlyTool = {
     const tasks = await firstValueFrom(system.client.api.query('pool.snapshottask.query'));
     return tasks.map((task) => {
       const cron = cronOf(task.schedule);
-      // Named field by field rather than passed through, so that a field a
-      // later TrueNAS release adds to the schedule does not reach the caller
-      // without a change here — the same rule the row itself is built under.
+      // The window is read here rather than in `cronFieldsOf`, which is shared
+      // with the cloud sync task below and whose schedule carries none.
       const schedule: Schedule | null =
         cron === null
           ? null
           : {
-              minute: fieldOrNull(cron.minute),
-              hour: fieldOrNull(cron.hour),
-              dom: fieldOrNull(cron.dom),
-              month: fieldOrNull(cron.month),
-              dow: fieldOrNull(cron.dow),
+              ...cronFieldsOf(cron),
               begin: fieldOrNull(cron.begin),
               end: fieldOrNull(cron.end),
             };
@@ -292,6 +323,256 @@ export const snapshotTasksList: ReadOnlyTool = {
         schedule_description: schedule === null ? null : describeSchedule(schedule),
         lifetime_value: task.lifetime_value ?? null,
         lifetime_unit: task.lifetime_unit ?? null,
+      };
+    });
+  },
+};
+
+/**
+ * The job states that describe a run that has ENDED, and so the only ones under
+ * which the recorded finish time is a finish time.
+ *
+ * This is the middleware's own terminal set, which the client spells out in
+ * `isJobFinished`. Under a state outside it the job is still going or still
+ * waiting, and its `time_finished` is whatever the record held before the
+ * current run started — reporting that as the last finish would name a real
+ * timestamp as something it is not, which is worse than reporting none.
+ */
+const ENDED_JOB_STATES = new Set(['SUCCESS', 'FAILED', 'ABORTED', 'ERROR', 'FINISHED']);
+
+/**
+ * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
+ * than answering, so one absurd recorded time would otherwise take the whole
+ * listing down with it — the same guard `replication.ts` and `snapshots.ts`
+ * each apply to a time of their own, restated here for the same reason they
+ * restate it rather than share it: a tool file is read on its own.
+ */
+const MAX_TIME_MS = 8.64e15;
+
+/**
+ * The job record a cloud sync task carries for its last run, restated with
+ * every field optional and untyped.
+ *
+ * The client declares `job` as `{ [k: string]: unknown } | null` — an open
+ * record naming nothing — so every field of it arrives as `unknown`, the same
+ * way a replication task's state record does. Only the three fields read here
+ * are named.
+ */
+interface LastRun {
+  state?: unknown;
+  time_finished?: unknown;
+  error?: unknown;
+}
+
+/**
+ * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
+ * which is the only date representation the client's own types declare
+ * (`TrueNasDate`). Restated with `$date` untyped because it arrives inside an
+ * open record.
+ */
+interface MiddlewareDate {
+  $date?: unknown;
+}
+
+/**
+ * The task's job record, or null where the row carries nothing to read one
+ * from.
+ *
+ * Guarded rather than asserted: the record arrives as `unknown`, and a row that
+ * sends something other than an object is exactly the case an assertion would
+ * have got wrong.
+ */
+function lastRunOf(job: unknown): LastRun | null {
+  return typeof job === 'object' && job !== null ? (job as LastRun) : null;
+}
+
+/**
+ * An instant the job record carries, in milliseconds since the epoch, or null
+ * where the system reported no time this tool can read.
+ *
+ * A bare number is accepted beside the `{ "$date": … }` envelope because the
+ * envelope exists only to tag a number as a date in transit; both are epoch
+ * milliseconds. Anything else — a formatted string, a date in another shape —
+ * is not read rather than guessed at, because guessing wrong about a timezone
+ * produces a timestamp that is confidently off by hours.
+ */
+function jobMillis(value: unknown): number | null {
+  const raw =
+    typeof value === 'object' && value !== null ? (value as MiddlewareDate).$date : value;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+  return Math.abs(raw) <= MAX_TIME_MS ? raw : null;
+}
+
+/**
+ * The state of the task's last run: the job's own state string, or
+ * `NEVER_RUN`, or null.
+ *
+ * `job: null` is what a task carries until the system has run it. The field is
+ * declared non-optional and nullable, so null is the middleware saying there is
+ * no run record rather than that it could not send one — and that is the answer
+ * this tool exists to keep separate from a failure.
+ *
+ * Null is neither of those: a job record in a shape this tool cannot read, or
+ * one naming no state. It must not read as a task the system has never run,
+ * which is a fact about the task rather than about this tool. A task in either
+ * has not been shown to be working.
+ *
+ * Any other state is passed through as the system spelled it, so a state a
+ * later TrueNAS release adds reaches the caller rather than being flattened
+ * into one of these.
+ */
+function lastRunState(job: unknown): string | null {
+  if (job === null) return 'NEVER_RUN';
+  const reported = lastRunOf(job)?.state;
+  return typeof reported === 'string' && reported.length > 0 ? reported : null;
+}
+
+/**
+ * When the last run ended, as an ISO 8601 UTC timestamp, or null where nothing
+ * this tool can read says a run ended.
+ *
+ * The state must be one that describes an ended run — see
+ * {@link ENDED_JOB_STATES} — before the recorded time is read as a finish time
+ * at all.
+ */
+function jobFinishedAt(run: LastRun | null, reported: string | null): string | null {
+  if (run === null || reported === null || !ENDED_JOB_STATES.has(reported)) return null;
+  const millis = jobMillis(run.time_finished);
+  return millis === null ? null : new Date(millis).toISOString();
+}
+
+/**
+ * The error text recorded with the last run, or null where none was recorded.
+ *
+ * An empty string is read as no text rather than as an error message of no
+ * characters: it names nothing a caller could act on, and reporting it beside a
+ * `FAILED` state would suggest the reason is available when it is not.
+ */
+function jobError(run: LastRun | null): string | null {
+  const error = run?.error;
+  return typeof error === 'string' && error.length > 0 ? error : null;
+}
+
+/**
+ * One named string field of a record the pinned client's types do not describe
+ * field by field, or null where the record or the field is not readable.
+ *
+ * Three of the four places a cloud sync row is read from are like that: the
+ * task's `attributes` and its credential are open records, and `description` is
+ * not declared on the row at all — the server sends it and the generated dump
+ * omits it, the same way it omits a job's own `description`, which the client
+ * corrects by hand for exactly that reason. Each is read as `unknown` because
+ * nothing in the pinned types vouches for it.
+ */
+function stringField(record: unknown, field: string): string | null {
+  if (typeof record !== 'object' || record === null) return null;
+  return fieldOrNull((record as Record<string, unknown>)[field]);
+}
+
+/**
+ * The credential's numeric id, or null where the row carries nothing to read
+ * one from.
+ *
+ * The client types `credentials` as a whole credential record, and the
+ * middleware also has an id-only form, so both are read. Nothing else of the
+ * credential is: its `provider` is where the access key, token or password
+ * lives, and this tool never looks inside it.
+ */
+function credentialId(credentials: unknown): number | null {
+  const id =
+    typeof credentials === 'object' && credentials !== null
+      ? (credentials as { id?: unknown }).id
+      : credentials;
+  return typeof id === 'number' && Number.isFinite(id) ? id : null;
+}
+
+export const cloudsyncTasksList: ReadOnlyTool = {
+  name: 'cloudsync_tasks_list',
+  description:
+    'Every cloud sync task on the system: what it copies where, when it runs ' +
+    "and how its last run went. `id` is the task's numeric identity and " +
+    '`description` the name it was given, null where the system reported ' +
+    'none. `direction` is `PUSH`, copying from this system out to the remote, ' +
+    'or `PULL`, copying onto it. `path` is the local end — the source on a ' +
+    '`PUSH` and the destination on a `PULL`. `bucket` and `folder` are the ' +
+    'remote end; `bucket` is null on a provider that has no buckets, such as ' +
+    'SFTP or WebDAV, and either is null where the system reported no value. ' +
+    '`credential_id` and `credential_name` identify the stored credential the ' +
+    'task authenticates with, and are the only account of it: no key, token, ' +
+    'password or other secret appears anywhere in this result. `enabled` is ' +
+    'whether the task is switched on and is null where the system reported no ' +
+    'value; a disabled task is still listed, because a task nobody switched ' +
+    'back on is exactly the one worth finding. `schedule` carries the cron ' +
+    'fields as the system holds them: `minute`, `hour`, `dom` (day of the ' +
+    'month), `month` and `dow` (day of the week). Each field is null where the ' +
+    'system reported no value, and `schedule` itself is null where the task ' +
+    'carries no readable schedule at all. A cloud sync task has no daily ' +
+    'window, unlike a periodic snapshot task, so none is reported. ' +
+    '`schedule_description` restates those fields in words — `at 02:00, every ' +
+    'day`, or `every 4 hours at :00, on Monday and Thursday`. It is null where ' +
+    'the schedule is in a shape this tool does not render in words, and a null ' +
+    'there says nothing about the task: it is a limit of this tool rather than ' +
+    'a task without a schedule, and `schedule` is the exact account of when ' +
+    'the task runs either way. `state` is the state the system recorded for ' +
+    'the last run. `SUCCESS`, `FINISHED`, `FAILED`, `ERROR` and `ABORTED` ' +
+    'describe a run that ended; `RUNNING`, `WAITING`, `PENDING`, `HOLD` and ' +
+    '`LOCKED` describe one that has not. `NEVER_RUN` is a task the system ' +
+    'holds no run record for at all, and null is a run record this tool could ' +
+    'not read — those two are different answers, and a task in either has not ' +
+    'been shown to be working. A state a later TrueNAS release adds is passed ' +
+    'through as the system spelled it, so `state` is not limited to that ' +
+    'list. `finished_at` is when the last run ended, as an ISO 8601 UTC ' +
+    'timestamp. It is reported only under the states that describe a run that ' +
+    'ended, and is null under every other state including `RUNNING` — the ' +
+    'system holds one job record per task, and while a run is going the time ' +
+    'in it belongs to the run before. `error` is the text recorded with that ' +
+    'run and is null where none was recorded, so a task in `FAILED` with a ' +
+    'null `error` failed for a reason the system did not record; it has not ' +
+    'succeeded. This tool reports tasks and their last run, not the contents ' +
+    'of the remote — what is actually stored there is not among these fields.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: a system holds tens of cloud sync tasks at
+    // most, and every field this tool reads is part of a task row as it stands
+    // — there is nothing to bound and no option that changes how it arrives.
+    const tasks = await firstValueFrom(system.client.api.query('cloudsync.query'));
+    return tasks.map((task) => {
+      const cron = cronOf(task.schedule);
+      const schedule = cron === null ? null : cronFieldsOf(cron);
+      // Read once and passed to `jobFinishedAt`, so that the state reported and
+      // the decision about whether the recorded time is a finish time cannot be
+      // made from two different readings of the same record.
+      const run = lastRunOf(task.job);
+      const reported = lastRunState(task.job);
+      return {
+        id: task.id,
+        description: stringField(task, 'description'),
+        direction: task.direction,
+        path: task.path,
+        // Named rather than passed through: `attributes` is an open record
+        // whose contents differ per provider, so a field a later TrueNAS
+        // release adds to it does not reach the caller without a change here.
+        bucket: stringField(task.attributes, 'bucket'),
+        folder: stringField(task.attributes, 'folder'),
+        // The credential by id and name and nothing else — its `provider` holds
+        // the access key, token or password, and is never read.
+        credential_id: credentialId(task.credentials),
+        credential_name: stringField(task.credentials, 'name'),
+        // Optional on the client's own type, so a middleware that omits it
+        // reports null rather than a default. Not defaulted either way: a task
+        // whose switch cannot be read must not be presented as one that is
+        // definitely on or definitely off.
+        enabled: task.enabled ?? null,
+        schedule,
+        // Rendered from the normalized fields rather than from the row, so that
+        // what is described and what is reported cannot be two different
+        // readings of the same schedule.
+        schedule_description: schedule === null ? null : describeSchedule(schedule),
+        state: reported,
+        finished_at: jobFinishedAt(run, reported),
+        error: jobError(run),
       };
     });
   },

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -5,6 +5,7 @@ import { Role } from '@/interfaces';
 import {
   alertsList,
   appsList,
+  cloudsyncTasksList,
   createDefaultCatalog,
   createSnapshot,
   disksList,
@@ -37,7 +38,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirteen sketch tools', () => {
+  it('registers the fourteen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -51,6 +52,7 @@ describe('createDefaultCatalog', () => {
       'snapshots_list',
       'replication_status',
       'snapshot_tasks_list',
+      'cloudsync_tasks_list',
       'snapshots_create',
     ]);
   });
@@ -100,6 +102,12 @@ describe('createDefaultCatalog', () => {
   it('advertises snapshot_tasks_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'snapshot_tasks_list',
+    );
+  });
+
+  it('advertises cloudsync_tasks_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'cloudsync_tasks_list',
     );
   });
 });
@@ -2028,5 +2036,268 @@ describe('snapshot_tasks_list', () => {
     ]) {
       expect(await described(shape)).toBeNull();
     }
+  });
+});
+
+describe('cloudsync_tasks_list', () => {
+  /**
+   * A cloud sync task as `cloudsync.query` reports one.
+   *
+   * `credentials` carries a `provider` because a real row does, and it is here
+   * to be dropped: it is where the access key lives, and the test that no
+   * secret survives is only worth anything if one was there to survive.
+   * `transfer_mode`, `snapshot`, `include`, `exclude`, `locked` and
+   * `pre_script` are here to be dropped too — fields of the real payload the
+   * tool does not name.
+   */
+  const task = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    description: 'Nightly offsite',
+    direction: 'PUSH',
+    path: '/mnt/tank/media',
+    attributes: { bucket: 'offsite-backups', folder: '/media', region: 'us-east-1' },
+    credentials: {
+      id: 7,
+      name: 'Backblaze B2',
+      provider: { type: 'B2', account: '00abc', key: 'SECRET-KEY-MATERIAL' },
+    },
+    enabled: true,
+    schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    job: {
+      id: 91,
+      state: 'SUCCESS',
+      time_started: { $date: 1_700_000_000_000 },
+      time_finished: { $date: 1_700_000_600_000 },
+      error: null,
+    },
+    transfer_mode: 'SYNC',
+    snapshot: false,
+    include: [],
+    exclude: [],
+    locked: false,
+    pre_script: 'echo hello',
+    ...over,
+  });
+
+  const listed = async (rows: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['cloudsync.query']: rows });
+    return (await cloudsyncTasksList.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  /** One task, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([task(over)]))[0];
+
+  it('maps a task to its remote, credential, schedule and last run', async () => {
+    expect(await listed([task()])).toEqual([
+      {
+        id: 3,
+        description: 'Nightly offsite',
+        direction: 'PUSH',
+        path: '/mnt/tank/media',
+        bucket: 'offsite-backups',
+        folder: '/media',
+        credential_id: 7,
+        credential_name: 'Backblaze B2',
+        enabled: true,
+        schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+        schedule_description: 'at 02:00, every day',
+        state: 'SUCCESS',
+        finished_at: '2023-11-14T22:23:20.000Z',
+        error: null,
+      },
+    ]);
+  });
+
+  it('surfaces no field a later release adds, at either level', async () => {
+    const rows = await listed([
+      task({
+        future_field: 'added by a later TrueNAS release',
+        schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*', timezone: 'UTC' },
+      }),
+    ]);
+    expect(Object.keys(rows[0])).toEqual([
+      'id',
+      'description',
+      'direction',
+      'path',
+      'bucket',
+      'folder',
+      'credential_id',
+      'credential_name',
+      'enabled',
+      'schedule',
+      'schedule_description',
+      'state',
+      'finished_at',
+      'error',
+    ]);
+    // No daily window: a cloud sync schedule carries none, and reporting two
+    // permanently null fields would say it does.
+    expect(Object.keys(rows[0]['schedule'] as object)).toEqual([
+      'minute',
+      'hour',
+      'dom',
+      'month',
+      'dow',
+    ]);
+  });
+
+  it('never lets key material out, whatever the credential carries', async () => {
+    const rows = await listed([task()]);
+    expect(JSON.stringify(rows)).not.toContain('SECRET-KEY-MATERIAL');
+    expect(JSON.stringify(rows)).not.toContain('provider');
+    // The credential is still identified — dropping the secret must not cost
+    // the caller the ability to say which credential a task uses.
+    expect(rows[0]['credential_id']).toBe(7);
+    expect(rows[0]['credential_name']).toBe('Backblaze B2');
+  });
+
+  it('reads an id-only credential, and reports one it cannot read as null', async () => {
+    expect((await one({ credentials: 11 }))['credential_id']).toBe(11);
+    // Named on an id-only credential is nothing this tool can invent.
+    expect((await one({ credentials: 11 }))['credential_name']).toBeNull();
+    for (const unreadable of [undefined, null, 'B2', Number.NaN, {}]) {
+      const row = await one({ credentials: unreadable });
+      expect(row['credential_id']).toBeNull();
+      expect(row['credential_name']).toBeNull();
+    }
+  });
+
+  it('asks for every task, with no filters and no options', async () => {
+    const { ctx, query } = fakeSystem({ ['cloudsync.query']: [task()] });
+    await cloudsyncTasksList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('cloudsync.query');
+  });
+
+  it('returns [] for a system with no cloud sync tasks', async () => {
+    expect(await listed([])).toEqual([]);
+  });
+
+  it('lists a disabled task, and reports a switch it cannot read as null', async () => {
+    // A task that exists and is off is the case worth surfacing: the offsite
+    // copy stops either way, and only one of the two announces itself.
+    expect((await one({ enabled: false }))['enabled']).toBe(false);
+    expect((await one({ enabled: undefined }))['enabled']).toBeNull();
+  });
+
+  it('reports a description it cannot read as null', async () => {
+    for (const unreadable of [undefined, '', 42, null]) {
+      expect((await one({ description: unreadable }))['description']).toBeNull();
+    }
+  });
+
+  it('names the remote end, and reports either part it cannot read as null', async () => {
+    // A provider with no buckets — SFTP, WebDAV — carries a folder alone.
+    const sftp = await one({ attributes: { folder: '/backups' } });
+    expect(sftp['bucket']).toBeNull();
+    expect(sftp['folder']).toBe('/backups');
+    for (const unreadable of [undefined, null, 'offsite-backups', 42]) {
+      const row = await one({ attributes: unreadable });
+      expect(row['bucket']).toBeNull();
+      expect(row['folder']).toBeNull();
+    }
+  });
+
+  it('reports a schedule it cannot read at all as null, with no words for it', async () => {
+    for (const unreadable of [undefined, null, '0 2 * * *', 42]) {
+      const row = await one({ schedule: unreadable });
+      expect(row['schedule']).toBeNull();
+      expect(row['schedule_description']).toBeNull();
+    }
+  });
+
+  it('reports a cron field it cannot read as null, and renders no words then', async () => {
+    const row = await one({ schedule: { minute: '', hour: 2, dom: '*', dow: null } });
+    expect(row['schedule']).toEqual({
+      minute: null,
+      hour: null,
+      dom: '*',
+      month: null,
+      dow: null,
+    });
+    expect(row['schedule_description']).toBeNull();
+  });
+
+  it('renders a schedule in words without a window to name', async () => {
+    // The same renderer as a periodic snapshot task, which reaches it with a
+    // window; a cloud sync schedule reaches it with none and reads the same.
+    expect(
+      (await one({ schedule: { minute: '15', hour: '*/4', dom: '*', month: '*', dow: '1,4' } }))[
+        'schedule_description'
+      ],
+    ).toBe('every 4 hours at :15, on Monday and Thursday');
+  });
+
+  it('separates a task that has never run from one it cannot read', async () => {
+    // `job: null` is the middleware saying there is no run record, which is
+    // what this tool exists to keep apart from a failure.
+    const never = await one({ job: null });
+    expect(never['state']).toBe('NEVER_RUN');
+    expect(never['finished_at']).toBeNull();
+    expect(never['error']).toBeNull();
+    // Null is not that: a record in a shape this tool could not read, or one
+    // naming no state. Neither has been shown to be working.
+    for (const unreadable of [undefined, 42, 'SUCCESS', {}, { state: '' }, { state: 7 }]) {
+      const row = await one({ job: unreadable });
+      expect(row['state']).toBeNull();
+      expect(row['finished_at']).toBeNull();
+    }
+  });
+
+  it('passes a state through as the system spelled it', async () => {
+    for (const state of ['FAILED', 'RUNNING', 'WAITING', 'ABORTED', 'A_LATER_RELEASE_STATE']) {
+      expect((await one({ job: { state } }))['state']).toBe(state);
+    }
+  });
+
+  it('reports a finish time only for a run that ended', async () => {
+    const at = { $date: 1_700_000_600_000 };
+    for (const state of ['SUCCESS', 'FINISHED', 'FAILED', 'ERROR', 'ABORTED']) {
+      expect((await one({ job: { state, time_finished: at } }))['finished_at']).toBe(
+        '2023-11-14T22:23:20.000Z',
+      );
+    }
+    // The system holds one job record per task, so while a run is going the
+    // time in it belongs to the run before — naming it as this run's finish
+    // would state a real timestamp as something it is not.
+    for (const state of ['RUNNING', 'WAITING', 'PENDING', 'HOLD', 'LOCKED']) {
+      expect((await one({ job: { state, time_finished: at } }))['finished_at']).toBeNull();
+    }
+  });
+
+  it('reads a bare epoch beside the $date envelope, and nothing else', async () => {
+    const finishedAt = async (time_finished: unknown): Promise<unknown> =>
+      (await one({ job: { state: 'SUCCESS', time_finished } }))['finished_at'];
+    // The envelope exists only to tag a number as a date in transit.
+    expect(await finishedAt(1_700_000_600_000)).toBe('2023-11-14T22:23:20.000Z');
+    for (const unreadable of [
+      undefined,
+      null,
+      // A formatted string is not guessed at: guessing wrong about a timezone
+      // produces a timestamp confidently off by hours.
+      '2023-11-14T22:23:20Z',
+      { $date: '1700000600000' },
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      // Beyond what a Date can hold, where `toISOString` throws rather than
+      // answering — one absurd time must not take the whole listing down.
+      8.64e15 + 1,
+      -(8.64e15 + 1),
+    ]) {
+      expect(await finishedAt(unreadable)).toBeNull();
+    }
+  });
+
+  it('carries the reason a run failed, and reports no reason as null', async () => {
+    expect((await one({ job: { state: 'FAILED', error: 'rclone exited 1' } }))['error']).toBe(
+      'rclone exited 1',
+    );
+    // A task in FAILED with a null error failed for a reason the system did
+    // not record; it has not succeeded.
+    for (const unreadable of [undefined, null, '', 42]) {
+      expect((await one({ job: { state: 'FAILED', error: unreadable } }))['error']).toBeNull();
+    }
+    expect((await one({ job: null }))['error']).toBeNull();
   });
 });


### PR DESCRIPTION
Adds `cloudsync_tasks_list`, a read-only tool returning every cloud sync task,
its schedule and how its last run went.

Fixes #22

## What it reports

One flat object per task, every field named explicitly — nothing from the
middleware payload passes through:

| field | |
|---|---|
| `id`, `description` | the task's numeric identity and the name it was given |
| `direction` | `PUSH` (out to the remote) or `PULL` (onto this system) |
| `path` | the local end — source on a `PUSH`, destination on a `PULL` |
| `bucket`, `folder` | the remote end; `bucket` is null on a provider that has none, such as SFTP or WebDAV |
| `credential_id`, `credential_name` | the stored credential, and the only account of it |
| `enabled` | null where the system reported no value, never defaulted |
| `schedule` | the five cron fields as the system holds them |
| `schedule_description` | those fields in words, or null where this tool cannot state them exactly |
| `state`, `finished_at`, `error` | how the last run went |

## Three decisions worth reading

**No key material, and a test that says so.** The credential is reported by id
and name. Its `provider` — where the access key, token or password lives — is
never read, and the shape this tool builds has nowhere to put one. The fixture
carries a real-looking secret in `credentials.provider.key` specifically so
that the assertion it does not survive is worth something.

**`NEVER_RUN` is not null.** `job: null` is the middleware saying there is no
run record, which is the answer this tool exists to keep apart from a failure.
Null `state` is a different answer: a job record this tool could not read. A
task in either has not been shown to be working, and the description says so.

**A finish time only for a run that ended.** The system holds one job record
per task, so while a run is going the time in it belongs to the run before.
`finished_at` is reported under `SUCCESS`, `FINISHED`, `FAILED`, `ERROR` and
`ABORTED`, and is null under every other state including `RUNNING` — naming
that time as this run's finish would state a real timestamp as something it is
not. This is the same rule `replication_status` applies to its own state
record.

## One shared change

The five cron fields are split out of `Schedule` as `CronFields`, and
`describeSchedule` now takes the daily window as optional. A cloud sync
schedule is `CloudCron` — five fields, no `begin`/`end` — so the difference
between the two task kinds is now in the types, rather than two permanently
null fields on every cloud sync row. `snapshot_tasks_list` is unchanged in
behaviour; its existing tests, including the exact-key-order assertion on
`schedule`, pass untouched.

## Two things worth knowing

**`description` is not on the pinned client's type.** `CloudSyncEntry` in
`@truenas/api-client` 2.x declares no `description`, but the server sends one
and the acceptance criteria ask for it — the same gap the client itself
documents and corrects by hand for a job's `description`. It is read
defensively off the row and reported null where absent, so this cannot break
if the generated shape later gains the field.

**`error` is included, which the acceptance criteria did not ask for.**
`state` and `finished_at` satisfy "the outcome and finish time of its last
run" on their own. Without `error`, a task reporting `FAILED` says nothing
about why, and the ticket's own Why section is about finding tasks that
stopped succeeding — so it is here, matching `replication_status`, which
reports the error text recorded with its state for the same reason.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
locally. Coverage: `src/tools/tasks.ts` at 100% statements and 100% branches;
globals 98.71 / 98.49 against floors of 97 / 96.

The shared review ran here in a separate process — the same reviewer, rubric
and threshold as the required check — and returned **nothing at or above
MEDIUM**. It raised five LOWs. Two were comments contradicting the code they
sat above, and are fixed in the second commit (prose only, no executable
change). The other three are left, and are recorded here rather than acted on:

- **`ENDED_JOB_STATES` duplicates the client's own `terminalStates`.** The
  client exports `isJobFinished`, but it takes a whole `Job` and the record
  inside a task row is `Record<string, unknown>`, so using it would mean
  asserting the row into a type the middleware does not promise. A client bump
  adding a terminal state would give a null `finished_at` for that state —
  which is the conservative direction, and the tool's contract already says a
  null there means the tool could not tell.
- **`MAX_TIME_MS`, `MiddlewareDate` and the millis/error helpers are a third
  copy**, after `replication.ts` and `snapshots.ts`. Extracting them is a
  layout decision across three tool files and belongs in its own change, not
  in a tool ticket; the repository has made the restate-per-file choice twice
  already.
- **`error` is verbatim middleware text**, so the description's "no secret
  appears anywhere in this result" is a promise about the fields this tool
  builds rather than about text the server wrote. Worth either narrowing that
  sentence or dropping `error`; both are judgement calls a reviewer should
  make rather than me, having just argued above for keeping the field.

Each is a real observation and none blocks; a follow-up ticket could take the
first and third together.
