### PR TITLE
feat(tools): add tasks_recent_runs, recent jobs with failures called out

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
-  `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`.
+  `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
+  `tasks_recent_runs`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,5 +73,6 @@ export {
   replicationStatus,
   snapshotTasksList,
   cloudsyncTasksList,
+  tasksRecentRuns,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,9 +7,9 @@ import { replicationStatus } from '@/tools/replication';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
-import { cloudsyncTasksList, snapshotTasksList } from '@/tools/tasks';
+import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: thirteen read-only tools plus one mutating tool. */
+/** The sketch's catalog: fourteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -25,6 +25,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(replicationStatus);
   catalog.register(snapshotTasksList);
   catalog.register(cloudsyncTasksList);
+  catalog.register(tasksRecentRuns);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -44,4 +45,5 @@ export {
   snapshotsList,
   snapshotTasksList,
   systemInfo,
+  tasksRecentRuns,
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -16,6 +16,12 @@ import { ReadOnlyTool } from '@/catalog/tool';
  * is on the same hardware as what it protects, so the copy that survives losing
  * the system is the one a cloud sync task made — and a task that stopped
  * succeeding announces itself nowhere until someone needs the copy.
+ *
+ * `tasks_recent_runs` comes at all of it from the other end. The two above list
+ * what is *arranged*, one kind of task at a time; that one lists what actually
+ * *ran*, of every kind at once — scrubs, replication, cloud sync, app upgrades,
+ * updates — because every long-running operation on TrueNAS is a job and they
+ * all land in the same place.
  */
 
 /**
@@ -357,6 +363,13 @@ const MAX_TIME_MS = 8.64e15;
  * record naming nothing — so every field of it arrives as `unknown`, the same
  * way a replication task's state record does. Only the three fields read here
  * are named.
+ *
+ * A `core.get_jobs` row satisfies this too, and `tasks_recent_runs` passes one
+ * straight to {@link jobFinishedAt} and {@link jobError}: it is the same job
+ * record, reached by listing the jobs rather than by reading the task that
+ * started one. The client types that row's fields where this does not, and
+ * every field named here is optional and `unknown`, so the typed row is
+ * assignable and the guards below cost it nothing.
  */
 interface LastRun {
   state?: unknown;
@@ -427,6 +440,11 @@ function lastRunState(job: unknown): string | null {
   return typeof reported === 'string' && reported.length > 0 ? reported : null;
 }
 
+/** An instant as an ISO 8601 UTC timestamp, or null where there is no instant. */
+function isoOrNull(millis: number | null): string | null {
+  return millis === null ? null : new Date(millis).toISOString();
+}
+
 /**
  * When the last run ended, as an ISO 8601 UTC timestamp, or null where nothing
  * this tool can read says a run ended.
@@ -437,8 +455,7 @@ function lastRunState(job: unknown): string | null {
  */
 function jobFinishedAt(run: LastRun | null, reported: string | null): string | null {
   if (run === null || reported === null || !ENDED_JOB_STATES.has(reported)) return null;
-  const millis = jobMillis(run.time_finished);
-  return millis === null ? null : new Date(millis).toISOString();
+  return isoOrNull(jobMillis(run.time_finished));
 }
 
 /**
@@ -579,5 +596,268 @@ export const cloudsyncTasksList: ReadOnlyTool = {
         error: jobError(run),
       };
     });
+  },
+};
+
+/**
+ * How far back `tasks_recent_runs` looks when the caller bounds nothing.
+ *
+ * The middleware holds every job it has run since it last started, which on a
+ * system that has been up for weeks is thousands of them, nearly all of which
+ * succeeded and are nobody's question. A day is the window that makes "what has
+ * this system been doing, and what went wrong" answerable in one call; a longer
+ * one is asked for rather than assumed.
+ */
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The ISO 8601 forms `since` is accepted in: a date, or a date and a time
+ * carrying an explicit zone.
+ *
+ * A zone is required for the same reason {@link jobMillis} will not read a
+ * formatted string. `Date.parse('2026-08-28 09:00')` is implementation-defined
+ * and Node reads it as LOCAL time, so a bound that looks exact would move the
+ * window by the offset of whatever machine this happens to run on — silently,
+ * and by hours. The date-only form is exempt because ECMAScript defines that
+ * one as UTC.
+ */
+const ISO_INSTANT =
+  /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2}))?$/;
+
+/**
+ * Whether the year, month and day are a date that exists.
+ *
+ * `Date.parse` does not settle this and is silent about it. A month out of
+ * range, an hour of 25 and a malformed offset each answer `NaN`, but a day the
+ * month does not have ROLLS OVER into the next one and answers a real instant:
+ * `2026-02-30` parses as the 2nd of March, measured. So a caller that bounded a
+ * report at a mistyped date would be handed a window starting two days after
+ * the one it named, with nothing anywhere saying so — and every job in the gap
+ * would be missing from an answer that looked complete.
+ *
+ * Rebuilt from the components and compared back, which needs no table of month
+ * lengths to know that February has no 30th and that some Februaries have a
+ * 29th. The year is not checked: the pattern above admits four digits and every
+ * four-digit year exists.
+ */
+function isRealDate(year: number, month: number, day: number): boolean {
+  const at = new Date(0);
+  at.setUTCFullYear(year, month - 1, day);
+  return at.getUTCMonth() === month - 1 && at.getUTCDate() === day;
+}
+
+/**
+ * The instant the result is bounded at, in milliseconds since the epoch — the
+ * default window back from `now` where the caller named none.
+ *
+ * Strict rather than lenient, as `snapshots_list` is about the dataset it is
+ * asked for and for the same reason: a `since` that cannot be read is not a
+ * request for the default window. Ignoring it would answer about the last day
+ * while the caller believes it answered about the last month, and an empty
+ * result would then read as "nothing failed" rather than as "the bound was not
+ * applied". Null and undefined are the argument being absent, which is not the
+ * same as unreadable and is what the default is for.
+ */
+function windowStart(raw: unknown, now: number): number {
+  if (raw == null) return now - DEFAULT_WINDOW_MS;
+  const match = typeof raw === 'string' ? ISO_INSTANT.exec(raw) : null;
+  if (match === null) {
+    throw new Error(
+      '"since" must be an ISO 8601 timestamp with a timezone, such as ' +
+        '"2026-08-28T09:00:00Z", or a date such as "2026-08-28"',
+    );
+  }
+  // `match[0]` is the whole match, which an anchored pattern makes the whole
+  // string — the same characters as `raw`, and typed where `raw` is `unknown`.
+  const text = match[0];
+  const millis = Date.parse(text);
+  if (Number.isNaN(millis) || !isRealDate(Number(match[1]), Number(match[2]), Number(match[3]))) {
+    throw new Error(`"since" is not a real date: "${text}"`);
+  }
+  return millis;
+}
+
+/**
+ * Whether the caller asked for failures alone.
+ *
+ * Strict, as `snapshots_create` is about `recursive`: coercing `"false"` or `0`
+ * would answer a different question from the one asked — every job the system
+ * ran, where the caller asked what went wrong — and a listing that is wrong in
+ * that direction is one a model will summarise as fact.
+ */
+function failedOnly(raw: unknown): boolean {
+  if (raw == null) return false;
+  if (typeof raw !== 'boolean') throw new Error('"failed_only" must be a boolean');
+  return raw;
+}
+
+/**
+ * The job states that describe a run that SUCCEEDED, and those that describe
+ * one still under way. Between them they are every state middleware defines —
+ * the client's own `JobState` — that is not a failure, and
+ * {@link ENDED_JOB_STATES} above is the first of these two together with
+ * `FAILED`, `ERROR` and `ABORTED`.
+ *
+ * Written as what `failed_only` EXCLUDES rather than as the failures it keeps,
+ * and that direction is the whole point. A failure state a later TrueNAS
+ * release adds is in neither set, so it survives the filter instead of being
+ * dropped from the one answer this tool exists to give. The reverse — listing
+ * the failures — would go quiet about exactly the runs nobody here has heard
+ * of yet.
+ */
+const SUCCEEDED_JOB_STATES = new Set(['SUCCESS', 'FINISHED']);
+const UNDER_WAY_JOB_STATES = new Set(['RUNNING', 'WAITING', 'PENDING', 'HOLD', 'LOCKED']);
+
+/**
+ * Whether `failed_only` keeps this job: one that has not succeeded and is not
+ * still going.
+ *
+ * A state this tool could not read counts as not succeeded. A job that cannot
+ * be shown to have worked has not been shown to have worked, and hiding it from
+ * the failure listing is the one mistake here that matters.
+ */
+function notSucceeded(state: string | null): boolean {
+  return state === null || !(SUCCEEDED_JOB_STATES.has(state) || UNDER_WAY_JOB_STATES.has(state));
+}
+
+/**
+ * How far through the job is, as a percentage, or null where the system
+ * reported none this tool can read.
+ *
+ * Not defaulted to zero: a job whose progress could not be read must not report
+ * as one that has not started, which is a claim about the job rather than about
+ * this tool.
+ */
+function progressPercent(progress: unknown): number | null {
+  const percent =
+    typeof progress === 'object' && progress !== null
+      ? (progress as { percent?: unknown }).percent
+      : undefined;
+  return typeof percent === 'number' && Number.isFinite(percent) ? percent : null;
+}
+
+/**
+ * What the system has been doing, and what went wrong doing it.
+ *
+ * Every long-running operation on TrueNAS is a job, so one call reaches across
+ * scrubs, replication, cloud sync, app upgrades and updates at once — where the
+ * per-family tools each answer for their own kind of task and none of them
+ * answers for a job nothing on the board started.
+ *
+ * A job row is the largest payload in this catalog: it carries the full
+ * arguments the job was called with, its whole result, and an excerpt of its
+ * logs. None of the three is reported. `arguments` and `credentials` are
+ * refused on the catalog's own rule that secrets do not pass through tools —
+ * a job that mounts a share or authenticates to a remote was called with the
+ * password — and `result` and `logs_excerpt` are refused for size, being
+ * unbounded and per-job. The query asks for the named fields alone, so on a
+ * middleware that honours `select` none of them is even fetched; the mapping
+ * below is what guarantees it either way.
+ */
+export const tasksRecentRuns: ReadOnlyTool = {
+  name: 'tasks_recent_runs',
+  description:
+    'Recent background jobs on the system, with failures called out. Every ' +
+    'long-running operation on TrueNAS is a job — scrubs, replication, cloud ' +
+    'sync, app upgrades, updates — so this answers what the system has been ' +
+    'doing and what went wrong, across all of them at once. `id` is the ' +
+    "job's numeric identity and `method` the API method it runs, such as " +
+    '`pool.scrub.run` or `app.upgrade`; the method is what says which kind of ' +
+    'operation a job is. `state` is the state the system recorded. `SUCCESS` ' +
+    'and `FINISHED` describe a run that succeeded; `FAILED`, `ERROR` and ' +
+    '`ABORTED` one that did not; `RUNNING`, `WAITING`, `PENDING`, `HOLD` and ' +
+    '`LOCKED` one still under way. A state a later TrueNAS release adds is ' +
+    'passed through as the system spelled it, so `state` is not limited to ' +
+    'that list, and null is a state this tool could not read — a job in either ' +
+    'has not been shown to have worked. `progress_percent` is how far through ' +
+    'the job is, and `progress_description` what it says it is doing; each is ' +
+    'null where the system reported no value, and a null percent is not zero. ' +
+    '`started_at` is when the job started and `finished_at` when it ended, ' +
+    'both as ISO 8601 UTC timestamps. `finished_at` is reported only under the ' +
+    'states that describe a run that ended, and is null under every other ' +
+    'state including `RUNNING`. Either is null where the system recorded no ' +
+    'time this tool can read. `error` is the text recorded with a job that ' +
+    'failed and is null where none was recorded, so a job in `FAILED` with a ' +
+    'null `error` failed for a reason the system did not record; it has not ' +
+    'succeeded. `failed_only` restricts the result to jobs that have not ' +
+    'succeeded and are not still under way — the failure states above, plus ' +
+    'any state this tool does not recognise or could not read, so a failure ' +
+    'is never hidden by being unfamiliar. `since` bounds the result to jobs ' +
+    'started at or after an ISO 8601 instant; omitted, THE LAST 24 HOURS, so ' +
+    'an empty result means nothing matched within that window rather than ' +
+    'that the system has never run the job in question. Pass `since` to look ' +
+    'further back. A job whose start time could not be read is returned under ' +
+    'any window, because nothing places it outside one. The arguments a job ' +
+    'was called with, its result, its credentials and its logs are NOT ' +
+    'returned: arguments and credentials can hold passwords and keys, and no ' +
+    'secret passes through this tool. This lists jobs, which are operations ' +
+    'the system ran; the schedules that start some of them are ' +
+    '`snapshot_tasks_list` and `cloudsync_tasks_list`, and a task that has ' +
+    'never run has no job here at all.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      failed_only: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Only report jobs that did not succeed and are not still running. ' +
+          'Default false, which reports every job in the window.',
+      },
+      since: {
+        type: 'string',
+        description:
+          'Only report jobs started at or after this instant, as an ISO 8601 ' +
+          'timestamp carrying a timezone — "2026-08-28T09:00:00Z" — or a ' +
+          'date, "2026-08-28", which is midnight UTC. Omitted, the last 24 ' +
+          'hours.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // Both arguments are read before the call, so an unreadable one is an
+    // error rather than a query the system answers and this tool then discards.
+    const failed = failedOnly(args['failed_only']);
+    const since = windowStart(args['since'], Date.now());
+    const jobs = await firstValueFrom(
+      // Options are inlined so the call's own parameter types apply, as in
+      // `storage.ts`. `select` names the fields this tool reports and no
+      // others, which keeps the arguments, result and logs of every job off
+      // the wire entirely on a middleware that applies it. It is defence in
+      // depth rather than the control: an unrecognised query option is dropped
+      // rather than refused, so the mapping below is what actually decides
+      // what a caller sees.
+      system.client.api.query('core.get_jobs', [], {
+        select: ['id', 'method', 'state', 'progress', 'time_started', 'time_finished', 'error'],
+      }),
+    );
+    const rows = [];
+    for (const job of jobs) {
+      const state = fieldOrNull(job.state);
+      if (failed && !notSucceeded(state)) continue;
+      const startedMillis = jobMillis(job.time_started);
+      // Only a job whose start time reads as older than the bound is dropped.
+      // One with no readable start time is kept: it cannot be shown to fall
+      // outside the window, and a failure that disappears because its
+      // timestamp was unreadable is the failure mode worth avoiding here.
+      if (startedMillis !== null && startedMillis < since) continue;
+      rows.push({
+        id: job.id,
+        method: job.method,
+        state,
+        // Named field by field rather than passed through: `progress` also
+        // carries `extra`, which is per-method and unbounded.
+        progress_percent: progressPercent(job.progress),
+        progress_description: stringField(job.progress, 'description'),
+        started_at: isoOrNull(startedMillis),
+        // The job row is the run record, so it is read as one — and the state
+        // passed is the one the caller is given, not a second reading of it.
+        finished_at: jobFinishedAt(job, state),
+        error: jobError(job),
+      });
+    }
+    return rows;
   },
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { of } from 'rxjs';
 import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { Role } from '@/interfaces';
@@ -17,6 +17,7 @@ import {
   scrubHistory,
   snapshotsList,
   snapshotTasksList,
+  tasksRecentRuns,
 } from '@/tools/index';
 
 /**
@@ -38,7 +39,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the fourteen sketch tools', () => {
+  it('registers the fifteen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -53,6 +54,7 @@ describe('createDefaultCatalog', () => {
       'replication_status',
       'snapshot_tasks_list',
       'cloudsync_tasks_list',
+      'tasks_recent_runs',
       'snapshots_create',
     ]);
   });
@@ -108,6 +110,12 @@ describe('createDefaultCatalog', () => {
   it('advertises cloudsync_tasks_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'cloudsync_tasks_list',
+    );
+  });
+
+  it('advertises tasks_recent_runs to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'tasks_recent_runs',
     );
   });
 });
@@ -2299,5 +2307,310 @@ describe('cloudsync_tasks_list', () => {
       expect((await one({ job: { state: 'FAILED', error: unreadable } }))['error']).toBeNull();
     }
     expect((await one({ job: null }))['error']).toBeNull();
+  });
+});
+
+describe('tasks_recent_runs', () => {
+  /**
+   * A fixed present, so the default window is a fixed interval rather than one
+   * that moves with the clock. Only `Date` is faked: the tool reads the clock
+   * and nothing here schedules anything, and faking timers wholesale would put
+   * the promise machinery under the same control for no reason.
+   */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+  /** NOW minus the tool's 24-hour default window. */
+  const WINDOW_START = NOW - 24 * 60 * 60 * 1000; // 2023-11-13T22:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * A job as `core.get_jobs` reports one, started ten minutes ago and finished
+   * five.
+   *
+   * `arguments`, `result`, `logs_excerpt`, `logs_path`, `exc_info` and
+   * `credentials` are here to be dropped, and the secrets among them are real
+   * strings for the same reason the cloud sync credential carries a key: the
+   * test that no secret survives is only worth anything if one was there to
+   * survive. `transient` and `abortable` are fields of the real payload the
+   * tool does not name.
+   */
+  const job = (over: Record<string, unknown> = {}) => ({
+    id: 412,
+    method: 'pool.scrub.run',
+    state: 'SUCCESS',
+    progress: { percent: 100, description: 'Scrubbing tank', extra: { pool: 'tank' } },
+    time_started: { $date: NOW - 600_000 },
+    time_finished: { $date: NOW - 300_000 },
+    error: null,
+    arguments: ['tank', { password: 'SECRET-ARGUMENT-MATERIAL' }],
+    result: { detail: 'SECRET-RESULT-MATERIAL' },
+    logs_path: '/var/log/jobs/412.log',
+    logs_excerpt: 'SECRET-LOG-MATERIAL',
+    exc_info: null,
+    credentials: { type: 'API_KEY', data: { key: 'SECRET-CREDENTIAL-MATERIAL' } },
+    transient: false,
+    abortable: true,
+    ...over,
+  });
+
+  const listed = async (
+    rows: unknown[],
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['core.get_jobs']: rows });
+    return (await tasksRecentRuns.handler(ctx, args)) as Record<string, unknown>[];
+  };
+
+  /** One job, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([job(over)]))[0];
+
+  /** The states a job reaches, grouped as `failed_only` reads them. */
+  const SUCCEEDED = ['SUCCESS', 'FINISHED'];
+  const UNDER_WAY = ['RUNNING', 'WAITING', 'PENDING', 'HOLD', 'LOCKED'];
+  const FAILED = ['FAILED', 'ERROR', 'ABORTED'];
+
+  it('maps a job to its method, state, progress, times and error', async () => {
+    expect(await listed([job()])).toEqual([
+      {
+        id: 412,
+        method: 'pool.scrub.run',
+        state: 'SUCCESS',
+        progress_percent: 100,
+        progress_description: 'Scrubbing tank',
+        started_at: '2023-11-14T22:03:20.000Z',
+        finished_at: '2023-11-14T22:08:20.000Z',
+        error: null,
+      },
+    ]);
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const rows = await listed([
+      job({
+        future_field: 'added by a later TrueNAS release',
+        progress: { percent: 100, description: 'Scrubbing tank', future_progress_field: 'x' },
+      }),
+    ]);
+    expect(Object.keys(rows[0])).toEqual([
+      'id',
+      'method',
+      'state',
+      'progress_percent',
+      'progress_description',
+      'started_at',
+      'finished_at',
+      'error',
+    ]);
+  });
+
+  it('never lets a job’s arguments, result, credentials or logs out', async () => {
+    const serialized = JSON.stringify(await listed([job()]));
+    for (const secret of [
+      'SECRET-ARGUMENT-MATERIAL',
+      'SECRET-RESULT-MATERIAL',
+      'SECRET-LOG-MATERIAL',
+      'SECRET-CREDENTIAL-MATERIAL',
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+    for (const field of ['arguments', 'result', 'credentials', 'logs_excerpt', 'logs_path']) {
+      expect(serialized).not.toContain(field);
+    }
+  });
+
+  it('asks for every job, naming the fields it reports and no others', async () => {
+    const { ctx, query } = fakeSystem({ ['core.get_jobs']: [job()] });
+    await tasksRecentRuns.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('core.get_jobs', [], {
+      select: ['id', 'method', 'state', 'progress', 'time_started', 'time_finished', 'error'],
+    });
+  });
+
+  it('returns [] for a system holding no jobs', async () => {
+    expect(await listed([])).toEqual([]);
+  });
+
+  it('reports the last 24 hours when nothing is asked for', async () => {
+    const rows = await listed([
+      job({ id: 1, time_started: { $date: WINDOW_START } }),
+      job({ id: 2, time_started: { $date: WINDOW_START - 1 } }),
+      job({ id: 3, time_started: { $date: NOW } }),
+    ]);
+    // Inclusive at the bound: a job started exactly 24 hours ago is in.
+    expect(rows.map((row) => row['id'])).toEqual([1, 3]);
+  });
+
+  it('keeps a job whose start time it cannot read, under any window', async () => {
+    for (const unreadable of [undefined, null, '2023-11-14T22:03:20Z', { $date: 'x' }]) {
+      // Nothing places it outside the window, and a failure that vanishes
+      // because its timestamp was unreadable is the outcome worth avoiding.
+      const rows = await listed([job({ time_started: unreadable })], { since: '2023-11-14' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]['started_at']).toBeNull();
+    }
+  });
+
+  it('bounds the result at a `since` the caller names', async () => {
+    const rows = await listed(
+      [
+        job({ id: 1, time_started: { $date: Date.parse('2023-11-01T00:00:00Z') } }),
+        job({ id: 2, time_started: { $date: Date.parse('2023-11-10T00:00:00Z') } }),
+      ],
+      { since: '2023-11-05T00:00:00Z' },
+    );
+    expect(rows.map((row) => row['id'])).toEqual([2]);
+  });
+
+  it('accepts a bare date, an offset and a fractional second', async () => {
+    // Every accepted form names one instant unambiguously; a bare date is UTC
+    // midnight, which ECMAScript defines rather than leaves to the host.
+    for (const since of [
+      '2023-11-10',
+      '2023-11-10T00:00Z',
+      '2023-11-10T00:00:00Z',
+      '2023-11-10T00:00:00.000Z',
+      '2023-11-09T19:00:00-05:00',
+    ]) {
+      const rows = await listed(
+        [
+          job({ id: 1, time_started: { $date: Date.parse('2023-11-09T00:00:00Z') } }),
+          job({ id: 2, time_started: { $date: Date.parse('2023-11-11T00:00:00Z') } }),
+        ],
+        { since },
+      );
+      expect(rows.map((row) => row['id'])).toEqual([2]);
+    }
+  });
+
+  it('refuses a `since` it cannot read rather than falling back to the default', async () => {
+    // Ignoring it would answer about the last day while the caller believes it
+    // answered about the last month, and an empty result would then read as
+    // "nothing failed".
+    for (const since of [
+      '',
+      'yesterday',
+      42,
+      true,
+      // No zone: Node reads this as local time, so the window would move by
+      // the offset of whatever machine happens to run it.
+      '2023-11-10 00:00:00',
+      '2023-11-10T00:00:00',
+      '2023-11-10T00:00:00+0500',
+    ]) {
+      await expect(listed([job()], { since })).rejects.toThrow('"since" must be an ISO 8601');
+    }
+    // The right shape and not a real date. The last three are the ones
+    // `Date.parse` does not catch: a day the month does not have rolls over
+    // into the next month and answers a real instant, so `2023-02-30` would
+    // otherwise bound the report at the 2nd of March without saying so.
+    for (const since of [
+      '2023-13-01',
+      '2023-11-10T25:00:00Z',
+      '2023-11-10T00:00:00+25:00',
+      '2023-02-30',
+      '2023-11-31',
+      '2023-02-29',
+    ]) {
+      await expect(listed([job()], { since })).rejects.toThrow('is not a real date');
+    }
+    // A leap day that exists is not caught with them — the check knows which
+    // Februaries have a 29th rather than that none does.
+    expect(await listed([job()], { since: '2020-02-29' })).toHaveLength(1);
+  });
+
+  it('treats an absent `since` as the default, and null as absent', async () => {
+    for (const since of [undefined, null]) {
+      const rows = await listed([job({ time_started: { $date: WINDOW_START - 1 } })], { since });
+      expect(rows).toEqual([]);
+    }
+  });
+
+  it('keeps every job when `failed_only` is not asked for', async () => {
+    for (const state of [...SUCCEEDED, ...UNDER_WAY, ...FAILED]) {
+      expect(await listed([job({ state })])).toHaveLength(1);
+      expect(await listed([job({ state })], { failed_only: false })).toHaveLength(1);
+    }
+  });
+
+  it('keeps only what has not succeeded when `failed_only` is set', async () => {
+    for (const state of [...FAILED, 'A_LATER_RELEASE_STATE', '']) {
+      // An unfamiliar state survives the filter: written as what to exclude,
+      // so a failure state a later release adds is never silently dropped.
+      expect(await listed([job({ state })], { failed_only: true })).toHaveLength(1);
+    }
+    for (const state of [...SUCCEEDED, ...UNDER_WAY]) {
+      expect(await listed([job({ state })], { failed_only: true })).toEqual([]);
+    }
+  });
+
+  it('refuses a `failed_only` that is not a boolean', async () => {
+    // Coercing would answer a different question — every job the system ran,
+    // where the caller asked what went wrong.
+    for (const failed_only of ['true', 'false', 0, 1, '']) {
+      await expect(listed([job()], { failed_only })).rejects.toThrow(
+        '"failed_only" must be a boolean',
+      );
+    }
+    // Absent is absent, and the default is false.
+    for (const failed_only of [undefined, null]) {
+      expect(await listed([job({ state: 'SUCCESS' })], { failed_only })).toHaveLength(1);
+    }
+  });
+
+  it('passes a state through as the system spelled it, and an unreadable one as null', async () => {
+    for (const state of [...SUCCEEDED, ...UNDER_WAY, ...FAILED, 'A_LATER_RELEASE_STATE']) {
+      expect((await one({ state }))['state']).toBe(state);
+    }
+    expect((await one({ state: '' }))['state']).toBeNull();
+  });
+
+  it('reports a finish time only for a run that ended', async () => {
+    for (const state of [...SUCCEEDED, ...FAILED]) {
+      expect((await one({ state }))['finished_at']).toBe('2023-11-14T22:08:20.000Z');
+    }
+    // A job still going has not ended, so the time in its record is not a
+    // finish time — and a state this tool could not read has not been shown to
+    // be one either.
+    for (const state of [...UNDER_WAY, '']) {
+      expect((await one({ state }))['finished_at']).toBeNull();
+    }
+  });
+
+  it('reports a progress it cannot read as null, and a null percent is not zero', async () => {
+    expect((await one({ progress: { percent: 0, description: 'Starting' } }))[
+      'progress_percent'
+    ]).toBe(0);
+    for (const unreadable of [undefined, null, 42, 'Scrubbing', {}, { percent: '50' }]) {
+      const row = await one({ progress: unreadable });
+      expect(row['progress_percent']).toBeNull();
+      expect(row['progress_description']).toBeNull();
+    }
+    for (const percent of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect((await one({ progress: { percent } }))['progress_percent']).toBeNull();
+    }
+    for (const description of [undefined, null, '', 42]) {
+      expect((await one({ progress: { percent: 10, description } }))[
+        'progress_description'
+      ]).toBeNull();
+    }
+  });
+
+  it('carries the reason a job failed, and reports no reason as null', async () => {
+    expect((await one({ state: 'FAILED', error: 'pool is unavailable' }))['error']).toBe(
+      'pool is unavailable',
+    );
+    // A job in FAILED with a null error failed for a reason the system did not
+    // record; it has not succeeded.
+    for (const unreadable of [undefined, null, '', 42]) {
+      expect((await one({ state: 'FAILED', error: unreadable }))['error']).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
Adds `tasks_recent_runs`, a read-only tool over `core.get_jobs`.

Every long-running operation on TrueNAS is a job, so one call answers "what has this system been doing, and what went wrong" across scrubs, replication, cloud sync, app upgrades and updates at once. The per-family tools in this file each answer only for their own kind of task, and none of them answers for a job nothing on the board started.

Fixes #23

## What it reports

`id`, `method`, `state`, `progress_percent`, `progress_description`, `started_at`, `finished_at`, `error` — named field by field, so nothing a later TrueNAS release adds to a job row reaches a caller without a change here.

## The three decisions worth reviewing

**Secrets.** A job row is the largest payload in this catalog and the most dangerous: it carries the full arguments the job was called with, its whole result, its credentials, and an excerpt of its logs. None of them is reported. `arguments` and `credentials` are refused on the catalog's own rule that secrets do not pass through tools — a job that mounts a share or authenticates to a remote was called with the password — and `result`, `logs_excerpt` and `exc_info` are refused for size, being unbounded and per-job. The query also names the reported fields in `select`, so on a middleware that applies it none of them is fetched at all; that is defence in depth, and the field-by-field mapping is what actually guarantees it, since an unrecognised query option is dropped rather than refused.

**`failed_only` is written as what it EXCLUDES** — the two success states and the five still-under-way states — rather than as the failures it keeps. A failure state a later TrueNAS release adds is then in neither set and survives the filter. Listing the failures instead would go quiet about exactly the runs nobody here has heard of yet, which is the one mistake that matters in a tool whose job is to surface failures. A state that could not be read counts as not-succeeded for the same reason.

**`since` is strict, and an unreadable one is an error rather than a fall back to the default window.** Ignoring it would answer about the last day while the caller believed it answered about the last month, and the empty result would then read as "nothing failed" rather than as "the bound was not applied". A timezone is required because `Date.parse` of an unzoned time is implementation-defined and Node reads it as local, which would move the window by the offset of whatever machine ran it.

`Date.parse` does not settle the date either, which is the one thing here that needed measuring rather than assuming: a day the month does not have **rolls over and answers a real instant**, so `2026-02-30` parses as the 2nd of March. A caller that mistyped a bound would have been handed a window starting two days after the one it named, with every job in the gap missing from an answer that looked complete. The components are rebuilt and compared back to catch it — which needs no table of month lengths to know February has no 30th and that some Februaries have a 29th. Out-of-range months, hours and offsets are `NaN` from `Date.parse` and were already caught.

A job whose start time cannot be read is returned under any window: nothing places it outside one, and a failure that disappears because its timestamp was unreadable is the failure mode worth avoiding here.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass locally. `src/tools/tasks.ts` is at 100% statements, branches, functions and lines; the global figures are 98.8 statements and 98.59 branches, against floors of 97 and 96.

## About the local review

**The shared review could not run here** — it exceeded its 420s cap and was stopped, so `local-review.py` exited 2 and wrote a brief instead. What ran was the same rubric, prompt and schema applied by a subagent in a separate context, which is **weaker evidence than the required check** and is stated here rather than implied. It returned five findings, all LOW, none blocking.

## What I did not change, and why

Per the local review loop, a round returning nothing at MEDIUM or above ends the work; the LOWs below are recorded rather than fixed, because every fix is a new diff and a new diff is a new round. They are all worth a reader's attention and several would make good follow-up tickets.

- **`error` is passed through verbatim**, against a description sentence that says no secret passes through this tool. `cloudsync_tasks_list` already does this, so the pattern is pre-existing — but that tool reads the job of one cloud sync task, where this one reads the job table of the whole system, including methods whose arguments are secrets. No concrete middleware error string embedding a credential could be named, which is why it is LOW. Closing it would mean either bounding `error` in length or naming `error` in that sentence as the one field whose text originates with the failing method.
- **The window filters on `time_started` only**, so a job still `RUNNING` that started before the window is absent from the default result — arguably the most interesting row for the question the tool opens with. It does what its description says, which is why it is LOW. Keeping any job not in an ended state regardless of the window would be one condition on the same line, and would match the fail-safe direction the rest of the file takes.
- **`core.get_jobs` is fetched unbounded** — no `limit`, no `order_by`, and `since` is applied in this process rather than pushed into the query, so `select` narrows each row but not the row count. Two things make that defensible: `time_started` arrives as `{"$date": …}`, so a server-side comparison on it is not obviously sound against an unverified middleware, and filtering here is what makes "keep a job whose start time is unreadable" possible at all. `order_by: ['-id']` with a generous `limit` would bound the payload without touching the semantics.
- **The three state sets are hand-copied from the client's `JobState` enum** and the test re-declares its own copy, so the two drift together rather than one pinning the other. The drift direction is the safe one this file deliberately chose — over-report rather than hide — which is why it is LOW. One assertion comparing the union of the three against `Object.values(JobState)` would turn a silent widening into a failing test.
- **`"since" is not a real date`** is also the message for an out-of-range hour, second or offset, where the date is real and the time is not. The spec asserts that same message for those inputs, so the wording and the test would move together.
