### PR TITLE
feat(tools): add nvmeof_list, NVMe-oF subsystems and their namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
-  `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`.
+  `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
+  `nvmeof_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,5 +77,6 @@ export {
   sharesList,
   shareAccess,
   iscsiList,
+  nvmeofList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -409,20 +409,68 @@ interface Namespace {
 }
 
 /**
- * The namespaces of each subsystem, indexed by subsystem id.
+ * One row of a secondary read, with the subsystem its record named.
  *
- * A namespace names its subsystem with the whole subsystem record nested inside
- * it rather than with a bare id, so the join is on a value read out of that
- * untyped record. One the system did not identify that way has nothing to be
- * filed under and is left out — the alternative is filing it under a subsystem
- * it may not belong to, which would report a namespace on the wrong device.
+ * Both reads name their subsystem with the whole subsystem record nested inside
+ * the row rather than with a bare id, so the join is on a value read out of that
+ * untyped record. `subsystem_id` is that value and `subsystem` the name beside
+ * it, kept because it is all there is left to report the row by where the id is
+ * missing or answers to no subsystem in the listing.
+ *
+ * `value` is what the row says, and is null for a row that carries nothing
+ * statable even where its subsystem is known — a host grant with no NQN.
  */
-async function readNamespaces(system: SystemHandle): Promise<Map<number, Namespace[]>> {
+interface Claim<T> {
+  value: T;
+  subsystem_id: number | null;
+  subsystem: string | null;
+}
+
+/** Rows filed under the subsystem each named, and the ones that could not be. */
+interface Attribution<T> {
+  bySubsystem: Map<number, T[]>;
+  unattributed: Claim<T>[];
+}
+
+/**
+ * The rows of one read, each filed under the subsystem it named where that can
+ * be done and set aside where it cannot.
+ *
+ * A row is set aside where its record named no readable subsystem id, where
+ * that id answers to no subsystem in the listing, or where the row itself says
+ * nothing statable. Filing any of those under a subsystem anyway would report a
+ * namespace on the wrong device, or a host as allowed onto one it is not — but
+ * dropping them outright is the failure this exists to prevent: a subsystem's
+ * empty list would then say the rows are not there, when what is true is that
+ * they could not be placed. The caller reports them beside the listing instead.
+ */
+function attribute<T>(rows: Claim<T>[], listed: Set<number>): Attribution<T> {
+  const bySubsystem = new Map<number, T[]>();
+  const unattributed: Claim<T>[] = [];
+  for (const row of rows) {
+    const id = row.subsystem_id;
+    if (row.value === null || id === null || !listed.has(id)) {
+      unattributed.push(row);
+      continue;
+    }
+    const filed = bySubsystem.get(id);
+    if (filed === undefined) bySubsystem.set(id, [row.value]);
+    else filed.push(row.value);
+  }
+  return { bySubsystem, unattributed };
+}
+
+/**
+ * Every namespace the system reported, each with the subsystem its row named.
+ *
+ * The rows are not grouped here because grouping needs the subsystem listing to
+ * decide what a named id attributes to, and this read is issued before that
+ * listing has arrived.
+ */
+async function readNamespaces(system: SystemHandle): Promise<Claim<Namespace>[]> {
   const namespaces = await firstValueFrom(system.client.api.query('nvmet.namespace.query'));
-  const bySubsystem = new Map<number, Namespace[]>();
+  const claims: Claim<Namespace>[] = [];
   for (const namespace of namespaces) {
-    const subsystem = numberOrNull(namespace.subsys['id']);
-    if (subsystem === null) continue;
     const row: Namespace = {
       id: numberOrNull(namespace.id),
       // The identifier an initiator addresses the namespace by, which is not
@@ -440,36 +488,34 @@ async function readNamespaces(system: SystemHandle): Promise<Map<number, Namespa
       enabled: booleanOrNull(namespace.enabled),
       locked: booleanOrNull(namespace.locked),
     };
-    const mapped = bySubsystem.get(subsystem);
-    if (mapped === undefined) bySubsystem.set(subsystem, [row]);
-    else mapped.push(row);
+    claims.push({
+      value: row,
+      subsystem_id: numberOrNull(namespace.subsys['id']),
+      subsystem: textOrNull(namespace.subsys['name']),
+    });
   }
-  return bySubsystem;
+  return claims;
 }
 
 /**
- * The NQNs of the hosts allowed onto each subsystem, indexed by subsystem id.
+ * The NQN of every host grant the system reported, each with the subsystem its
+ * row named.
  *
  * `nvmet.host_subsys.query` is the join table and it embeds both sides whole:
  * the host record it points at carries the NQN, so the hosts do not have to be
  * read separately and no row can point at a host that was not returned.
+ *
+ * A grant whose host carries no NQN is not the host any initiator connects as,
+ * so its `value` is null: it cannot go in a list whose whole content is names,
+ * and `attribute` sets it aside rather than putting a nameless entry there.
  */
-async function readHosts(system: SystemHandle): Promise<Map<number, string[]>> {
+async function readHosts(system: SystemHandle): Promise<Claim<string | null>[]> {
   const joins = await firstValueFrom(system.client.api.query('nvmet.host_subsys.query'));
-  const bySubsystem = new Map<number, string[]>();
-  for (const join of joins) {
-    const subsystem = numberOrNull(join.subsys['id']);
-    const hostnqn = textOrNull(join.host.hostnqn);
-    // A host with no NQN cannot be the host any initiator connects as, and one
-    // with no subsystem has nothing to be allowed onto; either way the row
-    // grants nothing that can be stated, and stating it anyway would put a
-    // nameless entry in a list whose whole content is names.
-    if (subsystem === null || hostnqn === null) continue;
-    const allowed = bySubsystem.get(subsystem);
-    if (allowed === undefined) bySubsystem.set(subsystem, [hostnqn]);
-    else allowed.push(hostnqn);
-  }
-  return bySubsystem;
+  return joins.map((join) => ({
+    value: textOrNull(join.host.hostnqn),
+    subsystem_id: numberOrNull(join.subsys['id']),
+    subsystem: textOrNull(join.subsys['name']),
+  }));
 }
 
 /** The JSON-RPC code for a method the server does not have. */
@@ -574,14 +620,26 @@ export const nvmeofList: ReadOnlyTool = {
     'is switched on and `locked` whether its dataset is locked; a locked or ' +
     'disabled namespace is configured but serves no data, and both are null ' +
     'where the system reported no value. AN EMPTY `namespaces` AND A NULL ONE ' +
-    'ARE DIFFERENT ANSWERS: empty means the namespaces were read and none is ' +
-    'on this subsystem; null means they could not be read at all. `hosts` is ' +
-    'null in the same way and for the same reason. Both are also null where ' +
-    "`id` is null, because the subsystem's own identity is what each is joined " +
-    'on and there is then nothing to attribute to it. `failures` names each ' +
-    'read that failed, as `source` — `namespaces` or `hosts` — and `error`, ' +
-    'and is empty when both were read, which is what tells a list that could ' +
-    'not be read from one that could not be attributed. This tool reads only ' +
+    'ARE DIFFERENT ANSWERS: empty means the namespaces were read and none of ' +
+    'them was placed on this subsystem; null means they could not be read at ' +
+    'all. `hosts` is null in the same way and for the same reason. Both are ' +
+    "also null where `id` is null, because the subsystem's own identity is " +
+    'what each is joined on and there is then nothing to attribute to it. ' +
+    '`failures` names each read that failed, as `source` — `namespaces` or ' +
+    '`hosts` — and `error`, and is empty when both were read. ' +
+    '`unattributed_namespaces` and `unattributed_hosts` hold the rows that ' +
+    'WERE read and could not be placed on any subsystem listed here. Each ' +
+    'carries the `subsystem_id` and `subsystem` name its own record named, so ' +
+    'what it claimed is visible: both are null where the record named neither, ' +
+    'and `subsystem_id` is set where it named an id no subsystem here answers ' +
+    'to. An entry in `unattributed_hosts` whose `hostnqn` is null is a grant ' +
+    'naming no host to report, which is the one kind that names a subsystem ' +
+    'and still cannot be listed under it. WHILE EITHER LIST IS NOT EMPTY THE ' +
+    'PER-SUBSYSTEM `namespaces` AND `hosts` LISTS ARE INCOMPLETE, and an empty ' +
+    'one there is not a subsystem with nothing on it. Both are empty when a ' +
+    'read failed, because nothing was read to place — `failures` is what says ' +
+    'so, and is also what tells a list that could not be read from one that ' +
+    'could not be attributed. This tool reads only ' +
     'NVMe-oF: iSCSI targets are `iscsi_list`, and SMB or NFS shares are ' +
     '`shares_list`. It does not report which ports a subsystem is published ' +
     'on, so a subsystem listed here is not necessarily reachable over the ' +
@@ -610,8 +668,11 @@ export const nvmeofList: ReadOnlyTool = {
         unsupported_reason: errorText(subsystems.reason),
         subsystems: null,
         // The other two reads fail the same way on such a system. Naming them
-        // would report one absent feature three times, as three defects.
+        // would report one absent feature three times, as three defects — and
+        // no row was read, so nothing was left out of a list either.
         failures: [],
+        unattributed_namespaces: [],
+        unattributed_hosts: [],
       };
     }
 
@@ -619,32 +680,52 @@ export const nvmeofList: ReadOnlyTool = {
     if (namespaces.failure !== null) failures.push(namespaces.failure);
     if (hosts.failure !== null) failures.push(hosts.failure);
 
+    // Read rather than trusted, and read once: the id is both the reported
+    // identity and what the other two reads are attributed by, so a subsystem
+    // the system did not number is one nothing can be attached to.
+    const identified = subsystems.rows.map((subsystem) => ({
+      subsystem,
+      id: numberOrNull(subsystem['id']),
+    }));
+    // What a namespace or host row has to name to be filed under a subsystem
+    // this listing actually reports. A row naming anything else is set aside
+    // rather than dropped, because a dropped row leaves an empty list behind
+    // that says the subsystem has none.
+    const listed = new Set(identified.flatMap(({ id }) => (id === null ? [] : [id])));
+    const attributed = namespaces.value === null ? null : attribute(namespaces.value, listed);
+    const allowed = hosts.value === null ? null : attribute(hosts.value, listed);
+
     return {
       supported: true,
       unsupported_reason: null,
-      subsystems: subsystems.rows.map((subsystem) => {
-        // Read rather than trusted, and read once: it is both the reported
-        // identity and what the other two reads are attributed by, so a
-        // subsystem the system did not number is one nothing can be attached to.
-        const id = numberOrNull(subsystem['id']);
-        return {
-          id,
-          name: textOrNull(subsystem['name']),
-          nqn: textOrNull(subsystem['subnqn']),
-          // Reported because it decides whether `hosts` means anything: where
-          // it is true the list does not restrict, and without this field an
-          // empty one reads as a subsystem nobody may attach to.
-          allow_any_host: booleanOrNull(subsystem['allow_any_host']),
-          // Null for a read that failed and for a subsystem with no id to join
-          // on; an empty list for a read that succeeded and found none.
-          hosts: hosts.value === null || id === null ? null : (hosts.value.get(id) ?? []),
-          namespaces:
-            namespaces.value === null || id === null
-              ? null
-              : (namespaces.value.get(id) ?? []),
-        };
-      }),
+      subsystems: identified.map(({ subsystem, id }) => ({
+        id,
+        name: textOrNull(subsystem['name']),
+        nqn: textOrNull(subsystem['subnqn']),
+        // Reported because it decides whether `hosts` means anything: where
+        // it is true the list does not restrict, and without this field an
+        // empty one reads as a subsystem nobody may attach to.
+        allow_any_host: booleanOrNull(subsystem['allow_any_host']),
+        // Null for a read that failed and for a subsystem with no id to join
+        // on; an empty list for a read that succeeded and found none.
+        hosts: allowed === null || id === null ? null : (allowed.bySubsystem.get(id) ?? []),
+        namespaces:
+          attributed === null || id === null ? null : (attributed.bySubsystem.get(id) ?? []),
+      })),
       failures,
+      // Flat rather than nested, as `iscsi_list` reports its own unattributable
+      // rows: what the row said is beside what it named, so a caller reading one
+      // entry sees both the namespace and why it is here rather than in a list.
+      unattributed_namespaces: (attributed?.unattributed ?? []).map((row) => ({
+        ...row.value,
+        subsystem_id: row.subsystem_id,
+        subsystem: row.subsystem,
+      })),
+      unattributed_hosts: (allowed?.unattributed ?? []).map((row) => ({
+        hostnqn: row.value,
+        subsystem_id: row.subsystem_id,
+        subsystem: row.subsystem,
+      })),
     };
   },
 };

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -636,10 +636,11 @@ export const nvmeofList: ReadOnlyTool = {
     'naming no host to report, which is the one kind that names a subsystem ' +
     'and still cannot be listed under it. WHILE EITHER LIST IS NOT EMPTY THE ' +
     'PER-SUBSYSTEM `namespaces` AND `hosts` LISTS ARE INCOMPLETE, and an empty ' +
-    'one there is not a subsystem with nothing on it. Both are empty when a ' +
-    'read failed, because nothing was read to place — `failures` is what says ' +
-    'so, and is also what tells a list that could not be read from one that ' +
-    'could not be attributed. This tool reads only ' +
+    'one there is not a subsystem with nothing on it. EACH list is empty when ' +
+    'the read that would fill it failed, because nothing was read to place, ' +
+    'and the other list is unaffected — `failures` names which read that was, ' +
+    'and is also what tells a list that could not be read from one that could ' +
+    'not be attributed. This tool reads only ' +
     'NVMe-oF: iSCSI targets are `iscsi_list`, and SMB or NFS shares are ' +
     '`shares_list`. It does not report which ports a subsystem is published ' +
     'on, so a subsystem listed here is not necessarily reachable over the ' +

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -3,31 +3,49 @@ import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 
 /**
- * Block-storage family: what the system serves over iSCSI, and who is attached
- * to it.
+ * Block-storage family: what the system serves as block devices rather than as
+ * filesystem paths, over each of the two protocols that do it.
  *
- * `shares_list` deliberately excludes iSCSI, and says so: a target exports a
- * block device rather than a filesystem path, and its vocabulary of targets,
- * extents and initiators answers a different question. That question is asked
- * here.
+ * `shares_list` deliberately excludes both, and says so: a target or a
+ * subsystem exports a block device rather than a filesystem path, and its
+ * vocabulary answers a different question. That question is asked here, once
+ * per protocol — `iscsi_list` for iSCSI, `nvmeof_list` for NVMe-oF. They are
+ * two tools rather than one because they share no vocabulary: targets, extents
+ * and initiators on one side, subsystems, namespaces and hosts on the other,
+ * with no field meaning the same thing in both.
  *
- * It takes four middleware namespaces to answer, and none of them nests inside
- * another. `iscsi.target.query` names the targets; `iscsi.extent.query` names
- * the backing stores; `iscsi.targetextent.query` is the join table that maps an
- * extent onto a target at a LUN; and `iscsi.global.sessions` is live state from
- * the running service rather than configuration at all — it is the only one
- * that says whether anything is actually connected. The last is the reason the
- * tool exists: a target with no session is the shape of a hypervisor that quietly
- * dropped its storage, and nothing in the first three can tell that from a
- * target nobody has ever used.
+ * iSCSI takes four middleware namespaces to answer, and none of them nests
+ * inside another. `iscsi.target.query` names the targets; `iscsi.extent.query`
+ * names the backing stores; `iscsi.targetextent.query` is the join table that
+ * maps an extent onto a target at a LUN; and `iscsi.global.sessions` is live
+ * state from the running service rather than configuration at all — it is the
+ * only one that says whether anything is actually connected. The last is the
+ * reason the tool exists: a target with no session is the shape of a hypervisor
+ * that quietly dropped its storage, and nothing in the first three can tell that
+ * from a target nobody has ever used.
+ *
+ * NVMe-oF takes three, and unlike the iSCSI four they do nest: a namespace
+ * carries the subsystem it belongs to, and the host/subsystem join carries both
+ * sides whole. None of them is live state — the middleware exposes no
+ * equivalent of `iscsi.global.sessions` for NVMe-oF in this client, so
+ * `nvmeof_list` answers what is configured and cannot say what is attached.
  */
 
-/** Which of the two secondary reads failed. */
-type Source = 'extents' | 'initiators';
+/** Which of the two secondary iSCSI reads failed. */
+type IscsiSource = 'extents' | 'initiators';
 
-/** One read that failed, and why, for the caller to act on. */
-interface Failure {
-  source: Source;
+/** Which of the two secondary NVMe-oF reads failed. */
+type NvmeofSource = 'namespaces' | 'hosts';
+
+/**
+ * One read that failed, and why, for the caller to act on.
+ *
+ * Parameterised by the sources of the tool it belongs to rather than holding
+ * every source in the file: the two tools read different things, and a failure
+ * naming `extents` has no meaning in an NVMe-oF listing.
+ */
+interface Failure<S extends string> {
+  source: S;
   error: string;
 }
 
@@ -46,23 +64,34 @@ function textOrNull(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
 /**
  * Why a read failed, in words.
  *
  * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and anything else
- * becomes a stated absence rather than `"[object Object]"`. Never empty: a
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Those are what a
+ * failed call actually rejects with, and reading neither made every real
+ * failure report as having said nothing. Anything else still becomes a stated
+ * absence rather than `"[object Object]"`, and the result is never empty: a
  * failure with no text still has to read as a failure.
  */
 function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? 'the system reported no reason';
-  return textOrNull(reason) ?? 'the system reported no reason';
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
 }
 
 /** A read that produced a value, or the failure that stopped it. */
-interface Attempt<T> {
+interface Attempt<T, S extends string> {
   value: T | null;
-  failure: Failure | null;
+  failure: Failure<S> | null;
 }
 
 /**
@@ -72,7 +101,10 @@ interface Attempt<T> {
  * which keeps this correct for a read that throws before it returns a promise
  * at all.
  */
-async function attempt<T>(source: Source, read: () => Promise<T>): Promise<Attempt<T>> {
+async function attempt<T, S extends string>(
+  source: S,
+  read: () => Promise<T>,
+): Promise<Attempt<T, S>> {
   try {
     return { value: await read(), failure: null };
   } catch (reason) {
@@ -320,7 +352,7 @@ export const iscsiList: ReadOnlyTool = {
       else attached.push(session);
     }
 
-    const failures: Failure[] = [];
+    const failures: Failure<IscsiSource>[] = [];
     if (extents.failure !== null) failures.push(extents.failure);
     if (sessions.failure !== null) failures.push(sessions.failure);
 
@@ -343,6 +375,276 @@ export const iscsiList: ReadOnlyTool = {
       })),
       failures,
       unattributed_initiators: groupUnattributed(unattributed),
+    };
+  },
+};
+
+/**
+ * A number the system reported, or null where it reported anything else.
+ *
+ * The NVMe-oF reads need this where the iSCSI ones do not: the pinned client
+ * types a subsystem entry as `Record<string, unknown>`, so every field of one —
+ * including the id the other two reads are joined on — arrives as `unknown` and
+ * has to be read rather than trusted. Non-finite is not a number here: an id
+ * that is `NaN` joins nothing and a size that is `NaN` measures nothing.
+ */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** A boolean the system reported, or null where it reported anything else. */
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+/** One namespace of a subsystem: a block device, as an initiator addresses it. */
+interface Namespace {
+  id: number | null;
+  nsid: number | null;
+  device_type: 'ZVOL' | 'FILE' | null;
+  device_path: string | null;
+  size_bytes: number | null;
+  enabled: boolean | null;
+  locked: boolean | null;
+}
+
+/**
+ * The namespaces of each subsystem, indexed by subsystem id.
+ *
+ * A namespace names its subsystem with the whole subsystem record nested inside
+ * it rather than with a bare id, so the join is on a value read out of that
+ * untyped record. One the system did not identify that way has nothing to be
+ * filed under and is left out — the alternative is filing it under a subsystem
+ * it may not belong to, which would report a namespace on the wrong device.
+ */
+async function readNamespaces(system: SystemHandle): Promise<Map<number, Namespace[]>> {
+  const namespaces = await firstValueFrom(system.client.api.query('nvmet.namespace.query'));
+  const bySubsystem = new Map<number, Namespace[]>();
+  for (const namespace of namespaces) {
+    const subsystem = numberOrNull(namespace.subsys['id']);
+    if (subsystem === null) continue;
+    const row: Namespace = {
+      id: numberOrNull(namespace.id),
+      // The identifier an initiator addresses the namespace by, which is not
+      // the middleware's own record id above and does not follow it.
+      nsid: numberOrNull(namespace.nsid),
+      device_type: namespace.device_type ?? null,
+      device_path: textOrNull(namespace.device_path),
+      // The size of a FILE namespace's backing file. A ZVOL namespace takes its
+      // size from the zvol and carries none here, so null is a size this read
+      // did not learn rather than a namespace of no size.
+      size_bytes: numberOrNull(namespace.filesize),
+      // Not defaulted to true or false, as with an iSCSI extent above: a
+      // namespace whose switch was not reported must not read as one that is
+      // definitely serving or definitely not.
+      enabled: booleanOrNull(namespace.enabled),
+      locked: booleanOrNull(namespace.locked),
+    };
+    const mapped = bySubsystem.get(subsystem);
+    if (mapped === undefined) bySubsystem.set(subsystem, [row]);
+    else mapped.push(row);
+  }
+  return bySubsystem;
+}
+
+/**
+ * The NQNs of the hosts allowed onto each subsystem, indexed by subsystem id.
+ *
+ * `nvmet.host_subsys.query` is the join table and it embeds both sides whole:
+ * the host record it points at carries the NQN, so the hosts do not have to be
+ * read separately and no row can point at a host that was not returned.
+ */
+async function readHosts(system: SystemHandle): Promise<Map<number, string[]>> {
+  const joins = await firstValueFrom(system.client.api.query('nvmet.host_subsys.query'));
+  const bySubsystem = new Map<number, string[]>();
+  for (const join of joins) {
+    const subsystem = numberOrNull(join.subsys['id']);
+    const hostnqn = textOrNull(join.host.hostnqn);
+    // A host with no NQN cannot be the host any initiator connects as, and one
+    // with no subsystem has nothing to be allowed onto; either way the row
+    // grants nothing that can be stated, and stating it anyway would put a
+    // nameless entry in a list whose whole content is names.
+    if (subsystem === null || hostnqn === null) continue;
+    const allowed = bySubsystem.get(subsystem);
+    if (allowed === undefined) bySubsystem.set(subsystem, [hostnqn]);
+    else allowed.push(hostnqn);
+  }
+  return bySubsystem;
+}
+
+/** The JSON-RPC code for a method the server does not have. */
+const METHOD_NOT_FOUND = -32601;
+
+/** The middleware's own name for the same thing. */
+const NO_SUCH_METHOD = 'ENOMETHOD';
+
+/**
+ * Whether a rejection is the system saying it has no such method, rather than a
+ * method it has and would not run.
+ *
+ * This is the whole basis for reporting a system as having no NVMe-oF, so it
+ * recognises only the two spellings that mean exactly that — the JSON-RPC code
+ * for an absent method, and the middleware's own error name for it — in the
+ * four places the client documents an error arriving: the rejection itself, a
+ * nested `data`, and the `reason` or `message` text either carries. It
+ * deliberately does not match looser English like "not found", which is also
+ * what a system says about a subsystem id that does not exist.
+ *
+ * (unconfirmed) Which of those shapes a TrueNAS too old for NVMe-oF actually
+ * rejects with has not been observed against a live system — only read off the
+ * client's own error types. Getting it wrong costs a raised error rather than a
+ * wrong answer: an unrecognised rejection is raised, never reported as
+ * unsupported.
+ */
+function isUnsupported(reason: unknown): boolean {
+  if (reason instanceof Error) return namesMissingMethod(reason.message);
+  if (typeof reason !== 'object' || reason === null) return namesMissingMethod(reason);
+  const carrier = reason as Record<string, unknown>;
+  if (carrier['code'] === METHOD_NOT_FOUND) return true;
+  if (carrier['errname'] === NO_SUCH_METHOD) return true;
+  if (namesMissingMethod(carrier['reason']) || namesMissingMethod(carrier['message'])) return true;
+  const data = carrier['data'];
+  return typeof data === 'object' && data !== null && isUnsupported(data);
+}
+
+/** Whether some text the system sent names the absent-method error. */
+function namesMissingMethod(text: unknown): boolean {
+  return typeof text === 'string' && text.includes(NO_SUCH_METHOD);
+}
+
+/** A read that produced rows, or the rejection that stopped it, kept whole. */
+interface Read<T> {
+  rows: T | null;
+  reason: unknown;
+}
+
+/**
+ * The subsystems, with a rejection kept as it arrived rather than reduced to
+ * text.
+ *
+ * `attempt` is the right shape for every other read here and the wrong one for
+ * this: whether this failure is raised or reported turns on what kind of
+ * rejection it is, and `attempt` has already thrown that away by the time its
+ * caller sees a `Failure`.
+ *
+ * The rows are `Record<string, unknown>[]` because that is how the pinned
+ * client types a subsystem entry — untyped, unlike the namespace and join rows
+ * beside it — rather than because this widens anything.
+ */
+function readSubsystems(system: SystemHandle): Promise<Read<Record<string, unknown>[]>> {
+  return firstValueFrom(system.client.api.query('nvmet.subsys.query')).then(
+    (rows) => ({ rows, reason: null }),
+    (reason: unknown) => ({ rows: null, reason }),
+  );
+}
+
+export const nvmeofList: ReadOnlyTool = {
+  name: 'nvmeof_list',
+  description:
+    'Every NVMe-oF subsystem the system exports, the hosts allowed onto each, ' +
+    'and the namespaces behind it. `supported` is whether this system has ' +
+    'NVMe-oF at all: a TrueNAS whose version predates it answers `false`, with ' +
+    '`subsystems` null and `unsupported_reason` naming what the system said. ' +
+    'READING THAT AS A SYSTEM WITH NO SUBSYSTEMS IS WRONG — it is a system ' +
+    'that cannot have any, which is a different answer from an empty list. ' +
+    '`false` is reported ONLY where the system said it has no such method: a ' +
+    'read that was denied, or that failed for any other reason, raises instead ' +
+    'of answering, so an unsupported verdict is never inferred from a failure ' +
+    'that said nothing about support. When `supported` is true ' +
+    '`unsupported_reason` is null and `subsystems` is the list. `id` is the ' +
+    "subsystem's numeric identity, `name` its short name, and `nqn` the NVMe " +
+    'Qualified Name an initiator connects to, null where the system reported ' +
+    'none. `allow_any_host` is whether the subsystem admits any host at all. ' +
+    'READ IT BEFORE READING `hosts` AS A RESTRICTION: where it is true, hosts ' +
+    'outside that list may attach, so an empty `hosts` is not a subsystem ' +
+    'nobody may reach; it is null where the system reported no value, which ' +
+    'settles neither. `hosts` are the NQNs of the hosts explicitly allowed ' +
+    'onto the subsystem, and are CONFIGURATION RATHER THAN LIVE STATE: this ' +
+    'tool reports who may attach and cannot report who is attached, because ' +
+    'the middleware exposes no NVMe-oF equivalent of the iSCSI session list. ' +
+    'An empty `hosts` therefore says nothing about whether the subsystem is in ' +
+    'use, and neither does a full one. `namespaces` are the block devices the ' +
+    'subsystem exports. `nsid` is the identifier an initiator addresses a ' +
+    "namespace by and `id` the middleware's own record id — different numbers, " +
+    'and neither follows the other. `device_type` is `ZVOL` or `FILE` and ' +
+    '`device_path` the backing zvol or file. `size_bytes` is the size of a ' +
+    'backing FILE and IS NULL ON A ZVOL NAMESPACE, which takes its size from ' +
+    'the zvol rather than carrying one here: null is a size this tool did not ' +
+    'learn, never a namespace of no size. `enabled` is whether the namespace ' +
+    'is switched on and `locked` whether its dataset is locked; a locked or ' +
+    'disabled namespace is configured but serves no data, and both are null ' +
+    'where the system reported no value. AN EMPTY `namespaces` AND A NULL ONE ' +
+    'ARE DIFFERENT ANSWERS: empty means the namespaces were read and none is ' +
+    'on this subsystem; null means they could not be read at all. `hosts` is ' +
+    'null in the same way and for the same reason. Both are also null where ' +
+    "`id` is null, because the subsystem's own identity is what each is joined " +
+    'on and there is then nothing to attribute to it. `failures` names each ' +
+    'read that failed, as `source` — `namespaces` or `hosts` — and `error`, ' +
+    'and is empty when both were read, which is what tells a list that could ' +
+    'not be read from one that could not be attributed. This tool reads only ' +
+    'NVMe-oF: iSCSI targets are `iscsi_list`, and SMB or NFS shares are ' +
+    '`shares_list`. It does not report which ports a subsystem is published ' +
+    'on, so a subsystem listed here is not necessarily reachable over the ' +
+    'network.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Every read is issued before any is awaited, so none waits on another, and
+    // as in `iscsi_list` only the first is allowed to fail the tool: a namespace
+    // and a host describe a subsystem, and with no subsystems there is nothing
+    // for either to describe.
+    const [subsystems, namespaces, hosts] = await Promise.all([
+      readSubsystems(system),
+      attempt('namespaces', () => readNamespaces(system)),
+      attempt('hosts', () => readHosts(system)),
+    ]);
+
+    if (subsystems.rows === null) {
+      // Raised rather than reported unless the system said the method is not
+      // there: "this system has no NVMe-oF" is a claim about the system, and a
+      // denied or dropped read is evidence for no such claim.
+      if (!isUnsupported(subsystems.reason)) throw subsystems.reason;
+      return {
+        supported: false,
+        unsupported_reason: errorText(subsystems.reason),
+        subsystems: null,
+        // The other two reads fail the same way on such a system. Naming them
+        // would report one absent feature three times, as three defects.
+        failures: [],
+      };
+    }
+
+    const failures: Failure<NvmeofSource>[] = [];
+    if (namespaces.failure !== null) failures.push(namespaces.failure);
+    if (hosts.failure !== null) failures.push(hosts.failure);
+
+    return {
+      supported: true,
+      unsupported_reason: null,
+      subsystems: subsystems.rows.map((subsystem) => {
+        // Read rather than trusted, and read once: it is both the reported
+        // identity and what the other two reads are attributed by, so a
+        // subsystem the system did not number is one nothing can be attached to.
+        const id = numberOrNull(subsystem['id']);
+        return {
+          id,
+          name: textOrNull(subsystem['name']),
+          nqn: textOrNull(subsystem['subnqn']),
+          // Reported because it decides whether `hosts` means anything: where
+          // it is true the list does not restrict, and without this field an
+          // empty one reads as a subsystem nobody may attach to.
+          allow_any_host: booleanOrNull(subsystem['allow_any_host']),
+          // Null for a read that failed and for a subsystem with no id to join
+          // on; an empty list for a read that succeeded and found none.
+          hosts: hosts.value === null || id === null ? null : (hosts.value.get(id) ?? []),
+          namespaces:
+            namespaces.value === null || id === null
+              ? null
+              : (namespaces.value.get(id) ?? []),
+        };
+      }),
+      failures,
     };
   },
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { ToolCatalog } from '@/catalog/catalog';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
-import { iscsiList } from '@/tools/block';
+import { iscsiList, nvmeofList } from '@/tools/block';
 import { disksList } from '@/tools/disks';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
@@ -11,7 +11,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: seventeen read-only tools plus one mutating tool. */
+/** The sketch's catalog: eighteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -31,6 +31,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(sharesList);
   catalog.register(shareAccess);
   catalog.register(iscsiList);
+  catalog.register(nvmeofList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -43,6 +44,7 @@ export {
   disksList,
   iscsiList,
   listDatasets,
+  nvmeofList,
   poolStatus,
   poolTopology,
   quotaReport,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -11,6 +11,7 @@ import {
   disksList,
   iscsiList,
   listDatasets,
+  nvmeofList,
   poolStatus,
   poolTopology,
   quotaReport,
@@ -41,8 +42,25 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
   return { ctx: { system }, call, query };
 }
 
+/**
+ * A SystemHandle whose queries answer independently, either with rows or by
+ * failing — `fakeSystem` answers every method from one map and has no way to
+ * make a call fail, which the tools that read several methods and return a
+ * partial answer are largely about.
+ */
+function failingSystem(
+  rows: Partial<Record<string, unknown>>,
+  failures: Partial<Record<string, unknown>> = {},
+): { ctx: ToolContext; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn((method: string) =>
+    method in failures ? throwError(() => failures[method]) : of(rows[method]),
+  );
+  const system = { name: 'nas', client: { api: { query } } } as unknown as SystemHandle;
+  return { ctx: { system }, query };
+}
+
 describe('createDefaultCatalog', () => {
-  it('registers the eighteen sketch tools', () => {
+  it('registers the nineteen sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -61,6 +79,7 @@ describe('createDefaultCatalog', () => {
       'shares_list',
       'share_access',
       'iscsi_list',
+      'nvmeof_list',
       'snapshots_create',
     ]);
   });
@@ -135,6 +154,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises iscsi_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('iscsi_list');
+  });
+
+  it('advertises nvmeof_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('nvmeof_list');
   });
 });
 
@@ -3746,22 +3769,6 @@ describe('share_access', () => {
 
 describe('iscsi_list', () => {
   /**
-   * A SystemHandle whose four iSCSI queries answer independently, either with
-   * rows or by failing — `fakeSystem` answers every method from one map and has
-   * no way to make a call fail, which several of these tests are about.
-   */
-  const fakeIscsi = (
-    rows: Partial<Record<string, unknown>>,
-    failures: Partial<Record<string, unknown>> = {},
-  ): { ctx: ToolContext; query: ReturnType<typeof vi.fn> } => {
-    const query = vi.fn((method: string) =>
-      method in failures ? throwError(() => failures[method]) : of(rows[method]),
-    );
-    const system = { name: 'nas', client: { api: { query } } } as unknown as SystemHandle;
-    return { ctx: { system }, query };
-  };
-
-  /**
    * A target as `iscsi.target.query` reports one. `rel_tgt_id`, `mode`,
    * `groups` and `auth_networks` are real fields of the payload the tool does
    * not name, and are here to be dropped.
@@ -3830,7 +3837,7 @@ describe('iscsi_list', () => {
     rows: Partial<Record<string, unknown>> = {},
     failures: Partial<Record<string, unknown>> = {},
   ): Promise<Listing> => {
-    const { ctx } = fakeIscsi(
+    const { ctx } = failingSystem(
       {
         ['iscsi.target.query']: [target()],
         ['iscsi.extent.query']: [extent()],
@@ -4272,7 +4279,7 @@ describe('iscsi_list', () => {
   });
 
   it('issues every read before awaiting any of them', async () => {
-    const { ctx, query } = fakeIscsi({
+    const { ctx, query } = failingSystem({
       ['iscsi.target.query']: [target()],
       ['iscsi.extent.query']: [extent()],
       ['iscsi.targetextent.query']: [mapping()],
@@ -4289,6 +4296,436 @@ describe('iscsi_list', () => {
       'iscsi.extent.query',
       'iscsi.targetextent.query',
       'iscsi.global.sessions',
+    ]);
+    await listing;
+  });
+});
+
+describe('nvmeof_list', () => {
+  /**
+   * A subsystem as `nvmet.subsys.query` reports one. `serial`, `pi_enable`,
+   * `ana` and the three id lists are real fields of the payload the tool does
+   * not name, and are here to be dropped — `hosts` and `namespaces` especially,
+   * which the tool answers with the joined records rather than with these ids.
+   */
+  const subsystem = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'nvme0',
+    subnqn: 'nqn.2011-06.com.truenas.ctl:nvme0',
+    serial: 'a1b2c3d4e5f6',
+    allow_any_host: false,
+    pi_enable: false,
+    qid_max: null,
+    ieee_oui: null,
+    ana: null,
+    hosts: [3],
+    namespaces: [7],
+    ports: [1],
+    ...over,
+  });
+
+  /**
+   * A namespace as `nvmet.namespace.query` reports one: a ZVOL, which is the
+   * kind that carries no `filesize` of its own.
+   */
+  const namespace = (over: Record<string, unknown> = {}) => ({
+    id: 7,
+    nsid: 1,
+    subsys: { id: 1, name: 'nvme0' },
+    device_type: 'ZVOL',
+    device_path: 'zvol/tank/nvme0',
+    filesize: null,
+    device_uuid: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    device_nguid: 'e2b4c1a05f9d4c7e',
+    enabled: true,
+    locked: false,
+    ...over,
+  });
+
+  /** A row of the join table allowing one host onto one subsystem. */
+  const hostJoin = (over: Record<string, unknown> = {}) => ({
+    id: 2,
+    host: { id: 3, hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:esx1', dhchap_key: null },
+    subsys: { id: 1, name: 'nvme0' },
+    ...over,
+  });
+
+  type Listing = {
+    supported: boolean;
+    unsupported_reason: string | null;
+    subsystems: Record<string, unknown>[] | null;
+    failures: Record<string, unknown>[];
+  };
+
+  const listed = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Listing> => {
+    const { ctx } = failingSystem(
+      {
+        ['nvmet.subsys.query']: [subsystem()],
+        ['nvmet.namespace.query']: [namespace()],
+        ['nvmet.host_subsys.query']: [hostJoin()],
+        ...rows,
+      },
+      failures,
+    );
+    return (await nvmeofList.handler(ctx, {})) as Listing;
+  };
+
+  /** The single subsystem of a listing, for the cases about one's fields. */
+  const onlySubsystem = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => ((await listed(rows, failures)).subsystems ?? [])[0];
+
+  it('reports each subsystem with its allowed hosts and its namespaces', async () => {
+    expect(await listed()).toEqual({
+      supported: true,
+      unsupported_reason: null,
+      subsystems: [
+        {
+          id: 1,
+          name: 'nvme0',
+          nqn: 'nqn.2011-06.com.truenas.ctl:nvme0',
+          allow_any_host: false,
+          hosts: ['nqn.2014-08.org.nvmexpress:uuid:esx1'],
+          namespaces: [
+            {
+              id: 7,
+              nsid: 1,
+              device_type: 'ZVOL',
+              device_path: 'zvol/tank/nvme0',
+              size_bytes: null,
+              enabled: true,
+              locked: false,
+            },
+          ],
+        },
+      ],
+      failures: [],
+    });
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const listing = await listed({
+      ['nvmet.subsys.query']: [subsystem({ future_field: 'added by a later release' })],
+      ['nvmet.namespace.query']: [namespace({ future_field: 'added by a later release' })],
+      ['nvmet.host_subsys.query']: [hostJoin({ future_field: 'added by a later release' })],
+    });
+    expect(Object.keys(listing)).toEqual([
+      'supported',
+      'unsupported_reason',
+      'subsystems',
+      'failures',
+    ]);
+    const only = (listing.subsystems ?? [])[0];
+    expect(Object.keys(only)).toEqual([
+      'id',
+      'name',
+      'nqn',
+      'allow_any_host',
+      'hosts',
+      'namespaces',
+    ]);
+    expect(Object.keys((only['namespaces'] as Record<string, unknown>[])[0])).toEqual([
+      'id',
+      'nsid',
+      'device_type',
+      'device_path',
+      'size_bytes',
+      'enabled',
+      'locked',
+    ]);
+  });
+
+  it('reports a subsystem with no namespaces as an empty list, not omitted', async () => {
+    expect(await onlySubsystem({ ['nvmet.namespace.query']: [] })).toMatchObject({
+      name: 'nvme0',
+      namespaces: [],
+    });
+  });
+
+  it('reports a subsystem no host is allowed onto as an empty list', async () => {
+    expect(await onlySubsystem({ ['nvmet.host_subsys.query']: [] })).toMatchObject({ hosts: [] });
+  });
+
+  it('reports whether any host is admitted, so an empty list is not read as a bar', async () => {
+    // With `allow_any_host` true the host list restricts nothing, and without
+    // this field an empty one reads as a subsystem nobody may attach to.
+    const listing = await listed({
+      ['nvmet.subsys.query']: [
+        subsystem({ allow_any_host: true }),
+        subsystem({ id: 2, name: 'nvme1', allow_any_host: 'yes' }),
+      ],
+      ['nvmet.host_subsys.query']: [],
+    });
+    expect(
+      (listing.subsystems ?? []).map((one) => [one['name'], one['allow_any_host'], one['hosts']]),
+    ).toEqual([
+      ['nvme0', true, []],
+      // Present but not a boolean settles neither, so it is null rather than
+      // the false that would assert the list is the whole of who may attach.
+      ['nvme1', null, []],
+    ]);
+  });
+
+  it('reports the backing device of a ZVOL namespace and of a FILE one', async () => {
+    const namespaces = (
+      await onlySubsystem({
+        ['nvmet.namespace.query']: [
+          namespace(),
+          namespace({
+            id: 8,
+            nsid: 2,
+            device_type: 'FILE',
+            device_path: '/mnt/tank/nvme/logs.img',
+            filesize: 10737418240,
+          }),
+        ],
+      })
+    )['namespaces'] as Record<string, unknown>[];
+    // A ZVOL takes its size from the zvol and reports none here. Null is that
+    // unlearned size — reporting 0 would say the namespace holds nothing.
+    expect(namespaces[0]).toMatchObject({ device_type: 'ZVOL', size_bytes: null });
+    expect(namespaces[1]).toMatchObject({
+      device_type: 'FILE',
+      device_path: '/mnt/tank/nvme/logs.img',
+      size_bytes: 10737418240,
+    });
+  });
+
+  it('reports a namespace field the system omitted or garbled as null', async () => {
+    const namespaces = (
+      await onlySubsystem({
+        ['nvmet.namespace.query']: [
+          { subsys: { id: 1 }, device_uuid: 'u', nsid: 'first', filesize: Number.NaN },
+        ],
+      })
+    )['namespaces'] as Record<string, unknown>[];
+    // `enabled` and `locked` especially: false would say the namespace is
+    // definitely not serving, which the system did not report either way.
+    expect(namespaces[0]).toEqual({
+      id: null,
+      nsid: null,
+      device_type: null,
+      device_path: null,
+      size_bytes: null,
+      enabled: null,
+      locked: null,
+    });
+  });
+
+  it('reads a subsystem field the system omitted as having none', async () => {
+    expect(
+      await onlySubsystem({ ['nvmet.subsys.query']: [{ id: 1, serial: 'a1b2c3' }] }),
+    ).toMatchObject({ name: null, nqn: null, allow_any_host: null });
+    for (const missing of [null, undefined, '']) {
+      expect(
+        await onlySubsystem({ ['nvmet.subsys.query']: [subsystem({ subnqn: missing })] }),
+      ).toMatchObject({ nqn: null });
+    }
+  });
+
+  it('groups namespaces and hosts under the subsystem each names', async () => {
+    const listing = await listed({
+      ['nvmet.subsys.query']: [subsystem(), subsystem({ id: 2, name: 'nvme1' })],
+      ['nvmet.namespace.query']: [
+        namespace(),
+        namespace({ id: 8, nsid: 1, subsys: { id: 2 }, device_path: 'zvol/tank/nvme1' }),
+        namespace({ id: 9, nsid: 2, device_path: 'zvol/tank/nvme0b' }),
+      ],
+      ['nvmet.host_subsys.query']: [
+        hostJoin(),
+        hostJoin({
+          id: 5,
+          subsys: { id: 2 },
+          host: { id: 4, hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:esx2' },
+        }),
+        hostJoin({ id: 6, host: { id: 4, hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:esx2' } }),
+      ],
+    });
+    expect(
+      (listing.subsystems ?? []).map((one) => [
+        one['name'],
+        one['hosts'],
+        (one['namespaces'] as Record<string, unknown>[]).map((each) => each['device_path']),
+      ]),
+    ).toEqual([
+      [
+        'nvme0',
+        ['nqn.2014-08.org.nvmexpress:uuid:esx1', 'nqn.2014-08.org.nvmexpress:uuid:esx2'],
+        ['zvol/tank/nvme0', 'zvol/tank/nvme0b'],
+      ],
+      ['nvme1', ['nqn.2014-08.org.nvmexpress:uuid:esx2'], ['zvol/tank/nvme1']],
+    ]);
+  });
+
+  it('leaves out a row the system did not attribute to a subsystem', async () => {
+    // Filing it under a subsystem it may not belong to would report a namespace
+    // on the wrong device, and a host as allowed onto one it is not.
+    const listing = await listed({
+      ['nvmet.namespace.query']: [namespace({ subsys: { name: 'nvme0' } })],
+      ['nvmet.host_subsys.query']: [hostJoin({ subsys: {} })],
+    });
+    expect((listing.subsystems ?? [])[0]).toMatchObject({ namespaces: [], hosts: [] });
+    expect(listing.failures).toEqual([]);
+  });
+
+  it('leaves out a host row carrying no NQN to report', async () => {
+    for (const missing of [null, '', undefined]) {
+      expect(
+        await onlySubsystem({
+          ['nvmet.host_subsys.query']: [hostJoin({ host: { id: 3, hostnqn: missing } })],
+        }),
+      ).toMatchObject({ hosts: [] });
+    }
+  });
+
+  it('attributes nothing to a subsystem the system did not number', async () => {
+    const listing = await listed({ ['nvmet.subsys.query']: [subsystem({ id: 'nvme0' })] });
+    // Null as for a read that failed, because there is no id to join on — and
+    // an empty `failures` is what tells this apart from that.
+    expect((listing.subsystems ?? [])[0]).toEqual({
+      id: null,
+      name: 'nvme0',
+      nqn: 'nqn.2011-06.com.truenas.ctl:nvme0',
+      allow_any_host: false,
+      hosts: null,
+      namespaces: null,
+    });
+    expect(listing.failures).toEqual([]);
+  });
+
+  it('distinguishes namespaces that could not be read from a subsystem with none', async () => {
+    const listing = await listed({}, { ['nvmet.namespace.query']: new Error('denied') });
+    // Null rather than empty: an empty list would say the subsystem exports
+    // nothing, which is the one answer this tool must not invent.
+    expect((listing.subsystems ?? [])[0]).toMatchObject({ namespaces: null });
+    expect((listing.subsystems ?? [])[0]).not.toMatchObject({ hosts: null });
+    expect(listing.failures).toEqual([{ source: 'namespaces', error: 'denied' }]);
+  });
+
+  it('distinguishes hosts that could not be read from a subsystem with none', async () => {
+    const listing = await listed({}, { ['nvmet.host_subsys.query']: new Error('denied') });
+    expect((listing.subsystems ?? [])[0]).toMatchObject({ hosts: null });
+    expect((listing.subsystems ?? [])[0]).not.toMatchObject({ namespaces: null });
+    expect(listing.failures).toEqual([{ source: 'hosts', error: 'denied' }]);
+  });
+
+  it('reports both reads failing without losing the subsystems themselves', async () => {
+    const listing = await listed(
+      {},
+      {
+        ['nvmet.namespace.query']: new Error('denied'),
+        ['nvmet.host_subsys.query']: new Error('service not running'),
+      },
+    );
+    expect(listing.subsystems).toEqual([
+      {
+        id: 1,
+        name: 'nvme0',
+        nqn: 'nqn.2011-06.com.truenas.ctl:nvme0',
+        allow_any_host: false,
+        hosts: null,
+        namespaces: null,
+      },
+    ]);
+    expect(listing.failures).toEqual([
+      { source: 'namespaces', error: 'denied' },
+      { source: 'hosts', error: 'service not running' },
+    ]);
+  });
+
+  it('names a failure the system sent as an object rather than an Error', async () => {
+    // What a failed call actually rejects with: the client's own error types
+    // are a middleware object carrying `reason` and a JSON-RPC one carrying
+    // `message`. Reading neither reported every real failure as silent.
+    for (const [reason, error] of [
+      ['connection reset', 'connection reset'],
+      [{ reason: 'Not authorized' }, 'Not authorized'],
+      [{ code: 500, message: 'Internal error' }, 'Internal error'],
+      [new Error(''), 'the system reported no reason'],
+      [{ code: 500 }, 'the system reported no reason'],
+      [504, 'the system reported no reason'],
+    ] as [unknown, string][]) {
+      expect((await listed({}, { ['nvmet.host_subsys.query']: reason })).failures).toEqual([
+        { source: 'hosts', error },
+      ]);
+    }
+  });
+
+  it('reports a system whose version has no NVMe-oF as unsupported, not as empty', async () => {
+    // Every spelling of "no such method" the client's error types allow: the
+    // JSON-RPC code, the middleware's error name, either text field, and the
+    // nested `data` a JSON-RPC error wraps a middleware one in.
+    for (const reason of [
+      new Error('[ENOMETHOD] Method "nvmet.subsys.query" not found'),
+      '[ENOMETHOD] no such method',
+      { code: -32601, message: 'Method not found' },
+      { errname: 'ENOMETHOD', reason: 'Method does not exist' },
+      { reason: '[ENOMETHOD] Method does not exist' },
+      { message: '[ENOMETHOD] Method does not exist' },
+      { code: -32000, message: 'call failed', data: { errname: 'ENOMETHOD', reason: 'gone' } },
+    ]) {
+      expect(await listed({}, { ['nvmet.subsys.query']: reason })).toMatchObject({
+        supported: false,
+        subsystems: null,
+        // The other two reads fail the same way on such a system; naming them
+        // would report one absent feature three times, as three defects.
+        failures: [],
+      });
+    }
+    expect(
+      (await listed({}, { ['nvmet.subsys.query']: { code: -32601, message: 'Method not found' } }))
+        .unsupported_reason,
+    ).toBe('Method not found');
+  });
+
+  it('raises rather than calling a read it could not make unsupported', async () => {
+    // "This system has no NVMe-oF" is a claim about the system, and a denied or
+    // dropped read is evidence for no such claim.
+    await expect(listed({}, { ['nvmet.subsys.query']: new Error('denied') })).rejects.toThrow(
+      'denied',
+    );
+    await expect(
+      listed({}, { ['nvmet.subsys.query']: { code: -32000, message: 'connection reset' } }),
+    ).rejects.toEqual({ code: -32000, message: 'connection reset' });
+    await expect(listed({}, { ['nvmet.subsys.query']: 'connection reset' })).rejects.toBe(
+      'connection reset',
+    );
+    await expect(listed({}, { ['nvmet.subsys.query']: null })).rejects.toBeNull();
+  });
+
+  it('reports a system that has NVMe-oF and no subsystems as an empty list', async () => {
+    expect(
+      await listed({
+        ['nvmet.subsys.query']: [],
+        ['nvmet.namespace.query']: [],
+        ['nvmet.host_subsys.query']: [],
+      }),
+    ).toEqual({
+      supported: true,
+      unsupported_reason: null,
+      subsystems: [],
+      failures: [],
+    });
+  });
+
+  it('issues every read before awaiting any of them', async () => {
+    const { ctx, query } = failingSystem({
+      ['nvmet.subsys.query']: [subsystem()],
+      ['nvmet.namespace.query']: [namespace()],
+      ['nvmet.host_subsys.query']: [hostJoin()],
+    });
+    const listing = nvmeofList.handler(ctx, {});
+    // Asserted before the handler is awaited at all, which is what makes this
+    // about concurrency rather than order: a handler that awaited one read
+    // before starting the next would have made one call by this point.
+    expect(query.mock.calls.map((one) => one[0])).toEqual([
+      'nvmet.subsys.query',
+      'nvmet.namespace.query',
+      'nvmet.host_subsys.query',
     ]);
     await listing;
   });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -4355,6 +4355,8 @@ describe('nvmeof_list', () => {
     unsupported_reason: string | null;
     subsystems: Record<string, unknown>[] | null;
     failures: Record<string, unknown>[];
+    unattributed_namespaces: Record<string, unknown>[];
+    unattributed_hosts: Record<string, unknown>[];
   };
 
   const listed = async (
@@ -4404,6 +4406,8 @@ describe('nvmeof_list', () => {
         },
       ],
       failures: [],
+      unattributed_namespaces: [],
+      unattributed_hosts: [],
     });
   });
 
@@ -4418,6 +4422,8 @@ describe('nvmeof_list', () => {
       'unsupported_reason',
       'subsystems',
       'failures',
+      'unattributed_namespaces',
+      'unattributed_hosts',
     ]);
     const only = (listing.subsystems ?? [])[0];
     expect(Object.keys(only)).toEqual([
@@ -4561,24 +4567,74 @@ describe('nvmeof_list', () => {
     ]);
   });
 
-  it('leaves out a row the system did not attribute to a subsystem', async () => {
+  it('reports a row the system did not attribute to a subsystem rather than dropping it', async () => {
     // Filing it under a subsystem it may not belong to would report a namespace
-    // on the wrong device, and a host as allowed onto one it is not.
+    // on the wrong device, and a host as allowed onto one it is not. Dropping
+    // it instead leaves an empty list saying the subsystem has none, which is
+    // the answer that gets acted on — so it is reported beside the listing.
     const listing = await listed({
       ['nvmet.namespace.query']: [namespace({ subsys: { name: 'nvme0' } })],
       ['nvmet.host_subsys.query']: [hostJoin({ subsys: {} })],
     });
     expect((listing.subsystems ?? [])[0]).toMatchObject({ namespaces: [], hosts: [] });
+    expect(listing.unattributed_namespaces).toEqual([
+      {
+        id: 7,
+        nsid: 1,
+        device_type: 'ZVOL',
+        device_path: 'zvol/tank/nvme0',
+        size_bytes: null,
+        enabled: true,
+        locked: false,
+        // The record named a name and no id, so the name is what is left to
+        // report it by. Both are null where it named neither, as here for the
+        // host row.
+        subsystem_id: null,
+        subsystem: 'nvme0',
+      },
+    ]);
+    expect(listing.unattributed_hosts).toEqual([
+      {
+        hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:esx1',
+        subsystem_id: null,
+        subsystem: null,
+      },
+    ]);
     expect(listing.failures).toEqual([]);
   });
 
-  it('leaves out a host row carrying no NQN to report', async () => {
+  it('reports a row naming a subsystem the listing does not contain', async () => {
+    // The id is readable and answers to nothing, which drops the row as surely
+    // as an unreadable one: it is filed under a key no subsystem ever reads.
+    const listing = await listed({
+      ['nvmet.namespace.query']: [namespace({ subsys: { id: 99, name: 'nvme9' } })],
+      ['nvmet.host_subsys.query']: [hostJoin({ subsys: { id: 99, name: 'nvme9' } })],
+    });
+    expect((listing.subsystems ?? [])[0]).toMatchObject({ namespaces: [], hosts: [] });
+    expect(listing.unattributed_namespaces).toMatchObject([
+      { id: 7, subsystem_id: 99, subsystem: 'nvme9' },
+    ]);
+    expect(listing.unattributed_hosts).toEqual([
+      {
+        hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:esx1',
+        subsystem_id: 99,
+        subsystem: 'nvme9',
+      },
+    ]);
+    expect(listing.failures).toEqual([]);
+  });
+
+  it('reports a host row carrying no NQN rather than listing a nameless entry', async () => {
     for (const missing of [null, '', undefined]) {
-      expect(
-        await onlySubsystem({
-          ['nvmet.host_subsys.query']: [hostJoin({ host: { id: 3, hostnqn: missing } })],
-        }),
-      ).toMatchObject({ hosts: [] });
+      const listing = await listed({
+        ['nvmet.host_subsys.query']: [hostJoin({ host: { id: 3, hostnqn: missing } })],
+      });
+      expect((listing.subsystems ?? [])[0]).toMatchObject({ hosts: [] });
+      // The one kind that names a subsystem and still cannot be listed under
+      // it: the grant is real, and there is no name to put in a list of names.
+      expect(listing.unattributed_hosts).toEqual([
+        { hostnqn: null, subsystem_id: 1, subsystem: 'nvme0' },
+      ]);
     }
   });
 
@@ -4595,6 +4651,25 @@ describe('nvmeof_list', () => {
       namespaces: null,
     });
     expect(listing.failures).toEqual([]);
+    // The rows named a subsystem this listing cannot answer to, so they are
+    // reported rather than lost with the id that would have placed them.
+    expect(listing.unattributed_namespaces).toMatchObject([{ id: 7, subsystem_id: 1 }]);
+    expect(listing.unattributed_hosts).toMatchObject([{ subsystem_id: 1 }]);
+  });
+
+  it('reports nothing as unattributed where the read that would fill it failed', async () => {
+    // Empty because no row was read to place, not because every row was placed.
+    // `failures` is what carries the difference.
+    const listing = await listed(
+      {},
+      {
+        ['nvmet.namespace.query']: new Error('denied'),
+        ['nvmet.host_subsys.query']: new Error('denied'),
+      },
+    );
+    expect(listing.unattributed_namespaces).toEqual([]);
+    expect(listing.unattributed_hosts).toEqual([]);
+    expect(listing.failures).toHaveLength(2);
   });
 
   it('distinguishes namespaces that could not be read from a subsystem with none', async () => {
@@ -4672,8 +4747,11 @@ describe('nvmeof_list', () => {
         supported: false,
         subsystems: null,
         // The other two reads fail the same way on such a system; naming them
-        // would report one absent feature three times, as three defects.
+        // would report one absent feature three times, as three defects. No row
+        // was read either, so nothing was left out of a list.
         failures: [],
+        unattributed_namespaces: [],
+        unattributed_hosts: [],
       });
     }
     expect(
@@ -4709,6 +4787,8 @@ describe('nvmeof_list', () => {
       unsupported_reason: null,
       subsystems: [],
       failures: [],
+      unattributed_namespaces: [],
+      unattributed_hosts: [],
     });
   });
 


### PR DESCRIPTION
Closes #27

## What this adds

`nvmeof_list`, a read-only tool in `src/tools/block.ts` beside `iscsi_list`, reporting every NVMe-oF subsystem the system exports, the hosts allowed onto each, and the namespaces behind it.

Three middleware reads, all issued before any is awaited:

| read | answers |
|---|---|
| `nvmet.subsys.query` | the subsystems themselves |
| `nvmet.namespace.query` | the block devices behind each, carrying its subsystem nested inside it |
| `nvmet.host_subsys.query` | which hosts are allowed onto which subsystem, embedding both sides whole |

## The ticket's two unconfirmed design notes, confirmed

The ticket asked for both to be corrected here with what was found.

**`nvmet.subsys.query` and `nvmet.namespace.query` are both present** in the pinned client, and so is `nvmet.host_subsys.query`. All three are entries of `ApiCallDirectory$7` — the v25.10.0 call directory that `DefaultApiDirectory` aliases, which is the surface `ApiSurface` in `src/catalog/tool.ts` types every tool against. The ticket's note was written against `ApiCallDirectoryBase`, the intersection of every generated version, which does not carry `nvmet.namespace.query` (nor `iscsi.extent.query`, which `iscsi_list` already calls). The distinction is which of the two the client resolves `api.query` against, and for a client parameterised with a version it is that version's directory.

**A subsystem entry is untyped.** `NVMetSubsysEntry` is `Record<string, unknown>` in this client, so every field of a subsystem — including the id the other two reads are joined on — arrives as `unknown` and is read rather than trusted (`numberOrNull`, `booleanOrNull`, the existing `textOrNull`). Namespace and join rows *are* typed, but their nested `subsys` is the same untyped record, so the join runs through the same guard. That is also why no field can reach a caller as `undefined` and silently vanish from the JSON.

## The distinctions the description promises

- **`supported`.** A system whose version predates NVMe-oF answers `false`, `subsystems: null`, and `unsupported_reason` naming what the system said — not an empty list, which would read as a system that has NVMe-oF and exports nothing. It is reported `false` **only** where the system said it has no such method: the JSON-RPC `-32601`, or the middleware's `ENOMETHOD`, at the top level of the rejection or in the nested `data`, in the error name or in either text field. Anything else — a denied read, a dropped connection — is **raised**, so an unsupported verdict is never inferred from a failure that said nothing about support. `iscsi_list` raises on its own primary read the same way.
- **Configuration, not live state.** The middleware exposes no NVMe-oF equivalent of `iscsi.global.sessions` in this client, so the tool reports who *may* attach and the description says outright that it cannot report who *is* attached. An empty `hosts` is not an idle subsystem, and a full one is not a busy one.
- **`allow_any_host`.** Reported for the same reason `iscsi_list` reports `mode`: where it is true the host list restricts nothing, and without the field an empty `hosts` reads as a subsystem nobody may attach to.
- **Empty vs null vs unplaceable.** `hosts` and `namespaces` are `[]` for a read that succeeded and placed none of its rows here, `null` for one that failed — `failures` names which — and `null` too for a subsystem whose `id` the system did not report, since the id is what both are joined on. A row that was read and could **not** be placed on any subsystem listed goes into `unattributed_namespaces` or `unattributed_hosts` rather than being dropped; see below.
- **`size_bytes` is null on a ZVOL namespace**, which takes its size from the zvol rather than carrying a `filesize`. Null is a size this tool did not learn, never a namespace of no size.

## Round 2 — the rows that could not be placed

The first round's required check raised a MEDIUM (the local reviewer, independently, a HIGH): a namespace or host row the system did not attribute to a subsystem was dropped with no trace, leaving an empty `namespaces` beside an empty `failures` — which this tool's own description defines as *"the namespaces were read and none is on this subsystem"*. For an NVMe-oF listing that is the answer that gets acted on.

`iscsi_list`, in the same file, had already solved this: unattributable sessions go into `unattributed_initiators`, and its description says that while that list is not empty the per-target lists are incomplete. `nvmeof_list` now follows it, with `unattributed_namespaces` and `unattributed_hosts`. Each entry carries the `subsystem_id` and `subsystem` name its own record named, so what the row claimed is visible: both null where it named neither, `subsystem_id` set where it named an id nothing here answers to.

Three drops are now reported, where only two were even reachable in the first round:

1. A row whose nested subsystem record carries no readable `id`.
2. **A row naming an id no listed subsystem answers to** — filed under a map key nothing reads, and so lost exactly as silently as the first, but not named by either review. Closing only the first would have made the new field's own promise untrue.
3. A host grant whose host carries no NQN. It names a subsystem and still cannot be listed under it, since the list's whole content is names — so it appears with `hostnqn: null`.

Grouping moved out of the two reads and into one `attribute` helper, because deciding what a named id attributes to needs the subsystem listing, and that read is issued concurrently with the other two rather than before them. `readNamespaces` and `readHosts` now return the rows with the subsystem each claimed, and the handler places them.

Both lists are `[]` on the unsupported path, where no row was read at all. Each is `[]` when the read that would fill it failed — independently: a namespaces read that rejects leaves `unattributed_hosts` holding whatever the host read could not place, and `failures` names which read failed.

## Two changes inside `block.ts` that reach `iscsi_list`

Both are in the shared helpers at the top of the file, so they are called out rather than buried:

- **`errorText` now reads `reason` and `message` off a rejection that is a plain object.** Those are the two shapes the client documents itself as rejecting with (`JsonRpcError`, `TrueNasError`); reading neither reported *every* real failure, in this tool and in `iscsi_list`, as `the system reported no reason`. The existing assertion that `{ code: 500 }` reports that fallback still holds — that object carries neither field — so no `iscsi_list` behaviour changed except where it was previously discarding text the system had sent.
- **`Failure` and `attempt` are parameterised by their tool's own sources**, so a failure naming `extents` cannot appear in an NVMe-oF listing. Type-level only.

The file's header comment described the family as iSCSI-only and is now false, so it was rewritten. In the tests, `iscsi_list`'s local `fakeIscsi` helper is hoisted to module scope as `failingSystem` and shared, rather than duplicated for this tool.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test` (333 pass) and `yarn build` all run clean locally — the four gating steps of `.github/workflows/ci.yml`. `yarn test:coverage` passes with `block.ts` at 100% branch and statement coverage.

**This round's local review is weaker evidence than the first round's, and the difference is worth stating.** The project's own reviewer ran on the pre-fix commit and reported the same defect as the required check, at HIGH. On the fixed commit it timed out at its 420-second cap without producing findings, so the round fell back to a subagent applying the same rubric, threshold and schema in a fresh context — not the check's own verdict. That fallback returned **nothing at or above MEDIUM**, having also re-run typecheck, lint and the suite itself. Treat the required check on this PR as the first reader of the fix that is not me.

## What I did not change, and why

LOW findings across both rounds, left for a reader to weigh — a clean round ends the work, and every further fix is an unreviewed diff:

1. **`errorText` is duplicated in `src/tools/shares.ts:75`** and that copy still reports `{ reason: 'Not authorized' }` as having said nothing. Real, and outside this ticket: `shares.ts` restates the helper deliberately, and fixing it changes a tool this ticket does not own.
2. **`errorText` does not recurse into a nested `data.reason`** while `isUnsupported` does, so a JSON-RPC error wrapping a middleware one reports the outer generic message and drops the specific reason. Raised in both rounds. A genuine small improvement to the failure text; it changes no verdict.
3. **`isUnsupported` returns early for an `Error`**, so an `Error` carrying `errname: 'ENOMETHOD'` or `code: -32601` is judged on its message text alone, and the doc comment's "four places" overstates what that branch reads. Falling through to the object branch would cover both shapes. It costs a raised error rather than a wrong answer, which is the direction this function is deliberately biased in.
4. **`device_type` is passed through unguarded**, so a value outside `ZVOL | FILE` would reach a caller despite the declared union. `iscsi_list` passes `type` through identically two hundred lines above, so changing one without the other would be the inconsistency.
5. **The nested `subsys` and `host` records are dereferenced without a guard**, while every scalar beside them is read through `numberOrNull`/`textOrNull`. A row returned without a `subsys` key would throw out of the read. The pinned client declares both as required and the tool passes no `select`, so no response a supported system can produce omits them — I could not name a reachable failing input.
6. **`Attribution.bySubsystem` types the host lists as `(string | null)[]`** though `attribute` never files a null into one. Internal only; the handler returns `unknown`.
7. **The unsupported-path test only rejects `nvmet.subsys.query`**, so its `failures: []` assertion holds trivially rather than exercising the documented discard of the namespace and host failures. A real gap in what that test proves, though the behaviour it under-tests is one line.

Not reported at all, and worth a follow-up ticket rather than a silent widening here: **the tool does not say which ports a subsystem is published on**, so a subsystem listed here is not necessarily reachable over the network. The description states that limitation. Reporting it would need `nvmet.port.query` and `nvmet.port_subsys.query`, which is a fourth and fifth read and beyond this ticket's acceptance criteria.
