### PR TITLE
feat(tools): add share_access, who can reach a share and with what rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
-  `tasks_recent_runs`, `shares_list`.
+  `tasks_recent_runs`, `shares_list`, `share_access`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,5 +75,6 @@ export {
   cloudsyncTasksList,
   tasksRecentRuns,
   sharesList,
+  shareAccess,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,13 +4,13 @@ import { appsList } from '@/tools/apps';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
-import { sharesList } from '@/tools/shares';
+import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: fifteen read-only tools plus one mutating tool. */
+/** The sketch's catalog: sixteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -28,6 +28,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(cloudsyncTasksList);
   catalog.register(tasksRecentRuns);
   catalog.register(sharesList);
+  catalog.register(shareAccess);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -44,6 +45,7 @@ export {
   quotaReport,
   replicationStatus,
   scrubHistory,
+  shareAccess,
   sharesList,
   snapshotsList,
   snapshotTasksList,

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -43,9 +43,16 @@ interface Failure {
   error: string;
 }
 
-/** One protocol's shares, or the failure that stopped them being read. */
-interface Attempt {
-  shares: Share[];
+/**
+ * One protocol's rows, or the failure that stopped them being read.
+ *
+ * Generic in the row because `shares_list` and `share_access` read the same two
+ * queries for different fields: the first wants the share as it is presented,
+ * the second wants the NFS restrictions alongside it. The failure half is
+ * identical for both and is what this exists to share.
+ */
+interface Attempt<T> {
+  rows: T[];
   failure: Failure | null;
 }
 
@@ -100,10 +107,16 @@ async function smbShares(system: SystemHandle): Promise<Share[]> {
   }));
 }
 
-/** Every NFS export the system holds. */
-async function nfsShares(system: SystemHandle): Promise<Share[]> {
-  const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
-  return shares.map((share) => ({
+/**
+ * One NFS export as this family presents one.
+ *
+ * Split out of `nfsShares` because `share_access` reads the same rows for their
+ * host restrictions and must present the share half identically — two mappings
+ * of one row would drift, and the drift would show as one tool naming a share
+ * differently from the other.
+ */
+function nfsShare(share: { id: number; path: string; enabled?: boolean; comment?: string }): Share {
+  return {
     protocol: 'NFS' as const,
     id: share.id,
     // An NFS export has no name. The middleware identifies one by the path it
@@ -115,7 +128,13 @@ async function nfsShares(system: SystemHandle): Promise<Share[]> {
     path: textOrNull(share.path),
     enabled: share.enabled ?? null,
     comment: textOrNull(share.comment),
-  }));
+  };
+}
+
+/** Every NFS export the system holds. */
+async function nfsShares(system: SystemHandle): Promise<Share[]> {
+  const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
+  return shares.map(nfsShare);
 }
 
 /**
@@ -126,11 +145,11 @@ async function nfsShares(system: SystemHandle): Promise<Share[]> {
  * at all. Neither caller can: both are `async`, so a throw anywhere inside them
  * arrives as a rejection.
  */
-async function attempt(protocol: Protocol, read: () => Promise<Share[]>): Promise<Attempt> {
+async function attempt<T>(protocol: Protocol, read: () => Promise<T[]>): Promise<Attempt<T>> {
   try {
-    return { shares: await read(), failure: null };
+    return { rows: await read(), failure: null };
   } catch (reason) {
-    return { shares: [], failure: { protocol, error: errorText(reason) } };
+    return { rows: [], failure: { protocol, error: errorText(reason) } };
   }
 }
 
@@ -180,7 +199,7 @@ export const sharesList: ReadOnlyTool = {
     const shares: Share[] = [];
     const failures: Failure[] = [];
     for (const attempted of attempts) {
-      shares.push(...attempted.shares);
+      shares.push(...attempted.rows);
       if (attempted.failure !== null) failures.push(attempted.failure);
     }
     // Nothing was read, so there is no partial answer to preserve. An empty
@@ -196,5 +215,409 @@ export const sharesList: ReadOnlyTool = {
       );
     }
     return { shares, failures };
+  },
+};
+
+/**
+ * Who may reach one share, and with what rights.
+ *
+ * `shares_list` says what is shared and from where. This says who can get at
+ * it, and the answer is in two different places depending on the protocol —
+ * neither of them the share record on its own:
+ *
+ *     SMB   the filesystem ACL on the shared path, which is what decides what
+ *           each user may do once a client has connected
+ *     NFS   the export's own host and network restrictions, which decide which
+ *           MACHINES may mount it at all, and then that same filesystem ACL,
+ *           which decides what the ids arriving over the mount may do
+ *
+ * So the ACL is read for both and the restrictions are read for NFS, and
+ * neither half is presented as the whole answer.
+ */
+
+/** One protocol's shares, with the export restrictions that only NFS carries. */
+interface AccessTarget {
+  share: Share;
+  hosts: string[] | null;
+  networks: string[] | null;
+}
+
+/** Which share the caller asked about. */
+interface Selector {
+  share: string;
+  protocol: Protocol | null;
+}
+
+/** One entry of the ACL on a share's path: a principal, and what it grants. */
+interface AccessEntry {
+  tag: string | null;
+  name: string | null;
+  id: number | null;
+  access: 'ALLOW' | 'DENY' | null;
+  permissions: string[] | null;
+  children_only: boolean | null;
+}
+
+/** The ACL on a share's path, as this tool presents it. */
+interface Acl {
+  type: string | null;
+  trivial: boolean | null;
+  owner_user: string | null;
+  owner_uid: number | null;
+  owner_group: string | null;
+  owner_gid: number | null;
+  entries: AccessEntry[] | null;
+}
+
+/** A finite number as the middleware reported it, or null where it reported none. */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * The numeric id of an ACL entry's principal, or null where the entry names no
+ * principal by id.
+ *
+ * TrueNAS writes `-1` on an entry whose tag IS the principal — `owner@`,
+ * `group@`, `everyone@` — so a negative id is an absent one rather than an
+ * account nobody could resolve. Reporting it verbatim would put a uid in the
+ * result that no user has.
+ */
+function principalId(value: unknown): number | null {
+  const id = numberOrNull(value);
+  return id === null || id < 0 ? null : id;
+}
+
+/**
+ * An NFS export's host or network restriction list.
+ *
+ * An absent list and an empty one are the same answer from the middleware — the
+ * export carries no restriction of that kind — so both map to `[]` rather than
+ * one of them becoming a null that would read as unreadable. Only a value that
+ * is not a list at all is unreadable, and entries that are not text are dropped
+ * because a restriction that cannot be read as a host or a network restricts
+ * nothing this tool can report.
+ */
+function restrictionList(value: unknown): string[] | null {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) return null;
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+/**
+ * The permissions one ACL entry grants, by name, or null where the entry's
+ * permissions could not be read.
+ *
+ * Three shapes reach here and all three are the middleware's own vocabulary
+ * rather than one invented in this file: an NFS4 preset (`{ BASIC:
+ * 'FULL_CONTROL' }`), an NFS4 permission set (`{ READ_DATA: true, … }`), and a
+ * POSIX one (`{ READ: true, WRITE: false, EXECUTE: true }`). The last two are
+ * the same shape, so one pass over the true keys covers both.
+ *
+ * An empty list is an entry that names no permission, which is not the same as
+ * a permission set that could not be read — a caller reviewing access must not
+ * see the second as the first and conclude the entry grants nothing.
+ */
+function permissionNames(perms: unknown): string[] | null {
+  if (perms === null || typeof perms !== 'object') return null;
+  const record = perms as Record<string, unknown>;
+  // A preset names one permission rather than a set of them, and a preset whose
+  // name cannot be read leaves the entry unreadable rather than empty: it is
+  // known to grant something, and what it grants is exactly what was lost.
+  if ('BASIC' in record) {
+    const basic = textOrNull(record['BASIC']);
+    return basic === null ? null : [basic];
+  }
+  return Object.keys(record).filter((name) => record[name] === true);
+}
+
+/**
+ * Whether an entry grants nothing on the path itself and exists only to be
+ * inherited by what is created inside it, or null where that could not be read.
+ *
+ * Both ACL types have this and spell it differently: POSIX marks the entry
+ * `default`, NFS4 sets `INHERIT_ONLY` among its flags. It is reported because
+ * such an entry looks exactly like access to the share and is not — listing its
+ * principal without saying so would answer "who can reach this" with a name
+ * that cannot. An NFS4 preset flag is `INHERIT` or `NOINHERIT`, and neither is
+ * inherit-only, so a preset always reads false.
+ */
+function childrenOnly(ace: Record<string, unknown>): boolean | null {
+  if (typeof ace['default'] === 'boolean') return ace['default'];
+  const flags = ace['flags'];
+  if (flags === null || typeof flags !== 'object') return null;
+  const record = flags as Record<string, unknown>;
+  if ('BASIC' in record) return textOrNull(record['BASIC']) === null ? null : false;
+  return record['INHERIT_ONLY'] === true;
+}
+
+/**
+ * One ACL entry, mapped field by field.
+ *
+ * The row is read as an untyped record rather than through the client's
+ * `NFS4ACE | POSIXACE` union: the two differ in which keys they carry, so every
+ * read of a key one of them lacks would need narrowing that the entry itself is
+ * what decides. An entry that is not an object at all is reported with every
+ * field null rather than dropped — a principal this tool cannot read is still a
+ * principal on the path, and dropping it would answer with a shorter list that
+ * reads as complete.
+ */
+function accessEntry(ace: unknown): AccessEntry {
+  const row = ace !== null && typeof ace === 'object' ? (ace as Record<string, unknown>) : {};
+  const access = row['type'];
+  return {
+    tag: textOrNull(row['tag']),
+    name: textOrNull(row['who']),
+    id: principalId(row['id']),
+    access: access === 'ALLOW' || access === 'DENY' ? access : null,
+    permissions: permissionNames(row['perms']),
+    children_only: childrenOnly(row),
+  };
+}
+
+/** The ACL response, mapped to the fields this tool names. */
+function mapAcl(row: Record<string, unknown>): Acl {
+  const entries = row['acl'];
+  return {
+    type: textOrNull(row['acltype']),
+    trivial: typeof row['trivial'] === 'boolean' ? row['trivial'] : null,
+    owner_user: textOrNull(row['user']),
+    owner_uid: numberOrNull(row['uid']),
+    owner_group: textOrNull(row['group']),
+    owner_gid: numberOrNull(row['gid']),
+    // Null where the system reported no list at all, which is what a path with
+    // ACLs switched off answers. An empty list is an ACL that holds no entry.
+    entries: Array.isArray(entries) ? entries.map(accessEntry) : null,
+  };
+}
+
+/**
+ * The ACL on a share's path, or the reason there is none to report.
+ *
+ * A failure is returned rather than thrown because for an NFS export the host
+ * and network restrictions still answer half the question, and for an SMB share
+ * the share's own identity is still worth returning beside a stated reason. The
+ * one thing that must not happen is an empty entry list standing in for an
+ * unread one.
+ */
+async function readAcl(
+  system: SystemHandle,
+  share: Share,
+): Promise<{ acl: Acl | null; error: string | null }> {
+  if (share.path === null) {
+    return { acl: null, error: 'the system reported no path for this share, so it has no ACL' };
+  }
+  if (share.path === 'EXTERNAL') {
+    return {
+      acl: null,
+      error:
+        'this share redirects clients to another server rather than serving a path on this ' +
+        'system, so the rights it gives are held there and not here',
+    };
+  }
+  try {
+    // `simplified` collapses a permission set the middleware can name as a
+    // preset into that preset, which is the same fact in one word instead of
+    // fourteen booleans; `resolve_ids` is what turns a uid into the name the
+    // result reports, and an id it cannot resolve is left for this tool to
+    // report raw rather than being dropped.
+    const acl = await firstValueFrom(
+      system.client.api.call('filesystem.getacl', [share.path, true, true]),
+    );
+    return { acl: mapAcl(acl as unknown as Record<string, unknown>), error: null };
+  } catch (reason) {
+    return { acl: null, error: errorText(reason) };
+  }
+}
+
+/** Every SMB share, as a target. SMB carries no export restrictions of its own. */
+async function smbTargets(system: SystemHandle): Promise<AccessTarget[]> {
+  const shares = await smbShares(system);
+  return shares.map((share) => ({ share, hosts: null, networks: null }));
+}
+
+/** Every NFS export, as a target, with the restrictions on who may mount it. */
+async function nfsTargets(system: SystemHandle): Promise<AccessTarget[]> {
+  const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
+  return shares.map((share) => ({
+    share: nfsShare(share),
+    hosts: restrictionList(share.hosts),
+    networks: restrictionList(share.networks),
+  }));
+}
+
+/** The caller's arguments, or an error naming what is wrong with them. */
+function parseSelector(args: Record<string, unknown>): Selector {
+  const share = textOrNull(args['share']);
+  if (share === null) {
+    throw new Error(
+      'share is required: the name of an SMB share, or the exported path of an NFS export',
+    );
+  }
+  const protocol = args['protocol'];
+  if (protocol === undefined || protocol === null) return { share, protocol: null };
+  if (protocol !== 'SMB' && protocol !== 'NFS') {
+    throw new Error(`protocol must be "SMB" or "NFS", not ${JSON.stringify(protocol)}`);
+  }
+  return { share, protocol };
+}
+
+/**
+ * Whether one share is the one asked for.
+ *
+ * Name or path, because the two protocols are named differently and a caller
+ * asking about "the backups share" has one string either way: SMB shares carry
+ * a name, and an NFS export has none at all and is identified by what it
+ * exports.
+ */
+function selects(selector: Selector, share: Share): boolean {
+  if (selector.protocol !== null && share.protocol !== selector.protocol) return false;
+  return share.name === selector.share || share.path === selector.share;
+}
+
+/**
+ * Why nothing matched.
+ *
+ * A protocol whose list could not be read is named in the message, because
+ * "there is no such share" and "the share list this would have matched could
+ * not be read" are different answers and only the first is a fact about the
+ * system.
+ */
+function noMatch(selector: Selector, failures: Failure[]): Error {
+  const scope = selector.protocol === null ? '' : ` ${selector.protocol}`;
+  const notFound = `no${scope} share is named "${selector.share}" or exports that path`;
+  if (failures.length === 0) return new Error(notFound);
+  return new Error(
+    `${notFound}, and it may be one that could not be looked up: ${failures
+      .map((failure) => `${failure.protocol}: ${failure.error}`)
+      .join('; ')}`,
+  );
+}
+
+/** Why more than one share matched, and what would narrow it. */
+function ambiguous(selector: Selector, matches: AccessTarget[]): Error {
+  return new Error(
+    `"${selector.share}" matches ${matches.length} shares — ` +
+      `${matches.map((match) => `${match.share.protocol} share ${match.share.id}`).join(', ')}. ` +
+      'Ask again with the protocol argument, or with the SMB share name rather than its path.',
+  );
+}
+
+export const shareAccess: ReadOnlyTool = {
+  name: 'share_access',
+  description:
+    'Who can reach one share, and with what rights. Names the share by its SMB ' +
+    'share name, or — since an NFS export has no name — by the path it ' +
+    'exports; either string is accepted for either protocol, and `protocol` ' +
+    'restricts the search to one of them. A string matching NO share is an ' +
+    'error naming it, never an empty result: a share that does not exist and a ' +
+    'share nobody can reach are opposite answers. A string matching MORE THAN ' +
+    'one share is also an error, listing what it matched — one path can be ' +
+    'shared over both protocols at once and the two grant access differently, ' +
+    'so there is no single answer to give. `protocol`, `id`, `name`, `path` ' +
+    'and `enabled` identify the share and mean exactly what they mean in ' +
+    '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
+    'that a disabled share reaches nobody whatever the rest of this says. ' +
+    '`hosts` and `networks` are the NFS export restrictions: which machines may ' +
+    'mount it at all, by host and by network. THEY ARE EMPTY WHEN THE EXPORT IS ' +
+    'UNRESTRICTED — an empty `hosts` and an empty `networks` together mean any ' +
+    'machine that can reach this server may mount it, which is the opposite of ' +
+    'nobody. Both are null on an SMB share, where the protocol has no such ' +
+    'restriction, and null on an NFS export only where the system reported ' +
+    'something that could not be read as a list; `protocol` tells those two ' +
+    'apart. `acl` is the filesystem ACL on `path`, which is what decides what ' +
+    'each principal may do once connected — over SMB it is the whole answer, ' +
+    'and over NFS it applies to the ids arriving from a machine the ' +
+    'restrictions already let in. EXACTLY ONE of `acl` and `acl_error` is ' +
+    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
+    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
+    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
+    'there `entries` is null and access is governed by the Unix mode bits, ' +
+    'which this tool does not read, so it can say nothing about who has access. ' +
+    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
+    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
+    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
+    'are who the `owner@` and `group@` entries refer to. Each of `entries` is ' +
+    'one principal and what it holds. `tag` is `USER`, `GROUP`, or one of ' +
+    '`owner@`, `group@` and `everyone@`, where the tag IS the principal and ' +
+    '`name` and `id` are both null as a result rather than because nothing ' +
+    'resolved. Otherwise `name` is the resolved account or group name and `id` ' +
+    'is its raw numeric id; an id that resolved to no name is reported as `id` ' +
+    'with a null `name` and IS NEVER DROPPED, so an entry with neither a name ' +
+    'nor an id is one whose principal could not be read at all. `access` is ' +
+    '`ALLOW` or `DENY` on an NFS4 ACL and null on a POSIX one, which has no ' +
+    'deny entries. `permissions` names what the entry grants, in the ACL ' +
+    'type\'s own vocabulary — a single preset such as `FULL_CONTROL` or ' +
+    '`MODIFY`, or individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 ' +
+    'and `READ`, `WRITE` and `EXECUTE` on POSIX. An empty list is an entry that ' +
+    'names no permission; null is one whose permissions could not be read, and ' +
+    'is not evidence that it grants nothing. `children_only` true means the ' +
+    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
+    'created inside it, so its principal does not have the access it appears to ' +
+    'have; null is an entry whose inheritance could not be read. This tool ' +
+    'reads access and changes none of it, and it does not report Unix mode ' +
+    'bits, SMB service-level restrictions, or which users are members of a ' +
+    'group named here.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      share: {
+        type: 'string',
+        description:
+          'The SMB share name, or the exported path, of the share to report on, ' +
+          'e.g. "media" or "/mnt/tank/backups".',
+      },
+      protocol: {
+        type: 'string',
+        enum: ['SMB', 'NFS'],
+        description:
+          'Only consider shares of this protocol. Omitted, both are searched, ' +
+          'and a string matching one of each is an error rather than a guess.',
+      },
+    },
+    required: ['share'],
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    const selector = parseSelector(args);
+    // Both protocols are read even when one is asked for, and the unwanted one
+    // is discarded by `selects`. Issuing one query would be cheaper and would
+    // report a share of the other protocol as not existing, which is the one
+    // answer here that a caller would repeat as fact.
+    const attempts = await Promise.all([
+      attempt('SMB', () => smbTargets(system)),
+      attempt('NFS', () => nfsTargets(system)),
+    ]);
+    const matches: AccessTarget[] = [];
+    const failures: Failure[] = [];
+    for (const attempted of attempts) {
+      for (const target of attempted.rows) {
+        if (selects(selector, target.share)) matches.push(target);
+      }
+      // A failure of a protocol the caller excluded says nothing about their
+      // question, so it is not carried into the message they would read.
+      if (
+        attempted.failure !== null &&
+        (selector.protocol === null || selector.protocol === attempted.failure.protocol)
+      ) {
+        failures.push(attempted.failure);
+      }
+    }
+    if (matches.length === 0) throw noMatch(selector, failures);
+    if (matches.length > 1) throw ambiguous(selector, matches);
+    const target = matches[0];
+    const { acl, error } = await readAcl(system, target.share);
+    return {
+      protocol: target.share.protocol,
+      id: target.share.id,
+      name: target.share.name,
+      path: target.share.path,
+      enabled: target.share.enabled,
+      hosts: target.hosts,
+      networks: target.networks,
+      acl,
+      acl_error: error,
+    };
   },
 };

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -43,16 +43,9 @@ interface Failure {
   error: string;
 }
 
-/**
- * One protocol's rows, or the failure that stopped them being read.
- *
- * Generic in the row because `shares_list` and `share_access` read the same two
- * queries for different fields: the first wants the share as it is presented,
- * the second wants the NFS restrictions alongside it. The failure half is
- * identical for both and is what this exists to share.
- */
-interface Attempt<T> {
-  rows: T[];
+/** One protocol's shares, or the failure that stopped them being read. */
+interface Attempt {
+  rows: AccessTarget[];
   failure: Failure | null;
 }
 
@@ -164,8 +157,12 @@ async function smbTargets(system: SystemHandle): Promise<AccessTarget[]> {
       comment: textOrNull(share.comment),
     },
     readOnly: share.readonly ?? null,
-    // A fact about the protocol: SMB has no export restrictions and no id
-    // mapping, so there is nothing here rather than an empty set of them.
+    // Null rather than an empty set: nothing in this shape has an NFS
+    // counterpart. The share row the targeted surface returns
+    // (`SharingSMBEntry$2`) carries no host or network restriction and no id
+    // mapping at all — older TrueNAS releases had `hostsallow`/`hostsdeny` on
+    // the SMB share, and the client's directory for this version does not, so
+    // there is no field here to drop rather than a field being ignored.
     nfs: null,
   }));
 }
@@ -207,7 +204,10 @@ async function nfsTargets(system: SystemHandle): Promise<AccessTarget[]> {
  * at all. Neither caller can: both are `async`, so a throw anywhere inside them
  * arrives as a rejection.
  */
-async function attempt<T>(protocol: Protocol, read: () => Promise<T[]>): Promise<Attempt<T>> {
+async function attempt(
+  protocol: Protocol,
+  read: () => Promise<AccessTarget[]>,
+): Promise<Attempt> {
   try {
     return { rows: await read(), failure: null };
   } catch (reason) {
@@ -422,19 +422,34 @@ function accessEntry(ace: unknown): AccessEntry {
   };
 }
 
-/** The ACL response, mapped to the fields this tool names. */
-function mapAcl(row: Record<string, unknown>): Acl {
-  const entries = row['acl'];
+/**
+ * The ACL response, mapped to the fields this tool names.
+ *
+ * The parameter names the fields it reads rather than taking a record, so that
+ * a client-directory bump renaming one of them is a compile error here. The
+ * three ACL result shapes the call can answer with all carry these, and the
+ * runtime guards below stay because the response is still data: the type says
+ * the field is there, not that the system filled it sensibly.
+ */
+function mapAcl(row: {
+  acltype: string;
+  trivial: boolean;
+  user: string | null;
+  group: string | null;
+  uid: number | null;
+  gid: number | null;
+  acl: unknown;
+}): Acl {
   return {
-    type: textOrNull(row['acltype']),
-    trivial: typeof row['trivial'] === 'boolean' ? row['trivial'] : null,
-    owner_user: textOrNull(row['user']),
-    owner_uid: numberOrNull(row['uid']),
-    owner_group: textOrNull(row['group']),
-    owner_gid: numberOrNull(row['gid']),
+    type: textOrNull(row.acltype),
+    trivial: typeof row.trivial === 'boolean' ? row.trivial : null,
+    owner_user: textOrNull(row.user),
+    owner_uid: numberOrNull(row.uid),
+    owner_group: textOrNull(row.group),
+    owner_gid: numberOrNull(row.gid),
     // Null where the system reported no list at all, which is what a path with
     // ACLs switched off answers. An empty list is an ACL that holds no entry.
-    entries: Array.isArray(entries) ? entries.map(accessEntry) : null,
+    entries: Array.isArray(row.acl) ? (row.acl as unknown[]).map(accessEntry) : null,
   };
 }
 
@@ -471,7 +486,7 @@ async function readAcl(
     const acl = await firstValueFrom(
       system.client.api.call('filesystem.getacl', [share.path, true, true]),
     );
-    return { acl: mapAcl(acl as unknown as Record<string, unknown>), error: null };
+    return { acl: mapAcl(acl), error: null };
   } catch (reason) {
     return { acl: null, error: errorText(reason) };
   }
@@ -537,7 +552,9 @@ async function readShareAcl(
     const acl = await firstValueFrom(
       system.client.api.call('sharing.smb.getacl', [{ share_name: share.name }]),
     );
-    const entries = (acl as unknown as Record<string, unknown>)['share_acl'];
+    // Named rather than read out of a record, so that a client-directory bump
+    // renaming this field is a compile error rather than an answer of nulls.
+    const entries: unknown = acl.share_acl;
     if (!Array.isArray(entries)) {
       // Not reported as an empty ACL: at share level an empty list of entries
       // would read as a share nobody is allowed to reach, which is the opposite
@@ -660,7 +677,10 @@ export const shareAccess: ReadOnlyTool = {
     'id, and `sid` the Windows security identifier of a domain principal — and ' +
     'an entry that resolved to none of them is reported empty rather than ' +
     'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
-    '`CHANGE`, `READ` or `CUSTOM`. `acl` is the filesystem ACL on `path`, which ' +
+    '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
+    'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
+    'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
+    'the filesystem ACL on `path`, which ' +
     'is what decides what each principal may do once connected: over SMB it ' +
     'applies to whoever the share ACL above already let through, and over NFS ' +
     'to the ids arriving from a machine the restrictions already let in, after ' +

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -261,8 +261,9 @@ export const sharesList: ReadOnlyTool = {
     const shares: Share[] = [];
     const failures: Failure[] = [];
     for (const attempted of attempts) {
-      // The share half only: what an export restricts and whom it maps is
-      // `share_access`, and this tool's own description says so.
+      // The share half only. What an export restricts and whom it maps is read
+      // by the same query and belongs to `share_access`; this tool's own
+      // description says those fields are not among the ones it returns.
       shares.push(...attempted.rows.map((target) => target.share));
       if (attempted.failure !== null) failures.push(attempted.failure);
     }
@@ -374,7 +375,12 @@ function permissionNames(perms: unknown): string[] | null {
     return basic === null ? null : [basic];
   }
   const names = Object.keys(record);
-  if (!names.some((name) => typeof record[name] === 'boolean')) return null;
+  if (names.length === 0) return null;
+  // Whole or nothing, as a restriction list is: reporting the readable ones
+  // alone would answer with a definite, narrower set of rights than the entry
+  // carries, and a caller cannot tell that from an entry that really holds
+  // only those.
+  if (!names.every((name) => typeof record[name] === 'boolean')) return null;
   return names.filter((name) => record[name] === true);
 }
 
@@ -395,7 +401,13 @@ function childrenOnly(ace: Record<string, unknown>): boolean | null {
   if (flags === null || typeof flags !== 'object') return null;
   const record = flags as Record<string, unknown>;
   if ('BASIC' in record) return textOrNull(record['BASIC']) === null ? null : false;
-  return record['INHERIT_ONLY'] === true;
+  const inheritOnly = record['INHERIT_ONLY'];
+  // Absent is a flag that is not set, which the middleware states by omission.
+  // Present but not a boolean is a flag that could not be read, and answering
+  // false there would assert the entry grants access on the path — the claim
+  // this field exists to avoid making by accident.
+  if (inheritOnly === undefined) return false;
+  return typeof inheritOnly === 'boolean' ? inheritOnly : null;
 }
 
 /**

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -96,6 +96,22 @@ interface NfsExport {
 }
 
 /**
+ * What an SMB share says about which machines may reach it, beyond its ACLs.
+ *
+ * The SMB service applies these before either ACL is consulted, so a share
+ * whose ACLs grant everyone can still be reachable by almost nobody. They live
+ * under the share's `options`, whose shape differs by what the share is for —
+ * the client's directory declares them on the legacy shape alone, while the
+ * middleware accepts them on the others — so `options` is read as an untyped
+ * record for the same reason an ACL entry is: a key one variant lacks would
+ * need narrowing that the row itself is what decides.
+ */
+interface SmbShare {
+  hosts_allow: string[] | null;
+  hosts_deny: string[] | null;
+}
+
+/**
  * One share, with everything the share record itself says about reaching it.
  *
  * Both tools in this family read the same two queries, so this is what those
@@ -107,22 +123,23 @@ interface AccessTarget {
   share: Share;
   /** Read-only however the ACL reads, or null where the switch was not readable. */
   readOnly: boolean | null;
+  smb: SmbShare | null;
   nfs: NfsExport | null;
 }
 
 /**
- * An NFS export's host or network restriction list.
+ * One host, network or address-pattern restriction list, on either protocol.
  *
- * Only a list the export actually carries is reported. `[]` says the export
- * restricts nothing of that kind and ANY machine may mount it, which is the
+ * Only a list the share actually carries is reported. `[]` says the share
+ * restricts nothing of that kind and ANY machine may reach it, which is the
  * strongest claim this function makes — so it is made only where the system
  * sent an empty list and said so. An absent field is not that: the field is
- * optional on the client's own type, so its absence is a middleware that did
- * not report the restriction rather than an export that has none, and reading
+ * optional on the client's own types, so its absence is a middleware that did
+ * not report the restriction rather than a share that has none, and reading
  * the two as one would fail open in the direction that matters here.
  *
  * The list is also reported whole or not at all: dropping the entries that
- * could not be read would answer with a narrower restriction than the export
+ * could not be read would answer with a narrower restriction than the share
  * carries, and dropping all of them would answer `[]`, which again means the
  * opposite.
  */
@@ -132,6 +149,23 @@ function restrictionList(value: unknown): string[] | null {
     (item): item is string => typeof item === 'string' && item.length > 0,
   );
   return restrictions.length === value.length ? restrictions : null;
+}
+
+/**
+ * The host rules on an SMB share, read out of its `options`.
+ *
+ * A share whose options could not be read reports both lists null, which by
+ * the rule above is "no list this tool could read" rather than a share that
+ * restricts nothing — the same reading an absent field gets, and the only one
+ * that does not turn an unread gate into an open one.
+ */
+function smbHostRules(options: unknown): SmbShare {
+  const record =
+    options !== null && typeof options === 'object' ? (options as Record<string, unknown>) : {};
+  return {
+    hosts_allow: restrictionList(record['hostsallow']),
+    hosts_deny: restrictionList(record['hostsdeny']),
+  };
 }
 
 /** Every SMB share the system holds. */
@@ -157,12 +191,16 @@ async function smbTargets(system: SystemHandle): Promise<AccessTarget[]> {
       comment: textOrNull(share.comment),
     },
     readOnly: share.readonly ?? null,
-    // Null rather than an empty set: nothing in this shape has an NFS
-    // counterpart. The share row the targeted surface returns
-    // (`SharingSMBEntry$2`) carries no host or network restriction and no id
-    // mapping at all — older TrueNAS releases had `hostsallow`/`hostsdeny` on
-    // the SMB share, and the client's directory for this version does not, so
-    // there is no field here to drop rather than a field being ignored.
+    // `options` is where the SMB share's host rules moved: the row the client
+    // returns declares `hostsallow`/`hostsdeny` on the legacy option shape, and
+    // the middleware takes them on the others too, so they are read from the
+    // object whatever the share is for rather than only where a type says to
+    // expect them. Naming `options` here is what makes a rename of that field a
+    // compile error; the keys inside it differ by variant and are read as data.
+    smb: smbHostRules(share.options),
+    // Null rather than an empty set: an NFS export's restrictions and id
+    // mapping are a different protocol's record, and there is nothing on an SMB
+    // share to fill them with.
     nfs: null,
   }));
 }
@@ -185,6 +223,9 @@ async function nfsTargets(system: SystemHandle): Promise<AccessTarget[]> {
       comment: textOrNull(share.comment),
     },
     readOnly: share.ro ?? null,
+    // An NFS export is not served by the SMB service, so it has no host rules
+    // of that kind rather than unread ones.
+    smb: null,
     nfs: {
       hosts: restrictionList(share.hosts),
       networks: restrictionList(share.networks),
@@ -287,17 +328,20 @@ export const sharesList: ReadOnlyTool = {
  * Who may reach one share, and with what rights.
  *
  * `shares_list` says what is shared and from where. This says who can get at
- * it, and the answer is in two different places depending on the protocol —
- * neither of them the share record on its own:
+ * it, and the answer is in several places depending on the protocol — none of
+ * them the share record on its own:
  *
- *     SMB   the filesystem ACL on the shared path, which is what decides what
- *           each user may do once a client has connected
+ *     SMB   the share's own host rules, which decide which MACHINES may
+ *           connect; the share-level ACL, a second gate on who may; and the
+ *           filesystem ACL on the shared path, which is what decides what each
+ *           user may do once a client has connected
  *     NFS   the export's own host and network restrictions, which decide which
  *           MACHINES may mount it at all, and then that same filesystem ACL,
  *           which decides what the ids arriving over the mount may do
  *
- * So the ACL is read for both and the restrictions are read for NFS, and
- * neither half is presented as the whole answer.
+ * So the filesystem ACL is read for both, the share-level ACL and host rules
+ * for SMB, and the restrictions for NFS. No half is presented as the whole
+ * answer: access is the narrowest of all of them.
  */
 
 /** Which share the caller asked about. */
@@ -673,7 +717,18 @@ export const shareAccess: ReadOnlyTool = {
     '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
     'share or export is served read-only whatever its ACLs say — and null is a ' +
     'switch the system reported no value for, which is not the same as false. ' +
-    '`nfs` is the export record\'s own say in who may reach it, and is null on ' +
+    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
+    'applied by the SMB service before either ACL below is consulted, and is ' +
+    'null on an NFS export, which is not served by that service. Within it, ' +
+    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
+    'addresses or subnets — and where both name a machine the SMB service lets ' +
+    'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
+    'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
+    'here. Null is not that: it means the system reported no list this tool ' +
+    'could read — the field absent, the share\'s `options` absent, or a list ' +
+    'holding something that is not a host pattern — and it is NOT evidence ' +
+    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
+    'who may reach it, and is null on ' +
     'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
     '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
     'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
@@ -820,6 +875,7 @@ export const shareAccess: ReadOnlyTool = {
       path: target.share.path,
       enabled: target.share.enabled,
       read_only: target.readOnly,
+      smb: target.smb,
       nfs: target.nfs,
       share_acl: shareAcl.entries,
       share_acl_error: shareAcl.error,

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -459,9 +459,17 @@ function mapAcl(row: {
     owner_uid: numberOrNull(row.uid),
     owner_group: textOrNull(row.group),
     owner_gid: numberOrNull(row.gid),
-    // Null where the system reported no list at all, which is what a path with
-    // ACLs switched off answers. An empty list is an ACL that holds no entry.
-    entries: Array.isArray(row.acl) ? (row.acl as unknown[]).map(accessEntry) : null,
+    // Keyed on the type, not on the shape of `acl`, because the two say
+    // different things and only the type is authoritative about which. A
+    // `DISABLED` path has no ACL in force whatever list arrives beside it, so
+    // reporting the `[]` the middleware answers empty lists with would read as
+    // an ACL that grants nobody anything when access is really governed by the
+    // mode bits this tool does not read. Otherwise null is a list that could
+    // not be read, and an empty list is an ACL that holds no entry.
+    entries:
+      row.acltype === 'DISABLED' || !Array.isArray(row.acl)
+        ? null
+        : (row.acl as unknown[]).map(accessEntry),
   };
 }
 
@@ -700,7 +708,8 @@ export const shareAccess: ReadOnlyTool = {
     'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
     'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
     '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
-    'there `entries` is null and access is governed by the Unix mode bits, ' +
+    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
+    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
     'which this tool does not read, so it can say nothing about who has access ' +
     '— or null where the system named no type, which leaves the entries below ' +
     'readable but says nothing about which vocabulary they are in. ' +
@@ -708,7 +717,10 @@ export const shareAccess: ReadOnlyTool = {
     'group and everyone else. `owner_user` and `owner_group` are the names of ' +
     'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
     'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
-    'to. Each of `entries` is one entry of that ACL. `tag` says what kind, and ' +
+    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
+    'that holds no entry, and null is either the `DISABLED` path above or a ' +
+    'list the system did not report in a form this tool could read — never ' +
+    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
     'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
     'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
     'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -293,15 +293,21 @@ function principalId(value: unknown): number | null {
  *
  * An absent list and an empty one are the same answer from the middleware — the
  * export carries no restriction of that kind — so both map to `[]` rather than
- * one of them becoming a null that would read as unreadable. Only a value that
- * is not a list at all is unreadable, and entries that are not text are dropped
- * because a restriction that cannot be read as a host or a network restricts
- * nothing this tool can report.
+ * one of them becoming a null that would read as unreadable.
+ *
+ * Everything else is unreadable, and the list is reported whole or not at all:
+ * dropping the entries that could not be read would answer with a narrower
+ * restriction than the export carries, and dropping all of them would answer
+ * `[]`, which here means the OPPOSITE — no restriction, and any machine may
+ * mount it.
  */
 function restrictionList(value: unknown): string[] | null {
   if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) return null;
-  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+  const restrictions = value.filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  );
+  return restrictions.length === value.length ? restrictions : null;
 }
 
 /**
@@ -314,9 +320,13 @@ function restrictionList(value: unknown): string[] | null {
  * POSIX one (`{ READ: true, WRITE: false, EXECUTE: true }`). The last two are
  * the same shape, so one pass over the true keys covers both.
  *
- * An empty list is an entry that names no permission, which is not the same as
- * a permission set that could not be read — a caller reviewing access must not
- * see the second as the first and conclude the entry grants nothing.
+ * An empty list is an entry that names permissions and holds none of them —
+ * `{ READ: false, WRITE: false, EXECUTE: false }`, which a POSIX `OTHER` entry
+ * really does carry. That is not the same as a permission set that could not be
+ * read, and a caller reviewing access must not see the second as the first and
+ * conclude the entry grants nothing. So a set naming no permission this tool
+ * can read AT ALL — an empty object, or one whose every value is something
+ * other than a boolean — is unreadable rather than empty.
  */
 function permissionNames(perms: unknown): string[] | null {
   if (perms === null || typeof perms !== 'object') return null;
@@ -328,7 +338,9 @@ function permissionNames(perms: unknown): string[] | null {
     const basic = textOrNull(record['BASIC']);
     return basic === null ? null : [basic];
   }
-  return Object.keys(record).filter((name) => record[name] === true);
+  const names = Object.keys(record);
+  if (!names.some((name) => typeof record[name] === 'boolean')) return null;
+  return names.filter((name) => record[name] === true);
 }
 
 /**
@@ -529,8 +541,10 @@ export const shareAccess: ReadOnlyTool = {
     'UNRESTRICTED — an empty `hosts` and an empty `networks` together mean any ' +
     'machine that can reach this server may mount it, which is the opposite of ' +
     'nobody. Both are null on an SMB share, where the protocol has no such ' +
-    'restriction, and null on an NFS export only where the system reported ' +
-    'something that could not be read as a list; `protocol` tells those two ' +
+    'restriction, and null on an NFS export where the system reported ' +
+    'something that could not be read as a list of hosts or networks — ' +
+    'including a list holding an entry that is not one, since a restriction ' +
+    'reported in part is a different restriction; `protocol` tells those two ' +
     'apart. `acl` is the filesystem ACL on `path`, which is what decides what ' +
     'each principal may do once connected — over SMB it is the whole answer, ' +
     'and over NFS it applies to the ids arriving from a machine the ' +
@@ -550,9 +564,12 @@ export const shareAccess: ReadOnlyTool = {
     'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
     'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
     'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
-    'a ceiling on the others, described under `permissions`. `name` and `id` ' +
-    'are BOTH null on every tag that is its own principal, and on `MASK`, by ' +
-    'construction rather than because nothing resolved. On a `USER` or `GROUP` ' +
+    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
+    'null on a tag that is its own principal and on `MASK`: the system writes ' +
+    '-1 there, which is reported as null because no account holds it. `name` ' +
+    'is null on those tags too, since they name no separate account for the ' +
+    'system to resolve — a null on one of them is the tag\'s nature rather ' +
+    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
     'entry `name` is the resolved account or group name and `id` is its raw ' +
     'numeric id; an id that resolved to no name is reported as `id` beside a ' +
     'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
@@ -565,9 +582,10 @@ export const shareAccess: ReadOnlyTool = {
     'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
     'entry grants only what it and the `MASK` entry both name, so the two are ' +
     'read together and an entry can appear to hold more than it does. NFS4 has ' +
-    'no mask and no such step. An empty list is an entry that names no ' +
-    'permission; null is one whose permissions could not be read, and is not ' +
-    'evidence that it grants nothing. `children_only` true means the ' +
+    'no mask and no such step. An empty list is an entry that names ' +
+    'permissions and holds none of them; null is one whose permissions could ' +
+    'not be read, and is not evidence that it grants nothing. ' +
+    '`children_only` true means the ' +
     'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
     'created inside it, so its principal does not have the access it appears to ' +
     'have; null is an entry whose inheritance could not be read. This tool ' +

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -514,7 +514,13 @@ export const shareAccess: ReadOnlyTool = {
     'share nobody can reach are opposite answers. A string matching MORE THAN ' +
     'one share is also an error, listing what it matched — one path can be ' +
     'shared over both protocols at once and the two grant access differently, ' +
-    'so there is no single answer to give. `protocol`, `id`, `name`, `path` ' +
+    'so there is no single answer to give. `failures` reports a protocol whose ' +
+    'share list could not be read, as `protocol` and `error`, and is empty ' +
+    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
+    'ONLY ONE: the search for a second match ran over a list that was never ' +
+    'read, so a share of the protocol named there may also answer to the ' +
+    'string given, and the error this tool would otherwise raise is one it ' +
+    'could not detect. `protocol`, `id`, `name`, `path` ' +
     'and `enabled` identify the share and mean exactly what they mean in ' +
     '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
     'that a disabled share reaches nobody whatever the rest of this says. ' +
@@ -537,21 +543,31 @@ export const shareAccess: ReadOnlyTool = {
     '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
     'group and everyone else. `owner_user` and `owner_group` are the names of ' +
     'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
-    'are who the `owner@` and `group@` entries refer to. Each of `entries` is ' +
-    'one principal and what it holds. `tag` is `USER`, `GROUP`, or one of ' +
-    '`owner@`, `group@` and `everyone@`, where the tag IS the principal and ' +
-    '`name` and `id` are both null as a result rather than because nothing ' +
-    'resolved. Otherwise `name` is the resolved account or group name and `id` ' +
-    'is its raw numeric id; an id that resolved to no name is reported as `id` ' +
-    'with a null `name` and IS NEVER DROPPED, so an entry with neither a name ' +
-    'nor an id is one whose principal could not be read at all. `access` is ' +
-    '`ALLOW` or `DENY` on an NFS4 ACL and null on a POSIX one, which has no ' +
-    'deny entries. `permissions` names what the entry grants, in the ACL ' +
-    'type\'s own vocabulary — a single preset such as `FULL_CONTROL` or ' +
-    '`MODIFY`, or individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 ' +
-    'and `READ`, `WRITE` and `EXECUTE` on POSIX. An empty list is an entry that ' +
-    'names no permission; null is one whose permissions could not be read, and ' +
-    'is not evidence that it grants nothing. `children_only` true means the ' +
+    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
+    'to. Each of `entries` is one entry of that ACL. `tag` says what kind, and ' +
+    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
+    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
+    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
+    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
+    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
+    'a ceiling on the others, described under `permissions`. `name` and `id` ' +
+    'are BOTH null on every tag that is its own principal, and on `MASK`, by ' +
+    'construction rather than because nothing resolved. On a `USER` or `GROUP` ' +
+    'entry `name` is the resolved account or group name and `id` is its raw ' +
+    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
+    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
+    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
+    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
+    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
+    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
+    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
+    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
+    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
+    'entry grants only what it and the `MASK` entry both name, so the two are ' +
+    'read together and an entry can appear to hold more than it does. NFS4 has ' +
+    'no mask and no such step. An empty list is an entry that names no ' +
+    'permission; null is one whose permissions could not be read, and is not ' +
+    'evidence that it grants nothing. `children_only` true means the ' +
     'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
     'created inside it, so its principal does not have the access it appears to ' +
     'have; null is an entry whose inheritance could not be read. This tool ' +
@@ -618,6 +634,12 @@ export const shareAccess: ReadOnlyTool = {
       networks: target.networks,
       acl,
       acl_error: error,
+      // A protocol that could not be listed is reported even though one share
+      // was found, because the check for a second match ran over a list that
+      // was never read: the ambiguity this tool raises rather than guesses at
+      // is exactly the thing it could not see. Dropping this would present a
+      // half-searched answer as the unique one.
+      failures,
     };
   },
 };

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -120,18 +120,20 @@ interface AccessTarget {
 /**
  * An NFS export's host or network restriction list.
  *
- * An absent list and an empty one are the same answer from the middleware — the
- * export carries no restriction of that kind — so both map to `[]` rather than
- * one of them becoming a null that would read as unreadable.
+ * Only a list the export actually carries is reported. `[]` says the export
+ * restricts nothing of that kind and ANY machine may mount it, which is the
+ * strongest claim this function makes — so it is made only where the system
+ * sent an empty list and said so. An absent field is not that: the field is
+ * optional on the client's own type, so its absence is a middleware that did
+ * not report the restriction rather than an export that has none, and reading
+ * the two as one would fail open in the direction that matters here.
  *
- * Everything else is unreadable, and the list is reported whole or not at all:
- * dropping the entries that could not be read would answer with a narrower
- * restriction than the export carries, and dropping all of them would answer
- * `[]`, which here means the OPPOSITE — no restriction, and any machine may
- * mount it.
+ * The list is also reported whole or not at all: dropping the entries that
+ * could not be read would answer with a narrower restriction than the export
+ * carries, and dropping all of them would answer `[]`, which again means the
+ * opposite.
  */
 function restrictionList(value: unknown): string[] | null {
-  if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) return null;
   const restrictions = value.filter(
     (item): item is string => typeof item === 'string' && item.length > 0,
@@ -636,13 +638,14 @@ export const shareAccess: ReadOnlyTool = {
     'switch the system reported no value for, which is not the same as false. ' +
     '`nfs` is the export record\'s own say in who may reach it, and is null on ' +
     'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
-    '`networks` are which machines may mount the export at all. THEY ARE EMPTY ' +
-    'WHEN THE EXPORT IS UNRESTRICTED — an empty `hosts` and an empty `networks` ' +
-    'together mean any machine that can reach this server may mount it, which ' +
-    'is the opposite of nobody — and either is null where the system reported ' +
-    'something that could not be read as a list of hosts or networks, including ' +
-    'a list holding an entry that is not one, since a restriction reported in ' +
-    'part is a different restriction. `mapall_user` and `mapall_group`, when ' +
+    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
+    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
+    'mean any machine that can reach this server may mount it, which is the ' +
+    'opposite of nobody. Null is neither: it means the system reported no list ' +
+    'this tool could read — the field absent, or a list holding an entry that ' +
+    'is not a host or a network, since a restriction reported in part is a ' +
+    'different restriction — and it is NOT evidence that the export is ' +
+    'unrestricted. `mapall_user` and `mapall_group`, when ' +
     'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
     'that account before the ACL below is consulted, so the ACL then answers ' +
     'for that one account and not for whoever connected; `maproot_user` and ' +

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -84,57 +84,117 @@ function errorText(reason: unknown): string {
   return textOrNull(reason) ?? 'the system reported no reason';
 }
 
+/**
+ * What an NFS export says about who may reach it, beyond the ACL on its path.
+ *
+ * These are read from the export row rather than from a second call, and they
+ * are here because each of them can make the path's ACL overstate what someone
+ * actually gets: the restrictions decide which machines may mount it at all,
+ * and the map fields replace the id that arrives before the ACL is ever
+ * consulted.
+ */
+interface NfsExport {
+  hosts: string[] | null;
+  networks: string[] | null;
+  mapall_user: string | null;
+  mapall_group: string | null;
+  maproot_user: string | null;
+  maproot_group: string | null;
+}
+
+/**
+ * One share, with everything the share record itself says about reaching it.
+ *
+ * Both tools in this family read the same two queries, so this is what those
+ * queries produce and `shares_list` takes the `share` half of it. One mapping
+ * per protocol rather than two: two would drift, and the drift would show as
+ * one tool naming a share differently from the other.
+ */
+interface AccessTarget {
+  share: Share;
+  /** Read-only however the ACL reads, or null where the switch was not readable. */
+  readOnly: boolean | null;
+  nfs: NfsExport | null;
+}
+
+/**
+ * An NFS export's host or network restriction list.
+ *
+ * An absent list and an empty one are the same answer from the middleware — the
+ * export carries no restriction of that kind — so both map to `[]` rather than
+ * one of them becoming a null that would read as unreadable.
+ *
+ * Everything else is unreadable, and the list is reported whole or not at all:
+ * dropping the entries that could not be read would answer with a narrower
+ * restriction than the export carries, and dropping all of them would answer
+ * `[]`, which here means the OPPOSITE — no restriction, and any machine may
+ * mount it.
+ */
+function restrictionList(value: unknown): string[] | null {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) return null;
+  const restrictions = value.filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  );
+  return restrictions.length === value.length ? restrictions : null;
+}
+
 /** Every SMB share the system holds. */
-async function smbShares(system: SystemHandle): Promise<Share[]> {
+async function smbTargets(system: SystemHandle): Promise<AccessTarget[]> {
   // No filters and no options: a system holds tens of shares at most, and every
   // field this tool reads is part of a share row as it stands. No `select`
   // either — unlike a job row, a share row carries no credential and nothing
   // unbounded, and the mapping below is what decides what a caller sees.
   const shares = await firstValueFrom(system.client.api.query('sharing.smb.query'));
   return shares.map((share) => ({
-    protocol: 'SMB' as const,
-    id: share.id,
-    name: textOrNull(share.name),
-    // `EXTERNAL` is passed through as the system spelled it: an external share
-    // is a redirection to another server rather than a path on this one, and
-    // reporting null there would read as a path that could not be found.
-    path: textOrNull(share.path),
-    // Optional on the client's own type, so a middleware that omits it reports
-    // null rather than a default. Not defaulted either way: a share whose
-    // switch cannot be read must not be presented as definitely on or off.
-    enabled: share.enabled ?? null,
-    comment: textOrNull(share.comment),
+    share: {
+      protocol: 'SMB' as const,
+      id: share.id,
+      name: textOrNull(share.name),
+      // `EXTERNAL` is passed through as the system spelled it: an external share
+      // is a redirection to another server rather than a path on this one, and
+      // reporting null there would read as a path that could not be found.
+      path: textOrNull(share.path),
+      // Optional on the client's own type, so a middleware that omits it reports
+      // null rather than a default. Not defaulted either way: a share whose
+      // switch cannot be read must not be presented as definitely on or off.
+      enabled: share.enabled ?? null,
+      comment: textOrNull(share.comment),
+    },
+    readOnly: share.readonly ?? null,
+    // A fact about the protocol: SMB has no export restrictions and no id
+    // mapping, so there is nothing here rather than an empty set of them.
+    nfs: null,
   }));
 }
 
-/**
- * One NFS export as this family presents one.
- *
- * Split out of `nfsShares` because `share_access` reads the same rows for their
- * host restrictions and must present the share half identically — two mappings
- * of one row would drift, and the drift would show as one tool naming a share
- * differently from the other.
- */
-function nfsShare(share: { id: number; path: string; enabled?: boolean; comment?: string }): Share {
-  return {
-    protocol: 'NFS' as const,
-    id: share.id,
-    // An NFS export has no name. The middleware identifies one by the path it
-    // exports and carries no name field at all, so this is null on every NFS
-    // share — a fact about the protocol rather than about this system. Not the
-    // path repeated under a second key, which would read as a name somebody
-    // chose.
-    name: null,
-    path: textOrNull(share.path),
-    enabled: share.enabled ?? null,
-    comment: textOrNull(share.comment),
-  };
-}
-
 /** Every NFS export the system holds. */
-async function nfsShares(system: SystemHandle): Promise<Share[]> {
+async function nfsTargets(system: SystemHandle): Promise<AccessTarget[]> {
   const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
-  return shares.map(nfsShare);
+  return shares.map((share) => ({
+    share: {
+      protocol: 'NFS' as const,
+      id: share.id,
+      // An NFS export has no name. The middleware identifies one by the path it
+      // exports and carries no name field at all, so this is null on every NFS
+      // share — a fact about the protocol rather than about this system. Not the
+      // path repeated under a second key, which would read as a name somebody
+      // chose.
+      name: null,
+      path: textOrNull(share.path),
+      enabled: share.enabled ?? null,
+      comment: textOrNull(share.comment),
+    },
+    readOnly: share.ro ?? null,
+    nfs: {
+      hosts: restrictionList(share.hosts),
+      networks: restrictionList(share.networks),
+      mapall_user: textOrNull(share.mapall_user),
+      mapall_group: textOrNull(share.mapall_group),
+      maproot_user: textOrNull(share.maproot_user),
+      maproot_group: textOrNull(share.maproot_group),
+    },
+  }));
 }
 
 /**
@@ -193,13 +253,15 @@ export const sharesList: ReadOnlyTool = {
     // Both queries are issued before either is awaited, so the second is not
     // waiting on the first, and neither can take the other down.
     const attempts = await Promise.all([
-      attempt('SMB', () => smbShares(system)),
-      attempt('NFS', () => nfsShares(system)),
+      attempt('SMB', () => smbTargets(system)),
+      attempt('NFS', () => nfsTargets(system)),
     ]);
     const shares: Share[] = [];
     const failures: Failure[] = [];
     for (const attempted of attempts) {
-      shares.push(...attempted.rows);
+      // The share half only: what an export restricts and whom it maps is
+      // `share_access`, and this tool's own description says so.
+      shares.push(...attempted.rows.map((target) => target.share));
       if (attempted.failure !== null) failures.push(attempted.failure);
     }
     // Nothing was read, so there is no partial answer to preserve. An empty
@@ -234,13 +296,6 @@ export const sharesList: ReadOnlyTool = {
  * So the ACL is read for both and the restrictions are read for NFS, and
  * neither half is presented as the whole answer.
  */
-
-/** One protocol's shares, with the export restrictions that only NFS carries. */
-interface AccessTarget {
-  share: Share;
-  hosts: string[] | null;
-  networks: string[] | null;
-}
 
 /** Which share the caller asked about. */
 interface Selector {
@@ -286,28 +341,6 @@ function numberOrNull(value: unknown): number | null {
 function principalId(value: unknown): number | null {
   const id = numberOrNull(value);
   return id === null || id < 0 ? null : id;
-}
-
-/**
- * An NFS export's host or network restriction list.
- *
- * An absent list and an empty one are the same answer from the middleware — the
- * export carries no restriction of that kind — so both map to `[]` rather than
- * one of them becoming a null that would read as unreadable.
- *
- * Everything else is unreadable, and the list is reported whole or not at all:
- * dropping the entries that could not be read would answer with a narrower
- * restriction than the export carries, and dropping all of them would answer
- * `[]`, which here means the OPPOSITE — no restriction, and any machine may
- * mount it.
- */
-function restrictionList(value: unknown): string[] | null {
-  if (value === undefined || value === null) return [];
-  if (!Array.isArray(value)) return null;
-  const restrictions = value.filter(
-    (item): item is string => typeof item === 'string' && item.length > 0,
-  );
-  return restrictions.length === value.length ? restrictions : null;
 }
 
 /**
@@ -442,20 +475,80 @@ async function readAcl(
   }
 }
 
-/** Every SMB share, as a target. SMB carries no export restrictions of its own. */
-async function smbTargets(system: SystemHandle): Promise<AccessTarget[]> {
-  const shares = await smbShares(system);
-  return shares.map((share) => ({ share, hosts: null, networks: null }));
+/**
+ * One entry of an SMB share-level ACL: who it names, and what it does to them.
+ *
+ * A principal here can be named three ways and the middleware fills whichever
+ * it has, so all three are reported and none stands in for another: `name` is
+ * the resolved account, `id` with `kind` is the local uid or gid, and `sid` is
+ * the Windows security identifier a domain principal arrives as. An entry that
+ * resolved to none of them is still an entry, and is reported empty rather than
+ * dropped.
+ */
+interface ShareAclEntry {
+  name: string | null;
+  id: number | null;
+  kind: 'USER' | 'GROUP' | null;
+  sid: string | null;
+  access: 'ALLOWED' | 'DENIED' | null;
+  permission: string | null;
 }
 
-/** Every NFS export, as a target, with the restrictions on who may mount it. */
-async function nfsTargets(system: SystemHandle): Promise<AccessTarget[]> {
-  const shares = await firstValueFrom(system.client.api.query('sharing.nfs.query'));
-  return shares.map((share) => ({
-    share: nfsShare(share),
-    hosts: restrictionList(share.hosts),
-    networks: restrictionList(share.networks),
-  }));
+/** One share-level ACL entry, mapped field by field. */
+function shareAclEntry(entry: unknown): ShareAclEntry {
+  const row = entry !== null && typeof entry === 'object' ? (entry as Record<string, unknown>) : {};
+  const who = row['ae_who_id'];
+  const identity = who !== null && typeof who === 'object' ? (who as Record<string, unknown>) : {};
+  const kind = identity['id_type'];
+  const access = row['ae_type'];
+  return {
+    name: textOrNull(row['ae_who_str']),
+    id: numberOrNull(identity['id']),
+    kind: kind === 'USER' || kind === 'GROUP' ? kind : null,
+    sid: textOrNull(row['ae_who_sid']),
+    access: access === 'ALLOWED' || access === 'DENIED' ? access : null,
+    permission: textOrNull(row['ae_perm']),
+  };
+}
+
+/**
+ * The SMB share-level ACL, which is a second gate in front of the filesystem
+ * one and can deny what the path grants.
+ *
+ * Read for SMB only, because it is an SMB concept: an NFS export has no such
+ * layer, so both halves of the answer are null there rather than empty. As with
+ * the filesystem ACL, a failure is returned rather than thrown — the rest of
+ * the answer is still worth having beside a stated reason.
+ */
+async function readShareAcl(
+  system: SystemHandle,
+  share: Share,
+): Promise<{ entries: ShareAclEntry[] | null; error: string | null }> {
+  if (share.protocol !== 'SMB') return { entries: null, error: null };
+  if (share.name === null) {
+    return {
+      entries: null,
+      error: 'the system reported no name for this share, and the share ACL is read by name',
+    };
+  }
+  try {
+    const acl = await firstValueFrom(
+      system.client.api.call('sharing.smb.getacl', [{ share_name: share.name }]),
+    );
+    const entries = (acl as unknown as Record<string, unknown>)['share_acl'];
+    if (!Array.isArray(entries)) {
+      // Not reported as an empty ACL: at share level an empty list of entries
+      // would read as a share nobody is allowed to reach, which is the opposite
+      // of what a share carrying no share-level ACL means.
+      return {
+        entries: null,
+        error: 'the system reported no share-level ACL, so what it allows is not known here',
+      };
+    }
+    return { entries: entries.map(shareAclEntry), error: null };
+  } catch (reason) {
+    return { entries: null, error: errorText(reason) };
+  }
 }
 
 /** The caller's arguments, or an error naming what is wrong with them. */
@@ -536,24 +629,46 @@ export const shareAccess: ReadOnlyTool = {
     'and `enabled` identify the share and mean exactly what they mean in ' +
     '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
     'that a disabled share reaches nobody whatever the rest of this says. ' +
-    '`hosts` and `networks` are the NFS export restrictions: which machines may ' +
-    'mount it at all, by host and by network. THEY ARE EMPTY WHEN THE EXPORT IS ' +
-    'UNRESTRICTED — an empty `hosts` and an empty `networks` together mean any ' +
-    'machine that can reach this server may mount it, which is the opposite of ' +
-    'nobody. Both are null on an SMB share, where the protocol has no such ' +
-    'restriction, and null on an NFS export where the system reported ' +
-    'something that could not be read as a list of hosts or networks — ' +
-    'including a list holding an entry that is not one, since a restriction ' +
-    'reported in part is a different restriction; `protocol` tells those two ' +
-    'apart. `acl` is the filesystem ACL on `path`, which is what decides what ' +
-    'each principal may do once connected — over SMB it is the whole answer, ' +
-    'and over NFS it applies to the ids arriving from a machine the ' +
-    'restrictions already let in. EXACTLY ONE of `acl` and `acl_error` is ' +
+    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
+    'is reached only by a principal that every layer reporting on it allows. ' +
+    '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
+    'share or export is served read-only whatever its ACLs say — and null is a ' +
+    'switch the system reported no value for, which is not the same as false. ' +
+    '`nfs` is the export record\'s own say in who may reach it, and is null on ' +
+    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
+    '`networks` are which machines may mount the export at all. THEY ARE EMPTY ' +
+    'WHEN THE EXPORT IS UNRESTRICTED — an empty `hosts` and an empty `networks` ' +
+    'together mean any machine that can reach this server may mount it, which ' +
+    'is the opposite of nobody — and either is null where the system reported ' +
+    'something that could not be read as a list of hosts or networks, including ' +
+    'a list holding an entry that is not one, since a restriction reported in ' +
+    'part is a different restriction. `mapall_user` and `mapall_group`, when ' +
+    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
+    'that account before the ACL below is consulted, so the ACL then answers ' +
+    'for that one account and not for whoever connected; `maproot_user` and ' +
+    '`maproot_group` do the same for root alone. Each is null where no such ' +
+    'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
+    'front of the filesystem one that can DENY what the path grants, so a ' +
+    'principal allowed below may still be refused here. It and ' +
+    '`share_acl_error` are BOTH null on an NFS export, which has no such layer; ' +
+    'on an SMB share exactly one of them is non-null. Each of its entries names ' +
+    'a principal in whichever of three ways the system had — `name` the ' +
+    'resolved account, `id` with `kind` (`USER` or `GROUP`) the local numeric ' +
+    'id, and `sid` the Windows security identifier of a domain principal — and ' +
+    'an entry that resolved to none of them is reported empty rather than ' +
+    'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
+    '`CHANGE`, `READ` or `CUSTOM`. `acl` is the filesystem ACL on `path`, which ' +
+    'is what decides what each principal may do once connected: over SMB it ' +
+    'applies to whoever the share ACL above already let through, and over NFS ' +
+    'to the ids arriving from a machine the restrictions already let in, after ' +
+    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
     'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
     'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
     '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
     'there `entries` is null and access is governed by the Unix mode bits, ' +
-    'which this tool does not read, so it can say nothing about who has access. ' +
+    'which this tool does not read, so it can say nothing about who has access ' +
+    '— or null where the system named no type, which leaves the entries below ' +
+    'readable but says nothing about which vocabulary they are in. ' +
     '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
     'group and everyone else. `owner_user` and `owner_group` are the names of ' +
     'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
@@ -589,9 +704,12 @@ export const shareAccess: ReadOnlyTool = {
     'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
     'created inside it, so its principal does not have the access it appears to ' +
     'have; null is an entry whose inheritance could not be read. This tool ' +
-    'reads access and changes none of it, and it does not report Unix mode ' +
-    'bits, SMB service-level restrictions, or which users are members of a ' +
-    'group named here.',
+    'reads access and changes none of it. It does not report Unix mode bits, ' +
+    'the SMB service\'s own bind addresses, which users are members of a group ' +
+    'named here, or whether a dataset is locked by encryption — so a principal ' +
+    'this reports as having access can still be stopped by something outside ' +
+    'these fields, and this is an upper bound on access rather than a proof of ' +
+    'it.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -615,10 +733,11 @@ export const shareAccess: ReadOnlyTool = {
   mutating: false,
   async handler({ system }, args) {
     const selector = parseSelector(args);
-    // Both protocols are read even when one is asked for, and the unwanted one
-    // is discarded by `selects`. Issuing one query would be cheaper and would
-    // report a share of the other protocol as not existing, which is the one
-    // answer here that a caller would repeat as fact.
+    // Both protocols are read even when one is asked for, and `selects` then
+    // discards the excluded one. The saving from skipping it is one query
+    // against a list of tens of rows, and it would buy a second code path
+    // through the matching and failure handling below — where the cost of a
+    // mistake is a share reported as not existing.
     const attempts = await Promise.all([
       attempt('SMB', () => smbTargets(system)),
       attempt('NFS', () => nfsTargets(system)),
@@ -641,15 +760,22 @@ export const shareAccess: ReadOnlyTool = {
     if (matches.length === 0) throw noMatch(selector, failures);
     if (matches.length > 1) throw ambiguous(selector, matches);
     const target = matches[0];
-    const { acl, error } = await readAcl(system, target.share);
+    // Neither read waits on the other: they are separate gates in front of the
+    // same share and one failing must not cost the other.
+    const [{ acl, error }, shareAcl] = await Promise.all([
+      readAcl(system, target.share),
+      readShareAcl(system, target.share),
+    ]);
     return {
       protocol: target.share.protocol,
       id: target.share.id,
       name: target.share.name,
       path: target.share.path,
       enabled: target.share.enabled,
-      hosts: target.hosts,
-      networks: target.networks,
+      read_only: target.readOnly,
+      nfs: target.nfs,
+      share_acl: shareAcl.entries,
+      share_acl_error: shareAcl.error,
       acl,
       acl_error: error,
       // A protocol that could not be listed is reported even though one share

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -15,6 +15,7 @@ import {
   quotaReport,
   replicationStatus,
   scrubHistory,
+  shareAccess,
   sharesList,
   snapshotsList,
   snapshotTasksList,
@@ -40,7 +41,7 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the sixteen sketch tools', () => {
+  it('registers the seventeen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -57,6 +58,7 @@ describe('createDefaultCatalog', () => {
       'cloudsync_tasks_list',
       'tasks_recent_runs',
       'shares_list',
+      'share_access',
       'snapshots_create',
     ]);
   });
@@ -123,6 +125,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises shares_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('shares_list');
+  });
+
+  it('advertises share_access to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('share_access');
   });
 });
 
@@ -2841,5 +2847,461 @@ describe('shares_list', () => {
     await expect(sharesList.handler(ctx, {})).rejects.toThrow(
       'no share could be listed: SMB: smb is down; NFS: nfs is down',
     );
+  });
+});
+
+describe('share_access', () => {
+  /**
+   * A SystemHandle whose share lists and ACL read answer from one canned map,
+   * or fail. Both seams read that map because this tool uses `query` for the
+   * two share lists and `call` for the ACL, and half of these tests are about
+   * one of the three failing while the others answer.
+   */
+  const fakeAccess = (
+    rows: Partial<Record<string, unknown>>,
+    failures: Partial<Record<string, unknown>> = {},
+  ): { ctx: ToolContext; query: ReturnType<typeof vi.fn>; call: ReturnType<typeof vi.fn> } => {
+    const answer = (method: string) =>
+      method in failures ? throwError(() => failures[method]) : of(rows[method]);
+    const query = vi.fn(answer);
+    const call = vi.fn(answer);
+    const system = { name: 'nas', client: { api: { query, call } } } as unknown as SystemHandle;
+    return { ctx: { system }, query, call };
+  };
+
+  const smbShare = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    name: 'media',
+    path: '/mnt/tank/media',
+    enabled: true,
+    comment: 'Films and music',
+    ...over,
+  });
+
+  const nfsExport = (over: Record<string, unknown> = {}) => ({
+    id: 7,
+    path: '/mnt/tank/backups',
+    enabled: true,
+    comment: 'Nightly backups',
+    hosts: ['10.0.0.5'],
+    networks: ['10.0.0.0/24'],
+    ...over,
+  });
+
+  /** One ACL entry as `filesystem.getacl` reports one, resolved. */
+  const ace = (over: Record<string, unknown> = {}) => ({
+    tag: 'USER',
+    id: 1001,
+    who: 'alice',
+    type: 'ALLOW',
+    perms: { BASIC: 'FULL_CONTROL' },
+    flags: { BASIC: 'INHERIT' },
+    ...over,
+  });
+
+  const aclOf = (over: Record<string, unknown> = {}) => ({
+    path: '/mnt/tank/media',
+    user: 'root',
+    uid: 0,
+    group: 'wheel',
+    gid: 0,
+    acltype: 'NFS4',
+    trivial: false,
+    acl: [ace()],
+    ...over,
+  });
+
+  /** The one entry the default ACL holds, once mapped. */
+  const entry = {
+    tag: 'USER',
+    name: 'alice',
+    id: 1001,
+    access: 'ALLOW',
+    permissions: ['FULL_CONTROL'],
+    children_only: false,
+  };
+
+  /** The default ACL, once mapped. */
+  const acl = {
+    type: 'NFS4',
+    trivial: false,
+    owner_user: 'root',
+    owner_uid: 0,
+    owner_group: 'wheel',
+    owner_gid: 0,
+    entries: [entry],
+  };
+
+  const answered = async (
+    args: Record<string, unknown>,
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeAccess(
+      {
+        ['sharing.smb.query']: [smbShare()],
+        ['sharing.nfs.query']: [nfsExport()],
+        ['filesystem.getacl']: aclOf(),
+        ...rows,
+      },
+      failures,
+    );
+    return (await shareAccess.handler(ctx, args)) as Record<string, unknown>;
+  };
+
+  const entriesOf = (result: Record<string, unknown>): Record<string, unknown>[] =>
+    (result['acl'] as { entries: Record<string, unknown>[] }).entries;
+
+  /** The SMB share's single ACL entry, with only the fields a case is about differing. */
+  const oneEntry = async (over: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const result = await answered(
+      { share: 'media' },
+      { ['filesystem.getacl']: aclOf({ acl: [ace(over)] }) },
+    );
+    return entriesOf(result)[0];
+  };
+
+  it('reports an SMB share by name, with the ACL on its path', async () => {
+    expect(await answered({ share: 'media' })).toEqual({
+      protocol: 'SMB',
+      id: 3,
+      name: 'media',
+      path: '/mnt/tank/media',
+      enabled: true,
+      // SMB has no host or network restriction of its own.
+      hosts: null,
+      networks: null,
+      acl,
+      acl_error: null,
+    });
+  });
+
+  it('reports an NFS export by the path it exports, with who may mount it', async () => {
+    expect(await answered({ share: '/mnt/tank/backups' })).toEqual({
+      protocol: 'NFS',
+      id: 7,
+      // NFS identifies an export by its path and holds no name for one.
+      name: null,
+      path: '/mnt/tank/backups',
+      enabled: true,
+      hosts: ['10.0.0.5'],
+      networks: ['10.0.0.0/24'],
+      acl,
+      acl_error: null,
+    });
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['sharing.smb.query']: [smbShare({ future_field: 'added later' })],
+        ['filesystem.getacl']: aclOf({
+          future_field: 'added later',
+          acl: [ace({ future_field: 'added later' })],
+        }),
+      },
+    );
+    expect(Object.keys(result)).toEqual([
+      'protocol',
+      'id',
+      'name',
+      'path',
+      'enabled',
+      'hosts',
+      'networks',
+      'acl',
+      'acl_error',
+    ]);
+    expect(Object.keys(result['acl'] as object)).toEqual([
+      'type',
+      'trivial',
+      'owner_user',
+      'owner_uid',
+      'owner_group',
+      'owner_gid',
+      'entries',
+    ]);
+    expect(Object.keys(entriesOf(result)[0])).toEqual([
+      'tag',
+      'name',
+      'id',
+      'access',
+      'permissions',
+      'children_only',
+    ]);
+  });
+
+  it('reads the ACL of the path the share serves, resolving ids to names', async () => {
+    const { ctx, call } = fakeAccess({
+      ['sharing.smb.query']: [smbShare()],
+      ['sharing.nfs.query']: [],
+      ['filesystem.getacl']: aclOf(),
+    });
+    await shareAccess.handler(ctx, { share: 'media' });
+    expect(call).toHaveBeenCalledWith('filesystem.getacl', ['/mnt/tank/media', true, true]);
+  });
+
+  it('matches an SMB share by its path as well as by its name', async () => {
+    expect((await answered({ share: '/mnt/tank/media' }))['id']).toBe(3);
+  });
+
+  it('searches only the protocol asked for', async () => {
+    // The path is an SMB share's, so restricting to NFS must find nothing
+    // rather than answering with the SMB share.
+    await expect(answered({ share: '/mnt/tank/media', protocol: 'NFS' })).rejects.toThrow(
+      'no NFS share is named "/mnt/tank/media" or exports that path',
+    );
+  });
+
+  it('treats an omitted or null protocol as both', async () => {
+    for (const protocol of [undefined, null]) {
+      expect((await answered({ share: '/mnt/tank/backups', protocol }))['protocol']).toBe('NFS');
+    }
+  });
+
+  it('errors naming the share when nothing matches, rather than answering empty', async () => {
+    // A share that does not exist and a share nobody can reach are opposite
+    // answers, and an empty result would read as the second.
+    await expect(answered({ share: 'ghost' })).rejects.toThrow(
+      'no share is named "ghost" or exports that path',
+    );
+  });
+
+  it('says so when the share it did not find is one it could not have seen', async () => {
+    await expect(
+      answered({ share: 'ghost' }, {}, { ['sharing.nfs.query']: new Error('nfs is down') }),
+    ).rejects.toThrow(
+      'no share is named "ghost" or exports that path, and it may be one that could not be ' +
+        'looked up: NFS: nfs is down',
+    );
+  });
+
+  it('leaves out a failure of a protocol the caller excluded', async () => {
+    // The NFS list failing says nothing about a question restricted to SMB, so
+    // reporting it would make a complete answer read as a doubtful one.
+    await expect(
+      answered(
+        { share: 'ghost', protocol: 'SMB' },
+        {},
+        { ['sharing.nfs.query']: new Error('nfs is down') },
+      ),
+    ).rejects.toThrow('no SMB share is named "ghost" or exports that path');
+  });
+
+  it('errors rather than guessing when one string matches more than one share', async () => {
+    // A path shared over both protocols grants access differently through each,
+    // so there is no single answer to give.
+    await expect(
+      answered(
+        { share: '/mnt/tank/media' },
+        { ['sharing.nfs.query']: [nfsExport({ path: '/mnt/tank/media' })] },
+      ),
+    ).rejects.toThrow(
+      '"/mnt/tank/media" matches 2 shares — SMB share 3, NFS share 7. Ask again with the ' +
+        'protocol argument, or with the SMB share name rather than its path.',
+    );
+  });
+
+  it('rejects a call that names no share', async () => {
+    for (const missing of [undefined, null, '', 42]) {
+      await expect(answered({ share: missing })).rejects.toThrow('share is required');
+    }
+  });
+
+  it('rejects a protocol that is neither SMB nor NFS', async () => {
+    await expect(answered({ share: 'media', protocol: 'iSCSI' })).rejects.toThrow(
+      'protocol must be "SMB" or "NFS", not "iSCSI"',
+    );
+  });
+
+  it('reports an unrestricted NFS export as empty, which is not nobody', async () => {
+    // No host restriction and no network restriction together mean any machine
+    // that can reach the server may mount it.
+    for (const unrestricted of [[], undefined, null]) {
+      const result = await answered(
+        { share: '/mnt/tank/backups' },
+        {
+          ['sharing.nfs.query']: [
+            nfsExport({ hosts: unrestricted, networks: unrestricted }),
+          ],
+        },
+      );
+      expect(result['hosts']).toEqual([]);
+      expect(result['networks']).toEqual([]);
+    }
+  });
+
+  it('drops a restriction that is not text, and reports an unreadable list as null', async () => {
+    const result = await answered(
+      { share: '/mnt/tank/backups' },
+      { ['sharing.nfs.query']: [nfsExport({ hosts: ['10.0.0.5', '', 42], networks: 'everyone' })] },
+    );
+    expect(result['hosts']).toEqual(['10.0.0.5']);
+    expect(result['networks']).toBeNull();
+  });
+
+  it('states why a share that serves no path here has no ACL', async () => {
+    const external = await answered(
+      { share: 'media' },
+      { ['sharing.smb.query']: [smbShare({ path: 'EXTERNAL' })] },
+    );
+    expect(external['acl']).toBeNull();
+    expect(external['acl_error']).toContain('redirects clients to another server');
+
+    const pathless = await answered(
+      { share: 'media' },
+      { ['sharing.smb.query']: [smbShare({ path: null })] },
+    );
+    expect(pathless['acl']).toBeNull();
+    expect(pathless['acl_error']).toBe(
+      'the system reported no path for this share, so it has no ACL',
+    );
+  });
+
+  it('keeps the share and its restrictions when the ACL read fails', async () => {
+    // Over NFS the host restrictions still answer half the question, and an
+    // unread ACL must never arrive as an empty one.
+    for (const [reason, text] of [
+      [new Error('permission denied'), 'permission denied'],
+      [{ code: 500 }, 'the system reported no reason'],
+    ] as const) {
+      const result = await answered(
+        { share: '/mnt/tank/backups' },
+        {},
+        { ['filesystem.getacl']: reason },
+      );
+      expect(result['hosts']).toEqual(['10.0.0.5']);
+      expect(result['acl']).toBeNull();
+      expect(result['acl_error']).toBe(text);
+    }
+  });
+
+  it('reports a path with ACLs switched off as holding no entry list', async () => {
+    // Access there is governed by the Unix mode bits, which this tool does not
+    // read — an empty list would claim nobody has access.
+    const result = await answered(
+      { share: 'media' },
+      { ['filesystem.getacl']: aclOf({ acltype: 'DISABLED', acl: null, trivial: true }) },
+    );
+    expect(result['acl']).toEqual({
+      type: 'DISABLED',
+      trivial: true,
+      owner_user: 'root',
+      owner_uid: 0,
+      owner_group: 'wheel',
+      owner_gid: 0,
+      entries: null,
+    });
+  });
+
+  it('reports an ACL field it could not read as null', async () => {
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['filesystem.getacl']: aclOf({
+          acltype: '',
+          trivial: 'yes',
+          user: null,
+          uid: 'nobody',
+          group: '',
+          gid: Number.NaN,
+        }),
+      },
+    );
+    expect(result['acl']).toEqual({
+      type: null,
+      trivial: null,
+      owner_user: null,
+      owner_uid: null,
+      owner_group: null,
+      owner_gid: null,
+      entries: [entry],
+    });
+  });
+
+  it('reports an ACL that holds no entry as empty, which the mode bits do not', async () => {
+    expect(
+      (await answered({ share: 'media' }, { ['filesystem.getacl']: aclOf({ acl: [] }) }))['acl'],
+    ).toEqual({ ...acl, entries: [] });
+  });
+
+  it('reports a principal by name where it resolves and by raw id where it does not', async () => {
+    expect(await oneEntry({ who: null })).toMatchObject({ name: null, id: 1001 });
+    expect(await oneEntry({ who: 'alice', id: 1001 })).toMatchObject({ name: 'alice', id: 1001 });
+  });
+
+  it('reports the tags that are their own principal with neither a name nor an id', async () => {
+    // TrueNAS writes -1 on an entry whose tag IS the principal; reporting it
+    // verbatim would put a uid in the result that no account has.
+    expect(await oneEntry({ tag: 'owner@', who: null, id: -1 })).toMatchObject({
+      tag: 'owner@',
+      name: null,
+      id: null,
+    });
+  });
+
+  it('keeps an entry it could not read at all rather than dropping it', async () => {
+    // A shorter list of principals reads as a complete one.
+    const result = await answered(
+      { share: 'media' },
+      { ['filesystem.getacl']: aclOf({ acl: [null, 'nonsense'] }) },
+    );
+    expect(entriesOf(result)).toEqual([
+      { tag: null, name: null, id: null, access: null, permissions: null, children_only: null },
+      { tag: null, name: null, id: null, access: null, permissions: null, children_only: null },
+    ]);
+  });
+
+  it('reports ALLOW and DENY, and anything else as null', async () => {
+    expect((await oneEntry({ type: 'DENY' }))['access']).toBe('DENY');
+    for (const unreadable of [undefined, null, 'PERMIT']) {
+      expect((await oneEntry({ type: unreadable }))['access']).toBeNull();
+    }
+  });
+
+  it('names a preset permission, an NFS4 permission set, and a POSIX one', async () => {
+    expect((await oneEntry({ perms: { BASIC: 'MODIFY' } }))['permissions']).toEqual(['MODIFY']);
+    expect(
+      (await oneEntry({ perms: { READ_DATA: true, WRITE_DATA: false, EXECUTE: true } }))[
+        'permissions'
+      ],
+    ).toEqual(['READ_DATA', 'EXECUTE']);
+    expect(
+      (await oneEntry({ perms: { READ: true, WRITE: false, EXECUTE: true } }))['permissions'],
+    ).toEqual(['READ', 'EXECUTE']);
+  });
+
+  it('keeps an entry naming no permission apart from one whose permissions it could not read', async () => {
+    // The second is not evidence that the entry grants nothing.
+    expect((await oneEntry({ perms: {} }))['permissions']).toEqual([]);
+    for (const unreadable of [null, undefined, 'FULL_CONTROL']) {
+      expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
+    }
+    // A preset is known to grant something, and what it grants is exactly what
+    // an unreadable preset name loses.
+    for (const unreadable of [{ BASIC: '' }, { BASIC: 42 }]) {
+      expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
+    }
+  });
+
+  it('marks an entry that grants nothing on the path itself', async () => {
+    // POSIX says it outright; NFS4 says it among its flags.
+    expect((await oneEntry({ default: true }))['children_only']).toBe(true);
+    expect((await oneEntry({ default: false }))['children_only']).toBe(false);
+    expect((await oneEntry({ flags: { INHERIT_ONLY: true } }))['children_only']).toBe(true);
+    expect((await oneEntry({ flags: { FILE_INHERIT: true } }))['children_only']).toBe(false);
+    expect((await oneEntry({ flags: {} }))['children_only']).toBe(false);
+    // Neither preset flag is inherit-only.
+    for (const preset of ['INHERIT', 'NOINHERIT']) {
+      expect((await oneEntry({ flags: { BASIC: preset } }))['children_only']).toBe(false);
+    }
+  });
+
+  it('reports inheritance it could not read as null, not as access to the path', async () => {
+    for (const unreadable of [undefined, null, 'inherited']) {
+      expect((await oneEntry({ flags: unreadable }))['children_only']).toBeNull();
+    }
+    expect((await oneEntry({ flags: { BASIC: 42 } }))['children_only']).toBeNull();
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3433,12 +3433,22 @@ describe('share_access', () => {
     }
   });
 
-  it('reports a path with ACLs switched off as holding no entry list', async () => {
-    // Access there is governed by the Unix mode bits, which this tool does not
-    // read — an empty list would claim nobody has access.
+  it.each([
+    ['no list at all', null],
+    // The shape every other empty ACL arrives in. Reporting it as an empty
+    // entry list would say this ACL grants nobody anything, when in fact no
+    // ACL is in force and the mode bits this tool does not read decide.
+    ['an empty list', []],
+    // Nothing here is in force, so reporting it would name principals as
+    // having access the path does not give them.
+    ['a list of entries', [ace()]],
+  ])('reports a path with ACLs switched off as holding no entry list, given %s', async (
+    _shape,
+    acl,
+  ) => {
     const result = await answered(
       { share: 'media' },
-      { ['filesystem.getacl']: aclOf({ acltype: 'DISABLED', acl: null, trivial: true }) },
+      { ['filesystem.getacl']: aclOf({ acltype: 'DISABLED', acl, trivial: true }) },
     );
     expect(result['acl']).toEqual({
       type: 'DISABLED',
@@ -3449,6 +3459,16 @@ describe('share_access', () => {
       owner_gid: 0,
       entries: null,
     });
+  });
+
+  it('reports an entry list it could not read as null on a live ACL type', async () => {
+    // The other direction of the same tie: `entries` null is not the exclusive
+    // property of a DISABLED path, so an NFS4 ACL whose list did not arrive as
+    // one reports null rather than an empty list that would read as granting
+    // nobody anything.
+    expect(
+      (await answered({ share: 'media' }, { ['filesystem.getacl']: aclOf({ acl: null }) }))['acl'],
+    ).toEqual({ ...acl, entries: null });
   });
 
   it('reports an ACL field it could not read as null', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -2973,6 +2973,7 @@ describe('share_access', () => {
       networks: null,
       acl,
       acl_error: null,
+      failures: [],
     });
   });
 
@@ -2988,6 +2989,7 @@ describe('share_access', () => {
       networks: ['10.0.0.0/24'],
       acl,
       acl_error: null,
+      failures: [],
     });
   });
 
@@ -3012,6 +3014,7 @@ describe('share_access', () => {
       'networks',
       'acl',
       'acl_error',
+      'failures',
     ]);
     expect(Object.keys(result['acl'] as object)).toEqual([
       'type',
@@ -3087,6 +3090,28 @@ describe('share_access', () => {
         { ['sharing.nfs.query']: new Error('nfs is down') },
       ),
     ).rejects.toThrow('no SMB share is named "ghost" or exports that path');
+  });
+
+  it('says the answer may not be the only one when a protocol could not be searched', async () => {
+    // The check for a second match ran over a list that was never read, so the
+    // error this tool would otherwise raise is one it could not detect —
+    // presenting this as the unique answer would be a guess.
+    const result = await answered(
+      { share: '/mnt/tank/backups' },
+      {},
+      { ['sharing.smb.query']: new Error('smb is down') },
+    );
+    expect(result['protocol']).toBe('NFS');
+    expect(result['failures']).toEqual([{ protocol: 'SMB', error: 'smb is down' }]);
+  });
+
+  it('leaves failures empty when the caller excluded the protocol that failed', async () => {
+    const result = await answered(
+      { share: '/mnt/tank/backups', protocol: 'NFS' },
+      {},
+      { ['sharing.smb.query']: new Error('smb is down') },
+    );
+    expect(result['failures']).toEqual([]);
   });
 
   it('errors rather than guessing when one string matches more than one share', async () => {
@@ -3224,6 +3249,81 @@ describe('share_access', () => {
     expect(
       (await answered({ share: 'media' }, { ['filesystem.getacl']: aclOf({ acl: [] }) }))['acl'],
     ).toEqual({ ...acl, entries: [] });
+  });
+
+  it('maps a POSIX ACL, whose tags and shape are not the NFS4 ones', async () => {
+    // POSIX has its own tag vocabulary, no `type` at all, and a MASK entry
+    // that is a ceiling on the named entries rather than a principal. Every
+    // other ACL fixture here is NFS4, which shares the mapping but not the
+    // shape, so nothing else in this file would notice POSIX arriving wrong.
+    const posix = (over: Record<string, unknown>) => ({
+      perms: { READ: true, WRITE: false, EXECUTE: true },
+      default: false,
+      id: -1,
+      who: null,
+      ...over,
+    });
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['filesystem.getacl']: aclOf({
+          acltype: 'POSIX1E',
+          acl: [
+            posix({ tag: 'USER_OBJ', perms: { READ: true, WRITE: true, EXECUTE: true } }),
+            posix({ tag: 'USER', id: 1001, who: 'alice' }),
+            posix({ tag: 'MASK' }),
+            posix({ tag: 'OTHER', perms: { READ: false, WRITE: false, EXECUTE: false } }),
+            posix({ tag: 'GROUP', id: 2002, who: null, default: true }),
+          ],
+        }),
+      },
+    );
+    expect(entriesOf(result)).toEqual([
+      // The tag is its own principal, so neither a name nor an id is missing.
+      {
+        tag: 'USER_OBJ',
+        name: null,
+        id: null,
+        access: null,
+        permissions: ['READ', 'WRITE', 'EXECUTE'],
+        children_only: false,
+      },
+      {
+        tag: 'USER',
+        name: 'alice',
+        id: 1001,
+        access: null,
+        permissions: ['READ', 'EXECUTE'],
+        children_only: false,
+      },
+      // Not a principal: a ceiling on what the named entries above grant.
+      {
+        tag: 'MASK',
+        name: null,
+        id: null,
+        access: null,
+        permissions: ['READ', 'EXECUTE'],
+        children_only: false,
+      },
+      {
+        tag: 'OTHER',
+        name: null,
+        id: null,
+        access: null,
+        permissions: [],
+        children_only: false,
+      },
+      // A group whose gid resolved to no name, on an entry that grants nothing
+      // on the path itself.
+      {
+        tag: 'GROUP',
+        name: null,
+        id: 2002,
+        access: null,
+        permissions: ['READ', 'EXECUTE'],
+        children_only: true,
+      },
+    ]);
   });
 
   it('reports a principal by name where it resolves and by raw id where it does not', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3614,8 +3614,10 @@ describe('share_access', () => {
       expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
     }
     // A set naming no permission this tool can read at all is unreadable, not
-    // an entry that holds nothing.
-    for (const unreadable of [{}, { READ: 'yes' }]) {
+    // an entry that holds nothing. So is a partly readable one: reporting
+    // ['READ'] for the last of these would answer with a definite, narrower
+    // set of rights than the entry carries.
+    for (const unreadable of [{}, { READ: 'yes' }, { READ: true, WRITE: 'yes' }]) {
       expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
     }
     // A preset is known to grant something, and what it grants is exactly what
@@ -3643,5 +3645,8 @@ describe('share_access', () => {
       expect((await oneEntry({ flags: unreadable }))['children_only']).toBeNull();
     }
     expect((await oneEntry({ flags: { BASIC: 42 } }))['children_only']).toBeNull();
+    // Present but not a boolean: answering false would assert the entry grants
+    // access on the path, which is the claim this field exists to avoid.
+    expect((await oneEntry({ flags: { INHERIT_ONLY: 'yes' } }))['children_only']).toBeNull();
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3157,13 +3157,23 @@ describe('share_access', () => {
     }
   });
 
-  it('drops a restriction that is not text, and reports an unreadable list as null', async () => {
+  it('reports a restriction list it could not read whole as null, never in part', async () => {
+    // Reporting the readable entries alone would answer with a narrower
+    // restriction than the export carries, and dropping all of them would
+    // answer `[]` — which here means the opposite, that nothing is restricted.
     const result = await answered(
       { share: '/mnt/tank/backups' },
       { ['sharing.nfs.query']: [nfsExport({ hosts: ['10.0.0.5', '', 42], networks: 'everyone' })] },
     );
-    expect(result['hosts']).toEqual(['10.0.0.5']);
+    expect(result['hosts']).toBeNull();
     expect(result['networks']).toBeNull();
+
+    const allDropped = await answered(
+      { share: '/mnt/tank/backups' },
+      { ['sharing.nfs.query']: [nfsExport({ hosts: [42], networks: [''] })] },
+    );
+    expect(allDropped['hosts']).toBeNull();
+    expect(allDropped['networks']).toBeNull();
   });
 
   it('states why a share that serves no path here has no ACL', async () => {
@@ -3373,9 +3383,18 @@ describe('share_access', () => {
   });
 
   it('keeps an entry naming no permission apart from one whose permissions it could not read', async () => {
-    // The second is not evidence that the entry grants nothing.
-    expect((await oneEntry({ perms: {} }))['permissions']).toEqual([]);
+    // A POSIX `OTHER` entry really does carry an all-false permission set, and
+    // that is what an empty list means. The second is not evidence that the
+    // entry grants nothing.
+    expect(
+      (await oneEntry({ perms: { READ: false, WRITE: false, EXECUTE: false } }))['permissions'],
+    ).toEqual([]);
     for (const unreadable of [null, undefined, 'FULL_CONTROL']) {
+      expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
+    }
+    // A set naming no permission this tool can read at all is unreadable, not
+    // an entry that holds nothing.
+    for (const unreadable of [{}, { READ: 'yes' }]) {
       expect((await oneEntry({ perms: unreadable }))['permissions']).toBeNull();
     }
     // A preset is known to grant something, and what it grants is exactly what

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -2876,6 +2876,9 @@ describe('share_access', () => {
     enabled: true,
     comment: 'Films and music',
     readonly: false,
+    // The host rules live under `options`, whose other keys differ by what the
+    // share is for and are not read here.
+    options: { purpose: 'LEGACY_SHARE', hostsallow: ['10.0.0.5'], hostsdeny: ['ALL'] },
     ...over,
   });
 
@@ -3014,7 +3017,8 @@ describe('share_access', () => {
       path: '/mnt/tank/media',
       enabled: true,
       read_only: false,
-      // SMB has no export restrictions and no id mapping.
+      smb: { hosts_allow: ['10.0.0.5'], hosts_deny: ['ALL'] },
+      // An NFS export's restrictions and id mapping are a different protocol's.
       nfs: null,
       share_acl: shareAcl,
       share_acl_error: null,
@@ -3033,6 +3037,9 @@ describe('share_access', () => {
       path: '/mnt/tank/backups',
       enabled: true,
       read_only: false,
+      // An NFS export is not served by the SMB service, so it has no host
+      // rules of that kind rather than unread ones.
+      smb: null,
       nfs,
       // NFS has no share-level ACL, so neither half of that answer is present.
       share_acl: null,
@@ -3178,7 +3185,14 @@ describe('share_access', () => {
     const result = await answered(
       { share: 'media' },
       {
-        ['sharing.smb.query']: [smbShare({ future_field: 'added later' })],
+        ['sharing.smb.query']: [
+          smbShare({
+            future_field: 'added later',
+            // `options` is read key by key, so a later release adding one
+            // there must not reach the caller either.
+            options: { purpose: 'LEGACY_SHARE', hostsallow: [], future_field: 'added later' },
+          }),
+        ],
         ['filesystem.getacl']: aclOf({
           future_field: 'added later',
           acl: [ace({ future_field: 'added later' })],
@@ -3196,6 +3210,7 @@ describe('share_access', () => {
       'path',
       'enabled',
       'read_only',
+      'smb',
       'nfs',
       'share_acl',
       'share_acl_error',
@@ -3203,6 +3218,7 @@ describe('share_access', () => {
       'acl_error',
       'failures',
     ]);
+    expect(Object.keys(result['smb'] as object)).toEqual(['hosts_allow', 'hosts_deny']);
     expect(Object.keys((result['share_acl'] as object[])[0])).toEqual([
       'name',
       'id',
@@ -3395,6 +3411,57 @@ describe('share_access', () => {
       { ['sharing.nfs.query']: [nfsExport({ hosts: [42], networks: [''] })] },
     );
     expect(allDropped['nfs']).toMatchObject({ hosts: null, networks: null });
+  });
+
+  it('reports the host rules an SMB share carries, which run before both ACLs', async () => {
+    // A share whose ACLs grant everyone is still reached by nobody the SMB
+    // service turns away here, so an answer without these overstates access.
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['sharing.smb.query']: [
+          smbShare({
+            options: {
+              purpose: 'LEGACY_SHARE',
+              hostsallow: ['10.0.0.0/24', 'trusted.example'],
+              hostsdeny: [],
+            },
+          }),
+        ],
+      },
+    );
+    expect(result['smb']).toEqual({
+      hosts_allow: ['10.0.0.0/24', 'trusted.example'],
+      // Empty is a rule the share does not have, and turns nobody away.
+      hosts_deny: [],
+    });
+  });
+
+  it('does not read an absent SMB host rule as a share that turns nobody away', async () => {
+    // The keys are optional, and every option shape but the legacy one omits
+    // them, so their absence is a rule this tool could not read rather than
+    // one the share does not have. `[]` would say the opposite.
+    for (const options of [undefined, null, 'DEFAULT_SHARE', { purpose: 'DEFAULT_SHARE' }]) {
+      const result = await answered(
+        { share: 'media' },
+        { ['sharing.smb.query']: [smbShare({ options })] },
+      );
+      expect(result['smb']).toEqual({ hosts_allow: null, hosts_deny: null });
+    }
+  });
+
+  it('reports an SMB host rule it could not read whole as null, never in part', async () => {
+    // Same reading as the NFS lists above: a rule reported in part is a
+    // different rule, and here a narrower one lets machines in.
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['sharing.smb.query']: [
+          smbShare({ options: { hostsallow: ['10.0.0.5', 42], hostsdeny: 'ALL' } }),
+        ],
+      },
+    );
+    expect(result['smb']).toEqual({ hosts_allow: null, hosts_deny: null });
   });
 
   it('states why a share that serves no path here has no ACL', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3275,6 +3275,22 @@ describe('share_access', () => {
     );
   });
 
+  it('names both protocols when neither share list could be read', async () => {
+    await expect(
+      answered(
+        { share: 'ghost' },
+        {},
+        {
+          ['sharing.smb.query']: new Error('smb is down'),
+          ['sharing.nfs.query']: new Error('nfs is down'),
+        },
+      ),
+    ).rejects.toThrow(
+      'no share is named "ghost" or exports that path, and it may be one that could not be ' +
+        'looked up: SMB: smb is down; NFS: nfs is down',
+    );
+  });
+
   it('leaves out a failure of a protocol the caller excluded', async () => {
     // The NFS list failing says nothing about a question restricted to SMB, so
     // reporting it would make a complete answer read as a doubtful one.
@@ -3338,16 +3354,23 @@ describe('share_access', () => {
   it('reports an unrestricted NFS export as empty, which is not nobody', async () => {
     // No host restriction and no network restriction together mean any machine
     // that can reach the server may mount it.
-    for (const unrestricted of [[], undefined, null]) {
+    const result = await answered(
+      { share: '/mnt/tank/backups' },
+      { ['sharing.nfs.query']: [nfsExport({ hosts: [], networks: [] })] },
+    );
+    expect(result['nfs']).toMatchObject({ hosts: [], networks: [] });
+  });
+
+  it('does not read an absent restriction as an unrestricted export', async () => {
+    // The field is optional on the client's own type, so its absence is a
+    // middleware that did not report the restriction rather than an export
+    // that has none — and `[]` would claim any machine may mount it.
+    for (const absent of [undefined, null]) {
       const result = await answered(
         { share: '/mnt/tank/backups' },
-        {
-          ['sharing.nfs.query']: [
-            nfsExport({ hosts: unrestricted, networks: unrestricted }),
-          ],
-        },
+        { ['sharing.nfs.query']: [nfsExport({ hosts: absent, networks: absent })] },
       );
-      expect(result['nfs']).toMatchObject({ hosts: [], networks: [] });
+      expect(result['nfs']).toMatchObject({ hosts: null, networks: null });
     }
   });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -2875,6 +2875,7 @@ describe('share_access', () => {
     path: '/mnt/tank/media',
     enabled: true,
     comment: 'Films and music',
+    readonly: false,
     ...over,
   });
 
@@ -2883,10 +2884,53 @@ describe('share_access', () => {
     path: '/mnt/tank/backups',
     enabled: true,
     comment: 'Nightly backups',
+    ro: false,
     hosts: ['10.0.0.5'],
     networks: ['10.0.0.0/24'],
+    mapall_user: null,
+    mapall_group: null,
+    maproot_user: null,
+    maproot_group: null,
     ...over,
   });
+
+  /** One entry of an SMB share-level ACL as `sharing.smb.getacl` reports one. */
+  const shareAce = (over: Record<string, unknown> = {}) => ({
+    ae_who_str: 'alice',
+    ae_who_id: { id_type: 'USER', id: 1001 },
+    ae_who_sid: 'S-1-5-21-1-1001',
+    ae_type: 'ALLOWED',
+    ae_perm: 'FULL',
+    ...over,
+  });
+
+  const shareAclOf = (over: Record<string, unknown> = {}) => ({
+    share_name: 'media',
+    share_acl: [shareAce()],
+    ...over,
+  });
+
+  /** The default NFS export's own say in who may reach it, once mapped. */
+  const nfs = {
+    hosts: ['10.0.0.5'],
+    networks: ['10.0.0.0/24'],
+    mapall_user: null,
+    mapall_group: null,
+    maproot_user: null,
+    maproot_group: null,
+  };
+
+  /** The default SMB share ACL, once mapped. */
+  const shareAcl = [
+    {
+      name: 'alice',
+      id: 1001,
+      kind: 'USER',
+      sid: 'S-1-5-21-1-1001',
+      access: 'ALLOWED',
+      permission: 'FULL',
+    },
+  ];
 
   /** One ACL entry as `filesystem.getacl` reports one, resolved. */
   const ace = (over: Record<string, unknown> = {}) => ({
@@ -2942,6 +2986,7 @@ describe('share_access', () => {
         ['sharing.smb.query']: [smbShare()],
         ['sharing.nfs.query']: [nfsExport()],
         ['filesystem.getacl']: aclOf(),
+        ['sharing.smb.getacl']: shareAclOf(),
         ...rows,
       },
       failures,
@@ -2961,16 +3006,18 @@ describe('share_access', () => {
     return entriesOf(result)[0];
   };
 
-  it('reports an SMB share by name, with the ACL on its path', async () => {
+  it('reports an SMB share by name, with both gates in front of its path', async () => {
     expect(await answered({ share: 'media' })).toEqual({
       protocol: 'SMB',
       id: 3,
       name: 'media',
       path: '/mnt/tank/media',
       enabled: true,
-      // SMB has no host or network restriction of its own.
-      hosts: null,
-      networks: null,
+      read_only: false,
+      // SMB has no export restrictions and no id mapping.
+      nfs: null,
+      share_acl: shareAcl,
+      share_acl_error: null,
       acl,
       acl_error: null,
       failures: [],
@@ -2985,12 +3032,146 @@ describe('share_access', () => {
       name: null,
       path: '/mnt/tank/backups',
       enabled: true,
-      hosts: ['10.0.0.5'],
-      networks: ['10.0.0.0/24'],
+      read_only: false,
+      nfs,
+      // NFS has no share-level ACL, so neither half of that answer is present.
+      share_acl: null,
+      share_acl_error: null,
       acl,
       acl_error: null,
       failures: [],
     });
+  });
+
+  it('does not read the SMB share ACL for an NFS export', async () => {
+    const { ctx, call } = fakeAccess({
+      ['sharing.smb.query']: [],
+      ['sharing.nfs.query']: [nfsExport()],
+      ['filesystem.getacl']: aclOf(),
+    });
+    await shareAccess.handler(ctx, { share: '/mnt/tank/backups' });
+    expect(call).not.toHaveBeenCalledWith('sharing.smb.getacl', expect.anything());
+  });
+
+  it('reads the SMB share ACL by the share name', async () => {
+    const { ctx, call } = fakeAccess({
+      ['sharing.smb.query']: [smbShare()],
+      ['sharing.nfs.query']: [],
+      ['filesystem.getacl']: aclOf(),
+      ['sharing.smb.getacl']: shareAclOf(),
+    });
+    await shareAccess.handler(ctx, { share: 'media' });
+    expect(call).toHaveBeenCalledWith('sharing.smb.getacl', [{ share_name: 'media' }]);
+  });
+
+  it('reports a read-only share as read-only, and an unreadable switch as null', async () => {
+    // It caps every write permission reported anywhere else in the answer.
+    expect((await answered({ share: 'media' }, { ['sharing.smb.query']: [smbShare({ readonly: true })] }))['read_only']).toBe(true);
+    expect(
+      (
+        await answered(
+          { share: '/mnt/tank/backups' },
+          { ['sharing.nfs.query']: [nfsExport({ ro: true })] },
+        )
+      )['read_only'],
+    ).toBe(true);
+    for (const unreadable of [undefined, null]) {
+      const result = await answered(
+        { share: 'media' },
+        { ['sharing.smb.query']: [smbShare({ readonly: unreadable })] },
+      );
+      expect(result['read_only']).toBeNull();
+    }
+  });
+
+  it('reports the mapping that replaces who arrives over an NFS export', async () => {
+    // The ACL then answers for that one account rather than for whoever
+    // connected, so an answer that omitted this would be about the wrong user.
+    const result = await answered(
+      { share: '/mnt/tank/backups' },
+      {
+        ['sharing.nfs.query']: [
+          nfsExport({ mapall_user: 'nobody', mapall_group: '', maproot_user: 'root' }),
+        ],
+      },
+    );
+    expect(result['nfs']).toEqual({
+      ...nfs,
+      mapall_user: 'nobody',
+      mapall_group: null,
+      maproot_user: 'root',
+      maproot_group: null,
+    });
+  });
+
+  it('names a share ACL principal every way the system had, and keeps one it did not', async () => {
+    const result = await answered(
+      { share: 'media' },
+      {
+        ['sharing.smb.getacl']: shareAclOf({
+          share_acl: [
+            shareAce({ ae_who_str: null, ae_who_id: null, ae_type: 'DENIED', ae_perm: 'READ' }),
+            shareAce({ ae_who_id: { id_type: 'GROUP', id: 2002 }, ae_who_sid: null }),
+            // Neither an object nor an entry with anything readable in it.
+            null,
+            shareAce({ ae_who_str: '', ae_who_id: { id_type: 'ALIAS', id: 'x' }, ae_who_sid: '', ae_type: 'MAYBE', ae_perm: '' }),
+          ],
+        }),
+      },
+    );
+    expect(result['share_acl']).toEqual([
+      {
+        name: null,
+        id: null,
+        kind: null,
+        sid: 'S-1-5-21-1-1001',
+        access: 'DENIED',
+        permission: 'READ',
+      },
+      { name: 'alice', id: 2002, kind: 'GROUP', sid: null, access: 'ALLOWED', permission: 'FULL' },
+      { name: null, id: null, kind: null, sid: null, access: null, permission: null },
+      { name: null, id: null, kind: null, sid: null, access: null, permission: null },
+    ]);
+  });
+
+  it('does not present an unread share ACL as a share nobody may reach', async () => {
+    // An empty share-level ACL would read as everyone denied, which is the
+    // opposite of a share that carries no share-level ACL at all.
+    const missing = await answered(
+      { share: 'media' },
+      { ['sharing.smb.getacl']: shareAclOf({ share_acl: undefined }) },
+    );
+    expect(missing['share_acl']).toBeNull();
+    expect(missing['share_acl_error']).toBe(
+      'the system reported no share-level ACL, so what it allows is not known here',
+    );
+
+    const failed = await answered(
+      { share: 'media' },
+      {},
+      { ['sharing.smb.getacl']: new Error('smb is down') },
+    );
+    expect(failed['share_acl']).toBeNull();
+    expect(failed['share_acl_error']).toBe('smb is down');
+    // The rest of the answer survives it.
+    expect(failed['acl']).toEqual(acl);
+
+    const nameless = await answered(
+      { share: '/mnt/tank/media' },
+      { ['sharing.smb.query']: [smbShare({ name: null })] },
+    );
+    expect(nameless['share_acl_error']).toBe(
+      'the system reported no name for this share, and the share ACL is read by name',
+    );
+  });
+
+  it('reports a share ACL that allows nobody as empty, which is not unread', async () => {
+    const result = await answered(
+      { share: 'media' },
+      { ['sharing.smb.getacl']: shareAclOf({ share_acl: [] }) },
+    );
+    expect(result['share_acl']).toEqual([]);
+    expect(result['share_acl_error']).toBeNull();
   });
 
   it('surfaces no field a later release adds', async () => {
@@ -3002,6 +3183,10 @@ describe('share_access', () => {
           future_field: 'added later',
           acl: [ace({ future_field: 'added later' })],
         }),
+        ['sharing.smb.getacl']: shareAclOf({
+          future_field: 'added later',
+          share_acl: [shareAce({ future_field: 'added later' })],
+        }),
       },
     );
     expect(Object.keys(result)).toEqual([
@@ -3010,11 +3195,21 @@ describe('share_access', () => {
       'name',
       'path',
       'enabled',
-      'hosts',
-      'networks',
+      'read_only',
+      'nfs',
+      'share_acl',
+      'share_acl_error',
       'acl',
       'acl_error',
       'failures',
+    ]);
+    expect(Object.keys((result['share_acl'] as object[])[0])).toEqual([
+      'name',
+      'id',
+      'kind',
+      'sid',
+      'access',
+      'permission',
     ]);
     expect(Object.keys(result['acl'] as object)).toEqual([
       'type',
@@ -3152,8 +3347,7 @@ describe('share_access', () => {
           ],
         },
       );
-      expect(result['hosts']).toEqual([]);
-      expect(result['networks']).toEqual([]);
+      expect(result['nfs']).toMatchObject({ hosts: [], networks: [] });
     }
   });
 
@@ -3165,15 +3359,13 @@ describe('share_access', () => {
       { share: '/mnt/tank/backups' },
       { ['sharing.nfs.query']: [nfsExport({ hosts: ['10.0.0.5', '', 42], networks: 'everyone' })] },
     );
-    expect(result['hosts']).toBeNull();
-    expect(result['networks']).toBeNull();
+    expect(result['nfs']).toMatchObject({ hosts: null, networks: null });
 
     const allDropped = await answered(
       { share: '/mnt/tank/backups' },
       { ['sharing.nfs.query']: [nfsExport({ hosts: [42], networks: [''] })] },
     );
-    expect(allDropped['hosts']).toBeNull();
-    expect(allDropped['networks']).toBeNull();
+    expect(allDropped['nfs']).toMatchObject({ hosts: null, networks: null });
   });
 
   it('states why a share that serves no path here has no ACL', async () => {
@@ -3206,7 +3398,7 @@ describe('share_access', () => {
         {},
         { ['filesystem.getacl']: reason },
       );
-      expect(result['hosts']).toEqual(['10.0.0.5']);
+      expect(result['nfs']).toEqual(nfs);
       expect(result['acl']).toBeNull();
       expect(result['acl_error']).toBe(text);
     }

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3339,6 +3339,12 @@ describe('share_access', () => {
     );
   });
 
+  it('resolves a two-share match by the protocol the error advertises', async () => {
+    const rows = { ['sharing.nfs.query']: [nfsExport({ path: '/mnt/tank/media' })] };
+    expect((await answered({ share: '/mnt/tank/media', protocol: 'SMB' }, rows))['id']).toBe(3);
+    expect((await answered({ share: '/mnt/tank/media', protocol: 'NFS' }, rows))['id']).toBe(7);
+  });
+
   it('rejects a call that names no share', async () => {
     for (const missing of [undefined, null, '', 42]) {
       await expect(answered({ share: missing })).rejects.toThrow('share is required');


### PR DESCRIPTION
Adds `share_access`, a read-only tool answering "who can reach this share, and with what rights" in one call.

Fixes #25

## What it does

Names a share by its SMB share name or — since an NFS export has no name — by the path it exports. Either string works for either protocol, and `protocol` narrows the search.

A string matching **no** share is an error naming it, never an empty result: a share that does not exist and a share nobody can reach are opposite answers. A string matching **more than one** is also an error listing what it matched, because one path shared over both protocols grants access two different ways and there is no single answer to give.

## Which sources it reads, and why

The ticket asked for this to be confirmed and reported here.

| Source | Confirmed | What it contributes |
|---|---|---|
| `sharing.smb.query` | Yes — present in the targeted surface and already used by `shares_list` | share identity, `readonly`, and the host rules under `options` |
| `sharing.nfs.query` | Yes | export identity, `ro`, `hosts`, `networks`, the `mapall`/`maproot` fields |
| `filesystem.getacl` | Yes — `[path, simplified, resolve_ids]`, answering `NFS4ACLResult \| POSIXACLResult \| DISABLED_ACLResult` | the ACL on the shared path |
| `sharing.smb.getacl` | Yes — `[{ share_name }]`, answering `SMBShareAcl` | the SMB **share-level** ACL |

**The ticket's design note that `sharing.smb.query` is "not in the pinned client's `TrueNasEndpoint` enum" is correct but not a problem.** `query` is typed off the *call* directory (`QueryMethod<D['call']>`), not that enum, and the method resolves and typechecks. `filesystem.getacl` is likewise reached through `call`, not `query`.

**Three sources beyond the ticket's sketch, all because leaving them out made the tool overstate access:**

- **`sharing.smb.getacl`.** SMB applies a share-level ACL *in front of* the filesystem one, and it can DENY what the path grants — so a principal reported with `FULL_CONTROL` could be refused at the door. Reported as `share_acl`; null on NFS, which has no such layer.
- **The SMB share's `hostsallow`/`hostsdeny`**, which the SMB service applies before either ACL is consulted. They live under the share row's `options`, whose shape differs by what the share is for: the pinned client declares them on `LegacyOpt` alone, while every input variant accepts them. Reported as `smb`; null on NFS, which that service does not serve. See the round-9 note below — an earlier round of this PR asserted these did not exist, and that was wrong.
- **The NFS export's own `ro`, `mapall_user`, `mapall_group`, `maproot_user`, `maproot_group`**, which were already on the row being fetched. `ro` caps every write permission whatever the ACL says, and a `mapall` replaces the identity of every incoming request *before* the ACL is consulted — so the ACL then answers for an account that is not the one who connected.

**One source deliberately not read.** With `acltype: DISABLED` the path's access is governed by the Unix mode bits, which this tool does not read; `entries` is null there and the description says why, rather than implying an empty answer means nobody has access. `filesystem.stat` would give the mode bits, and that is a separate question from an ACL.

## The response, and the distinctions it keeps

Access is **the narrowest of everything reported**, not any one field, and the description says so — a principal reaches the share only if every layer reporting on it allows them.

Every nullable field distinguishes *unreadable* from *the system said none*, because collapsing either direction turns a gap into a false claim:

- `hosts`/`networks` on NFS and `hosts_allow`/`hosts_deny` on SMB are **empty when there is no rule of that kind** — any machine may reach the share, the opposite of nobody. Null means unreadable, and is not evidence either way. A list is reported whole or not at all, since a restriction reported in part is a different restriction. The SMB pair reads null on a share whose `options` are absent, which is most non-legacy shares: that says this tool could not see the gate, not that the gate is open.
- `entries` is **null on a `DISABLED` path whatever list arrives beside it**, since no ACL is in force there, and null under a live type is a list that could not be read. `[]` is an ACL that holds no entry.
- `share_acl` **empty means a share-level ACL that allows nobody**; a share carrying no such ACL reports null with a reason in `share_acl_error`.
- `permissions` `[]` is an entry naming permissions and holding none (a real POSIX `OTHER` entry); null is one that could not be read, and is not evidence it grants nothing.
- `children_only` marks an entry that grants nothing on the path itself and exists to be inherited — POSIX `default`, NFS4 `INHERIT_ONLY`. Reporting it matters because such an entry looks exactly like access and is not.
- A principal that resolved to no name is reported by raw id, and an entry the tool could not read at all is reported empty rather than dropped — a shorter list of principals reads as a complete one.
- Both ACL tag vocabularies are described. POSIX uses `USER_OBJ`, `GROUP_OBJ`, `OTHER` and `MASK`, and `MASK` is not a principal but a **ceiling**: a POSIX `USER`, `GROUP` or `GROUP_OBJ` entry grants only what it and the mask both name, so an entry can appear to hold more than it does.

`failures` reports a protocol whose share list could not be read. While it is non-empty **the answer may not be the only one** — the check for a second match ran over a list nobody read, so the ambiguity error is one the tool could not detect.

## Refactor

`smbShares`/`nfsShares` are gone. `smbTargets`/`nfsTargets` are the one fetch-and-map per protocol and `shares_list` takes the `share` half of them, so the two tools cannot drift in how they name a share. **`shares_list`'s output is unchanged** — same mapping, same fan-out, same failure handling.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test` (280 pass), `yarn test:coverage` and `yarn build` all pass locally. `src/tools/shares.ts` is at 100% statements and 100% branches; the global floors (branches 96 / statements 97) are met at 99.03 / 98.89. Every step in `.github/workflows/ci.yml` was run; none needed anything this machine does not have.

## About the review that produced this

**Nine local review rounds.** Six ran the project's own shared reviewer — the same rubric and threshold as the required check — and returned findings each time; three, including **the final clean round**, timed out at 420s and fell back to a subagent applying the same rubric.

**So the clean result is the weaker kind and should be read as such.** A clean round from the shared reviewer would be a strong prediction that the required check passes; this one is a different reader applying the same rubric, and the check on this PR is the first time the real reviewer will see the finished diff.

The rounds found, and this fixed: a sibling protocol's read failure silently discarded once one share matched (HIGH); the filesystem ACL described as the whole answer over SMB; the NFS `ro`/`mapall` fields fetched and dropped; an absent restriction list read as unrestricted; a partly-unreadable permission set reported as a definite narrower one; an unreadable `INHERIT_ONLY` reported as granting access; typed responses cast to `Record<string, unknown>` so a client rename would answer nulls instead of failing the build; several description clauses asserting distinctions the mapping did not deliver; and the two below.

**Round 8 — `entries` was tied to the shape of `acl`, not to the type that decides it.** The description promised `entries` is null exactly on a path whose ACLs are switched off, while the mapping never read `acltype`: a `DISABLED` path answering with the `[]` every other empty ACL arrives in reported an entry list that holds nobody, which by this tool's own vocabulary reads as an ACL granting nobody anything. The mapping now keys on `acltype`, the description states the other direction it had left undefined, and the test that hand-fed `acltype: 'DISABLED'` together with `acl: null` — certifying the contract without exercising it — now runs over all three shapes a `DISABLED` path could answer with, plus a live type whose list did not arrive.

**Round 9 corrected an earlier round of this PR, which was wrong.** Round 5 rated MEDIUM that SMB `hostsallow`/`hostsdeny` are dropped; this description then answered that they are not in the targeted surface and that reading one would be `TS2339`. **That answer was false.** They moved under `options`: `SharingSMBEntry$2.options` is a union whose `LegacyOpt` member declares both keys, and every input variant accepts them, so the SMB service's own host gate was being dropped from a tool whose entire question is who can reach a share. It is now read and reported as `smb`, with the same whole-or-nothing rule as the NFS lists beside it, and the file comment that made the false claim is corrected rather than softened.

## LOW findings not acted on

Left deliberately, since each is a new diff and a new diff is another review round:

- **The description is large (~9 kB) and is sent on every tool listing**, about three times the next-largest in the catalog. A real cost, and the honest trade: most of its length is the null-versus-empty rules above, and every attempt to compress one of them in these rounds is what produced a MEDIUM. Worth revisiting as its own change, with the field semantics settled first.
- **`parseSelector` reports a wrongly-typed `share` (e.g. `42`) as "share is required"**, where the `protocol` check names the bad value.
- **The ambiguity error advises `protocol` or the SMB name**, neither of which separates two shares of the same protocol on one path; there is no id argument to select by, and no test covers a same-protocol double match.
- **The share rows' `locked` and the NFS `security` (`SYS`/`KRB5`/…) are fetched but not reported.** Both bear on access — `locked` is an encryption-locked dataset, which the description lists as something this tool does not report while the field is in hand.
- **`share_acl`'s `permission` is documented as `FULL`/`CHANGE`/`READ`/`CUSTOM`**, and the client's `ae_perm` has no `CUSTOM` member.
- **`permissionNames`' JSDoc says a set is unreadable only when every value is non-boolean**, where the code and its tests reject a set in which any value is.
- **The two-protocol `attempt(...)` fan-out is duplicated in both handlers**; a shared helper would remove a drift point the file argues against elsewhere.

The `locked`/`security` gap and the duplicated fan-out are the ones worth a follow-up ticket rather than a passing mention.
