### PR TITLE
feat(tools): add shares_list, SMB and NFS shares in one list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
-  `tasks_recent_runs`.
+  `tasks_recent_runs`, `shares_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,5 +74,6 @@ export {
   snapshotTasksList,
   cloudsyncTasksList,
   tasksRecentRuns,
+  sharesList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,12 +4,13 @@ import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
+import { sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: fourteen read-only tools plus one mutating tool. */
+/** The sketch's catalog: fifteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -26,6 +27,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(snapshotTasksList);
   catalog.register(cloudsyncTasksList);
   catalog.register(tasksRecentRuns);
+  catalog.register(sharesList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -42,6 +44,7 @@ export {
   quotaReport,
   replicationStatus,
   scrubHistory,
+  sharesList,
   snapshotsList,
   snapshotTasksList,
   systemInfo,

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -1,0 +1,198 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+
+/**
+ * Shares family: what the system offers to the network, and where from.
+ *
+ * SMB and NFS are two independent middleware namespaces — `sharing.smb.query`
+ * and `sharing.nfs.query` — and nothing in either mentions the other. A person
+ * asking what a NAS shares is not asking a question about protocols, though, so
+ * the two are read together and merged into one list with a `protocol` field on
+ * each entry. iSCSI and NVMe-oF are deliberately not here: they export block
+ * devices rather than filesystem paths, and their vocabulary of targets,
+ * extents and namespaces answers a different question.
+ */
+
+/** The protocols this tool reads. */
+type Protocol = 'SMB' | 'NFS';
+
+/**
+ * One share, however it is shared. Every field is named explicitly rather than
+ * spread from the row, so a field a later TrueNAS release adds to either
+ * namespace does not reach the caller without a change here.
+ */
+interface Share {
+  protocol: Protocol;
+  id: number;
+  name: string | null;
+  path: string | null;
+  enabled: boolean | null;
+  comment: string | null;
+}
+
+/**
+ * One protocol whose shares could not be listed, and why.
+ *
+ * The point of reporting rather than throwing is that the two queries fail
+ * independently: an SMB service that is not running says nothing about the NFS
+ * exports, and losing those as well would answer half a question as none.
+ */
+interface Failure {
+  protocol: Protocol;
+  error: string;
+}
+
+/** One protocol's shares, or the failure that stopped them being read. */
+interface Attempt {
+  shares: Share[];
+  failure: Failure | null;
+}
+
+/**
+ * One string field of a share row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters: a
+ * share with no comment is what the middleware sends `""` for, and passing that
+ * through would put a field in the result that says nothing.
+ *
+ * `tasks.ts` has the same reading of a string field under another name, and
+ * this restates rather than shares it for the reason that file gives for
+ * restating its own guards: a tool file is read on its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * Why a protocol's query failed, in words, for the caller to act on.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and anything else
+ * becomes a stated absence rather than `"[object Object]"`. Never empty: a
+ * failure with no text still has to read as a failure.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? 'the system reported no reason';
+  return textOrNull(reason) ?? 'the system reported no reason';
+}
+
+/** Every SMB share the system holds. */
+async function smbShares(system: SystemHandle): Promise<Share[]> {
+  // No filters and no options: a system holds tens of shares at most, and every
+  // field this tool reads is part of a share row as it stands. No `select`
+  // either — unlike a job row, a share row carries no credential and nothing
+  // unbounded, and the mapping below is what decides what a caller sees.
+  const shares = await firstValueFrom(system.client.api.query('sharing.smb.query'));
+  return shares.map((share) => ({
+    protocol: 'SMB' as const,
+    id: share.id,
+    name: textOrNull(share.name),
+    // `EXTERNAL` is passed through as the system spelled it: an external share
+    // is a redirection to another server rather than a path on this one, and
+    // reporting null there would read as a path that could not be found.
+    path: textOrNull(share.path),
+    // Optional on the client's own type, so a middleware that omits it reports
+    // null rather than a default. Not defaulted either way: a share whose
+    // switch cannot be read must not be presented as definitely on or off.
+    enabled: share.enabled ?? null,
+    comment: textOrNull(share.comment),
+  }));
+}
+
+/** Every NFS export the system holds. */
+async function nfsShares(system: SystemHandle): Promise<Share[]> {
+  const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
+  return shares.map((share) => ({
+    protocol: 'NFS' as const,
+    id: share.id,
+    // An NFS export has no name. The middleware identifies one by the path it
+    // exports and carries no name field at all, so this is null on every NFS
+    // share — a fact about the protocol rather than about this system. Not the
+    // path repeated under a second key, which would read as a name somebody
+    // chose.
+    name: null,
+    path: textOrNull(share.path),
+    enabled: share.enabled ?? null,
+    comment: textOrNull(share.comment),
+  }));
+}
+
+/**
+ * One protocol's shares, with a failure caught and named rather than thrown.
+ *
+ * The read is passed as a thunk so that a synchronous throw out of the client
+ * is caught here too, and not only a rejected promise.
+ */
+async function attempt(protocol: Protocol, read: () => Promise<Share[]>): Promise<Attempt> {
+  try {
+    return { shares: await read(), failure: null };
+  } catch (reason) {
+    return { shares: [], failure: { protocol, error: errorText(reason) } };
+  }
+}
+
+export const sharesList: ReadOnlyTool = {
+  name: 'shares_list',
+  description:
+    'Every SMB and NFS share on the system, in one list. `protocol` is `SMB` ' +
+    'or `NFS` and says which of the two the share is served by; the two are ' +
+    'separate configurations in TrueNAS and a path can be shared over both at ' +
+    'once, appearing here once per protocol. `id` is the share\'s numeric ' +
+    'identity WITHIN ITS PROTOCOL — an SMB share and an NFS export can carry ' +
+    'the same id, so a share is identified by `protocol` and `id` together. ' +
+    '`name` is the SMB share name, the name clients connect to. It is ALWAYS ' +
+    'null on an NFS export: NFS identifies an export by the path it exports ' +
+    'and the system holds no name for one, so a null there is a fact about the ' +
+    'protocol rather than a share nobody named. `path` is the filesystem path ' +
+    'being shared, which matches `mountpoint` in `storage_list_datasets` where ' +
+    'the share is of a dataset. On an SMB share it can instead be the literal ' +
+    '`EXTERNAL`, which is a share that redirects clients to another server ' +
+    'rather than serving a path on this one. It is null only where the system ' +
+    'reported no path at all. `enabled` is whether the share is switched on. A ' +
+    'disabled share is LISTED and reported `enabled: false` rather than ' +
+    'omitted, because a share nobody switched back on is exactly the one worth ' +
+    'finding; null is a switch the system reported no value for, which is not ' +
+    'the same answer as false. `comment` is the description the share was ' +
+    'given and is null where it has none. `failures` reports a protocol whose ' +
+    'query failed, as `protocol` and `error`. It is empty when both were read. ' +
+    'WHILE IT IS NOT EMPTY THE LIST IS INCOMPLETE: every share of the protocol ' +
+    'named there is missing, and a share not appearing is not evidence that it ' +
+    'does not exist. One protocol failing does not hide the other, which is ' +
+    'why the failure is reported here instead of being raised — but if neither ' +
+    'could be read this tool raises an error rather than answering with an ' +
+    'empty list. This tool says what is shared and from where, not who may ' +
+    'reach it: the SMB share ACL and the NFS host and network restrictions are ' +
+    'not among these fields. iSCSI targets and NVMe-oF subsystems are not ' +
+    'shares in this sense and are not listed.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both queries are issued before either is awaited, so the second is not
+    // waiting on the first, and neither can take the other down.
+    const attempts = await Promise.all([
+      attempt('SMB', () => smbShares(system)),
+      attempt('NFS', () => nfsShares(system)),
+    ]);
+    const shares: Share[] = [];
+    const failures: Failure[] = [];
+    for (const attempted of attempts) {
+      shares.push(...attempted.shares);
+      if (attempted.failure !== null) failures.push(attempted.failure);
+    }
+    // Nothing was read, so there is no partial answer to preserve. An empty
+    // `shares` beside a `failures` a caller did not check reads as a system
+    // that shares nothing, which is the one wrong answer here that a model
+    // would repeat as fact — and every other tool in this catalog raises when
+    // its own query fails.
+    if (failures.length === attempts.length) {
+      throw new Error(
+        `no share could be listed: ${failures
+          .map((failure) => `${failure.protocol}: ${failure.error}`)
+          .join('; ')}`,
+      );
+    }
+    return { shares, failures };
+  },
+};

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -121,8 +121,10 @@ async function nfsShares(system: SystemHandle): Promise<Share[]> {
 /**
  * One protocol's shares, with a failure caught and named rather than thrown.
  *
- * The read is passed as a thunk so that a synchronous throw out of the client
- * is caught here too, and not only a rejected promise.
+ * The read is passed as a thunk so that the call is made inside the `try`,
+ * which keeps this correct for a read that throws before it returns a promise
+ * at all. Neither caller can: both are `async`, so a throw anywhere inside them
+ * arrives as a rejection.
  */
 async function attempt(protocol: Protocol, read: () => Promise<Share[]>): Promise<Attempt> {
   try {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { Role } from '@/interfaces';
 import {
@@ -15,6 +15,7 @@ import {
   quotaReport,
   replicationStatus,
   scrubHistory,
+  sharesList,
   snapshotsList,
   snapshotTasksList,
   tasksRecentRuns,
@@ -39,7 +40,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifteen sketch tools', () => {
+  it('registers the sixteen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -55,6 +56,7 @@ describe('createDefaultCatalog', () => {
       'snapshot_tasks_list',
       'cloudsync_tasks_list',
       'tasks_recent_runs',
+      'shares_list',
       'snapshots_create',
     ]);
   });
@@ -117,6 +119,10 @@ describe('createDefaultCatalog', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'tasks_recent_runs',
     );
+  });
+
+  it('advertises shares_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('shares_list');
   });
 });
 
@@ -2612,5 +2618,228 @@ describe('tasks_recent_runs', () => {
     for (const unreadable of [undefined, null, '', 42]) {
       expect((await one({ state: 'FAILED', error: unreadable }))['error']).toBeNull();
     }
+  });
+});
+
+describe('shares_list', () => {
+  /**
+   * A SystemHandle whose two share queries answer independently, either with
+   * rows or by failing. `fakeSystem` answers every method from one canned map
+   * and has no way to make a call fail, which is what half of these tests are
+   * about.
+   *
+   * A failure is a second map rather than a sentinel value in the first, so a
+   * test can say what the query rejected WITH — including a rejection that is
+   * not an `Error` at all, which a sentinel could not tell from a response.
+   */
+  const fakeShares = (
+    rows: Partial<Record<string, unknown>>,
+    failures: Partial<Record<string, unknown>> = {},
+  ): { ctx: ToolContext; query: ReturnType<typeof vi.fn> } => {
+    const query = vi.fn((method: string) =>
+      method in failures ? throwError(() => failures[method]) : of(rows[method]),
+    );
+    const system = { name: 'nas', client: { api: { query } } } as unknown as SystemHandle;
+    return { ctx: { system }, query };
+  };
+
+  /**
+   * An SMB share as `sharing.smb.query` reports one. `options`, `audit`,
+   * `purpose` and `locked` are real fields of the payload that this tool does
+   * not name, and are here to be dropped.
+   */
+  const smb = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    name: 'media',
+    path: '/mnt/tank/media',
+    enabled: true,
+    comment: 'Films and music',
+    purpose: 'DEFAULT_SHARE',
+    locked: false,
+    browsable: true,
+    audit: { enable: false },
+    options: { aapl_name_mangling: false },
+    ...over,
+  });
+
+  /**
+   * An NFS export as `sharing.nfs.query` reports one. `hosts`, `networks`,
+   * `security` and `maproot_user` are fields the tool does not name — who may
+   * reach the export is `share_access`, not this tool.
+   */
+  const nfs = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    path: '/mnt/tank/backups',
+    enabled: true,
+    comment: 'Nightly backups',
+    hosts: ['10.0.0.5'],
+    networks: ['10.0.0.0/24'],
+    security: ['SYS'],
+    maproot_user: 'root',
+    locked: null,
+    ...over,
+  });
+
+  const listed = async (
+    rows: Partial<Record<string, unknown>>,
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<{ shares: Record<string, unknown>[]; failures: Record<string, unknown>[] }> => {
+    const { ctx } = fakeShares(rows, failures);
+    return (await sharesList.handler(ctx, {})) as {
+      shares: Record<string, unknown>[];
+      failures: Record<string, unknown>[];
+    };
+  };
+
+  /** Both protocols answering, with only the fields a case is about differing. */
+  const both = async (
+    smbOver: Record<string, unknown> = {},
+    nfsOver: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>[]> =>
+    (
+      await listed({
+        ['sharing.smb.query']: [smb(smbOver)],
+        ['sharing.nfs.query']: [nfs(nfsOver)],
+      })
+    ).shares;
+
+  it('merges SMB and NFS into one list, each tagged with its protocol', async () => {
+    expect(
+      await listed({
+        ['sharing.smb.query']: [smb()],
+        ['sharing.nfs.query']: [nfs()],
+      }),
+    ).toEqual({
+      shares: [
+        {
+          protocol: 'SMB',
+          id: 3,
+          name: 'media',
+          path: '/mnt/tank/media',
+          enabled: true,
+          comment: 'Films and music',
+        },
+        {
+          protocol: 'NFS',
+          id: 3,
+          // NFS identifies an export by its path and holds no name for one.
+          name: null,
+          path: '/mnt/tank/backups',
+          enabled: true,
+          comment: 'Nightly backups',
+        },
+      ],
+      failures: [],
+    });
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const shares = await both(
+      { future_field: 'added by a later TrueNAS release' },
+      { future_field: 'added by a later TrueNAS release' },
+    );
+    for (const share of shares) {
+      expect(Object.keys(share)).toEqual([
+        'protocol',
+        'id',
+        'name',
+        'path',
+        'enabled',
+        'comment',
+      ]);
+    }
+  });
+
+  it('asks each protocol for every share', async () => {
+    const { ctx, query } = fakeShares({
+      ['sharing.smb.query']: [smb()],
+      ['sharing.nfs.query']: [nfs()],
+    });
+    await sharesList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('sharing.smb.query');
+    expect(query).toHaveBeenCalledWith('sharing.nfs.query');
+  });
+
+  it('returns an empty list for a system sharing nothing', async () => {
+    expect(await listed({ ['sharing.smb.query']: [], ['sharing.nfs.query']: [] })).toEqual({
+      shares: [],
+      failures: [],
+    });
+  });
+
+  it('returns a disabled share, marked disabled, rather than omitting it', async () => {
+    // A share nobody switched back on is exactly the one worth finding.
+    const shares = await both({ enabled: false }, { enabled: false });
+    expect(shares.map((share) => share['enabled'])).toEqual([false, false]);
+  });
+
+  it('reports a switch it could not read as null, which is not false', async () => {
+    for (const unreadable of [undefined, null]) {
+      const shares = await both({ enabled: unreadable }, { enabled: unreadable });
+      expect(shares.map((share) => share['enabled'])).toEqual([null, null]);
+    }
+  });
+
+  it('passes an SMB EXTERNAL share through as the system spelled it', async () => {
+    // Not a path on this system, and not a path that could not be found.
+    expect((await both({ path: 'EXTERNAL' }))[0]['path']).toBe('EXTERNAL');
+  });
+
+  it('reports a name, path or comment the system did not give as null', async () => {
+    for (const absent of [undefined, null, '', 42]) {
+      const shares = await both(
+        { name: absent, path: absent, comment: absent },
+        { path: absent, comment: absent },
+      );
+      expect(shares.map((share) => share['name'])).toEqual([null, null]);
+      expect(shares.map((share) => share['path'])).toEqual([null, null]);
+      expect(shares.map((share) => share['comment'])).toEqual([null, null]);
+    }
+  });
+
+  it('keeps one protocol’s shares when the other’s query fails', async () => {
+    const smbOnly = await listed(
+      { ['sharing.smb.query']: [smb()] },
+      { ['sharing.nfs.query']: new Error('nfs service is not running') },
+    );
+    expect(smbOnly.shares.map((share) => share['protocol'])).toEqual(['SMB']);
+    expect(smbOnly.failures).toEqual([{ protocol: 'NFS', error: 'nfs service is not running' }]);
+
+    const nfsOnly = await listed(
+      { ['sharing.nfs.query']: [nfs()] },
+      { ['sharing.smb.query']: new Error('smb service is not running') },
+    );
+    expect(nfsOnly.shares.map((share) => share['protocol'])).toEqual(['NFS']);
+    expect(nfsOnly.failures).toEqual([{ protocol: 'SMB', error: 'smb service is not running' }]);
+  });
+
+  it('names a failure that arrived as neither an Error nor any text', async () => {
+    for (const [reason, text] of [
+      ['nfs is down', 'nfs is down'],
+      [new Error(''), 'the system reported no reason'],
+      [{ code: 500 }, 'the system reported no reason'],
+      [undefined, 'the system reported no reason'],
+    ] as const) {
+      const result = await listed(
+        { ['sharing.smb.query']: [smb()] },
+        { ['sharing.nfs.query']: reason },
+      );
+      expect(result.failures).toEqual([{ protocol: 'NFS', error: text }]);
+    }
+  });
+
+  it('raises rather than answering with an empty list when neither could be read', async () => {
+    // An empty `shares` beside a `failures` nobody checked reads as a system
+    // that shares nothing, which is the one wrong answer that gets repeated.
+    const { ctx } = fakeShares(
+      {},
+      {
+        ['sharing.smb.query']: new Error('smb is down'),
+        ['sharing.nfs.query']: new Error('nfs is down'),
+      },
+    );
+    await expect(sharesList.handler(ctx, {})).rejects.toThrow(
+      'no share could be listed: SMB: smb is down; NFS: nfs is down',
+    );
   });
 });


### PR DESCRIPTION
Adds `shares_list`, a read-only tool returning every SMB and NFS share in one list with its protocol, name, path, enabled state and comment.

Fixes #24

## What it does

`sharing.smb.query` and `sharing.nfs.query` are two independent middleware namespaces and neither mentions the other. Someone asking what a NAS shares is not asking a question about protocols, so both are read and merged into one list, each entry tagged `protocol: "SMB" | "NFS"`. iSCSI and NVMe-oF stay out: they export block devices rather than filesystem paths, and their vocabulary answers a different question (#26, #27).

Every field is named explicitly rather than spread from the row, so a field a later TrueNAS release adds to either namespace cannot reach the caller without a change here. A test asserts the exact key list.

## The ticket's unconfirmed note, resolved

The ticket said, twice and marked unconfirmed, that `sharing.smb.query` and `sharing.nfs.query` are **not** in the pinned client's endpoint enum.

**They are both in the API directory the tools are written against.** `ApiSurface` is `DefaultApiDirectory`, which the pinned client aliases to `ApiDirectory$7` — v25.10.0, the oldest supported — and `ApiCallDirectory$7` declares both methods with typed entities (`SharingSMBEntry$2`, `SharingNFSEntry$1`) and an `entity` key, which is what makes them reachable through `api.query`. No cast or widening was needed and `yarn typecheck` passes against the pinned types.

## Two decisions worth reading

**`name` is always null on an NFS export.** `SharingNFSEntry` carries no name field at all — NFS identifies an export by the path it exports. Null rather than the path repeated under a second key, which would read as a name somebody chose. The tool description states this as a fact about the protocol rather than a share nobody named.

**A protocol that fails is reported, not raised — unless both fail.** The result is `{ shares, failures }`. Each query is attempted independently, so an SMB service that is not running does not cost the NFS exports as well; the failure lands in `failures` as `{ protocol, error }` and the description says in terms that while it is non-empty the list is incomplete.

When *neither* could be read the tool raises instead. The ticket specifies the one-fails case and is silent on this one; raising is the choice here because there is no partial answer left to preserve, an empty `shares` beside a `failures` the caller did not check reads as a system that shares nothing, and every other tool in this catalog raises when its own single query fails. Say so if you would rather it always answered.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all pass locally — the four steps `ci.yml` gates on. Coverage is 100% on `src/tools/shares.ts` (statements, branches, functions) and the global floors are unmoved at 98.86 / 98.66.

## Review

The shared review ran locally against the full diff and returned **nothing at or above MEDIUM** on its first round — the same reviewer, rubric and threshold as the required check, in a separate process. It raised two LOWs.

**Fixed:** the JSDoc on `attempt` claimed the thunk exists to catch a synchronous throw out of the client. Both callers are `async`, so a throw inside either arrives as a rejection and that case cannot arise. The comment was wrong about its own code, so it is corrected in a separate commit; the executable code is unchanged.

**Not fixed, deliberately:** `locked` is dropped from both share rows though both entity types carry it, so a share on a locked (encrypted, unmounted) dataset reports `enabled: true` while serving nothing. That is a real gap and a fair reading, but the ticket names five fields and adds "every field that survives is a field the LLM pays for on every call", and `enabled` is described here as whether the share is switched on rather than whether it is reachable — which is accurate as written. Whether a share is actually serving is closer to #25 (`share_access`) than to this ticket, and adding a sixth field on a LOW would be scope the ticket did not ask for. Worth filing as its own ticket if it should be here.
