### PR TITLE
feat(tools): add users_list, local and directory users with their groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
-  `nvmeof_list`.
+  `nvmeof_list`, `users_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,5 +78,6 @@ export {
   shareAccess,
   iscsiList,
   nvmeofList,
+  usersList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -1,0 +1,243 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+
+/**
+ * Accounts family: who has an account on this system, and what each belongs to.
+ *
+ * Two middleware namespaces answer it. `user.query` lists the accounts, local
+ * and directory-provided alike, and each account carries its primary group
+ * whole; `group.query` lists the groups. The second read is what the auxiliary
+ * memberships are resolved against — an account names those by group record id
+ * and by nothing else, so without the listing they are numbers with no meaning.
+ *
+ * The account record is the one place in this library where over-returning is a
+ * hazard rather than a cost: it holds `unixhash`, `smbhash`, `sshpubkey` and
+ * `password_history`, and passing a row through would put every one of them in
+ * front of an LLM. Every field that survives is named here, so a credential a
+ * later TrueNAS release adds to the record cannot reach a caller without a
+ * change to this file.
+ */
+
+/** One group of the system, as this tool reports it. */
+interface GroupRow {
+  id: number;
+  gid: number;
+  name: string | null;
+  local: boolean;
+}
+
+/**
+ * A group an account named, resolved against the listing where it could be.
+ *
+ * `id` is what the account itself said. `gid` and `name` come from the group
+ * listing, and are null where that id answers to no group in it — which is a
+ * membership this tool could not place, never a membership that is not there.
+ */
+interface GroupReference {
+  id: number | null;
+  gid: number | null;
+  name: string | null;
+}
+
+/** The group listing, or the failure that stopped it being read. */
+interface Attempt {
+  rows: GroupRow[] | null;
+  error: string | null;
+}
+
+/**
+ * One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters: an
+ * account with no full name set is what the middleware sends `""` for, and
+ * passing that through would put a field in the result that says nothing.
+ *
+ * `shares.ts`, `tasks.ts` and `block.ts` each hold the same reading under their
+ * own names, and this restates rather than shares it for the reason `shares.ts`
+ * gives for restating its own guards: a tool file is read on its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * A number the system reported, or null where it reported anything else.
+ *
+ * Needed only for the primary group, which the account record embeds as
+ * `Record<string, unknown>` on the pinned client: every field of it arrives as
+ * `unknown` and has to be read rather than trusted. Non-finite is not a number
+ * here — a group id that is `NaN` resolves against nothing.
+ */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/**
+ * Why the group read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Anything else
+ * still becomes a stated absence rather than `"[object Object]"`, and the
+ * result is never empty: a failure with no text still has to read as a failure.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/**
+ * The groups the system knows, with a failure named rather than thrown.
+ *
+ * Reported rather than fatal because the two reads fail independently: a groups
+ * query that fails leaves every account still listed, still identified, and
+ * still carrying the primary group its own record embedded. Losing all of that
+ * to answer none of the question is the trade this exists to refuse.
+ *
+ * The tool holds one secondary read, so this names it directly instead of
+ * carrying the `failures` list that `shares.ts` and `block.ts` use for their
+ * several — a list that could only ever hold zero entries or one says less than
+ * the field it would be holding.
+ */
+async function readGroups(system: SystemHandle): Promise<Attempt> {
+  try {
+    const groups = await firstValueFrom(system.client.api.query('group.query'));
+    return {
+      rows: groups.map((group) => ({
+        id: group.id,
+        gid: group.gid,
+        // The entry declares a legacy `group` alias beside this, holding the
+        // same text; only the current name is reported.
+        name: textOrNull(group.name),
+        local: group.local,
+      })),
+      error: null,
+    };
+  } catch (reason) {
+    return { rows: null, error: errorText(reason) };
+  }
+}
+
+/** A group id an account named, with what the listing says about it. */
+function reference(id: number, listing: Map<number, GroupRow>): GroupReference {
+  const listed = listing.get(id);
+  return { id, gid: listed?.gid ?? null, name: listed?.name ?? null };
+}
+
+/**
+ * The group an account owns new files as, from the record embedded in it.
+ *
+ * The listing is preferred over that record, field by field, because it is the
+ * typed source and the one the auxiliary memberships resolve against: a group
+ * named in both is named the same way in both. The embedded record is what
+ * keeps a primary group reportable at all when the group read failed, when the
+ * group is not in the listing, or when the listing holds no name for it — which
+ * is why this can name a group that an auxiliary membership of the same id
+ * could not, and why the tool's description says so.
+ *
+ * (unconfirmed) The field names the embedded record spells its gid and name
+ * with are not typed by the pinned client, so they are read here as `gid` and
+ * `name` on the evidence of the group entry beside it. Getting them wrong costs
+ * a null rather than a wrong group.
+ */
+function primaryGroup(
+  record: Record<string, unknown>,
+  listing: Map<number, GroupRow>,
+): GroupReference {
+  const id = numberOrNull(record['id']);
+  const listed = id === null ? undefined : listing.get(id);
+  return {
+    id,
+    gid: listed?.gid ?? numberOrNull(record['gid']),
+    name: listed?.name ?? textOrNull(record['name']),
+  };
+}
+
+export const usersList: ReadOnlyTool = {
+  name: 'users_list',
+  description:
+    'Every user account the system knows, local and directory-provided, with ' +
+    'the groups each belongs to, and the groups themselves. `username`, `uid` ' +
+    'and `full_name` identify the account, and `full_name` is null where none ' +
+    "is set. `id` is the middleware's own record id and `uid` the POSIX user " +
+    'id: DIFFERENT NUMBERS, and neither follows the other — `id` is what group ' +
+    'membership is expressed in, and `uid` is what a file on disk is owned by. ' +
+    '`local` is whether the account is defined on this system, and FALSE MEANS ' +
+    'THE ACCOUNT COMES FROM A DIRECTORY SERVICE — Active Directory or LDAP — ' +
+    'rather than that it is disabled or missing. `shell` is the login shell, ' +
+    'null where the system reported none, which is usual for a directory ' +
+    'account. `locked` is whether the account is barred from logging in, and ' +
+    'is null where the system reported no value, WHICH IS NOT THE SAME AS ' +
+    'UNLOCKED. `primary_group` is the group the account owns new files as, and ' +
+    '`auxiliary_groups` the other groups it is a member of. Each is reported ' +
+    'as `id`, `gid` and `name`, where `id` is the group record the account ' +
+    'named. For an auxiliary group the other two come from `groups`, and are ' +
+    'null where that id answers to no group there — one id naming a group this ' +
+    'listing does not hold, or every id when the groups could not be read at ' +
+    'all. THAT IS A MEMBERSHIP THAT COULD NOT BE PLACED, never one that is ' +
+    'not there. The primary group is the one the account record carries whole, ' +
+    'so its `gid` and `name` come from `groups` where its id is there and from ' +
+    'that embedded record otherwise: it can be named where an auxiliary group ' +
+    'of the same id could not be, and all three of its fields are null only ' +
+    'where the record named nothing readable. `auxiliary_groups` is ' +
+    'null where the system reported no membership at all, which is not the ' +
+    'empty list it reports for an account belonging to no group beyond its ' +
+    'primary one. `groups` is every group the system knows, each with its ' +
+    '`id`, its `gid`, its `name` and whether it is `local` in the same sense a ' +
+    'user is; it is null, with `groups_error` naming what the system said, ' +
+    'where the groups could not be read, and an empty list with `groups_error` ' +
+    'null where they were read and there are none. NO PASSWORD HASH, SSH KEY, ' +
+    'TWO-FACTOR SECRET OR OTHER CREDENTIAL MATERIAL IS RETURNED BY THIS TOOL ' +
+    'under any circumstances: only the fields named here are returned, ' +
+    'whatever else a later TrueNAS release adds to an account record. This is ' +
+    'the account listing rather than live state — it does not say who is ' +
+    'logged in — and it does not report what an account is permitted to do: ' +
+    'who may reach a share is `share_access`.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other. Only the account read may fail the tool: the groups are what the
+    // memberships resolve against, and with no accounts there is nothing for
+    // them to resolve for.
+    const [users, groups] = await Promise.all([
+      firstValueFrom(system.client.api.query('user.query')),
+      readGroups(system),
+    ]);
+
+    const listing = new Map((groups.rows ?? []).map((group) => [group.id, group]));
+
+    return {
+      users: users.map((user) => ({
+        id: user.id,
+        username: user.username,
+        uid: user.uid,
+        full_name: textOrNull(user.full_name),
+        local: user.local,
+        shell: textOrNull(user.shell),
+        // Not defaulted to false: an account whose lock state was not reported
+        // must not read as one that is definitely able to log in.
+        locked: user.locked ?? null,
+        primary_group: primaryGroup(user.group, listing),
+        // The record names auxiliary groups by record id, and the field is
+        // absent altogether on a system that reported no membership — which is
+        // null here, distinct from the empty list of an account in no group
+        // beyond its primary one.
+        auxiliary_groups:
+          user.groups === undefined ? null : user.groups.map((id) => reference(id, listing)),
+      })),
+      groups: groups.rows,
+      groups_error: groups.error,
+    };
+  },
+};

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -19,6 +19,25 @@ import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
  * change to this file.
  */
 
+/**
+ * How many accounts and how many groups `users_list` returns when the caller
+ * names no bound, and the most it returns however large a bound is asked for.
+ *
+ * A TrueNAS joined to a directory service answers `user.query` with the
+ * directory's accounts as well as its own — tens of thousands of them on a real
+ * domain, and `group.query` in proportion. The whole set is neither answerable
+ * inside a model's context nor useful once it is there. The same bound is
+ * applied to each list separately, both numbers are stated in the tool's
+ * description, and the bound actually applied comes back with the result, so a
+ * caller never has to infer which one was in force.
+ *
+ * `snapshots.ts` bounds `pool.snapshot.query` the same way and for the same
+ * reason; the numbers are restated here rather than shared for the reason that
+ * file gives for restating its own guards: a tool file is read on its own.
+ */
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1000;
+
 /** One group of the system, as this tool reports it. */
 interface GroupRow {
   id: number;
@@ -43,6 +62,7 @@ interface GroupReference {
 /** The group listing, or the failure that stopped it being read. */
 interface Attempt {
   rows: GroupRow[] | null;
+  truncated: boolean;
   error: string | null;
 }
 
@@ -108,11 +128,20 @@ function errorText(reason: unknown): string {
  * several — a list that could only ever hold zero entries or one says less than
  * the field it would be holding.
  */
-async function readGroups(system: SystemHandle): Promise<Attempt> {
+async function readGroups(system: SystemHandle, limit: number): Promise<Attempt> {
   try {
-    const groups = await firstValueFrom(system.client.api.query('group.query'));
+    // One more row than the bound, as `snapshots.ts` does: that extra row is
+    // what says the system held more than fit, and it is counted and dropped.
+    // No `order_by` — the system applies the bound, so what it is asked to sort
+    // on would decide WHICH groups a truncated listing holds, and no field of a
+    // group orders it by relevance to the accounts being listed.
+    const groups = await firstValueFrom(
+      // Options are inlined so the call's own parameter types apply: written to
+      // a `const` first they widen and the result degrades to `Partial<Entry>`.
+      system.client.api.query('group.query', [], { limit: limit + 1 }),
+    );
     return {
-      rows: groups.map((group) => ({
+      rows: groups.slice(0, limit).map((group) => ({
         id: group.id,
         gid: group.gid,
         // The entry declares a legacy `group` alias beside this, holding the
@@ -120,10 +149,12 @@ async function readGroups(system: SystemHandle): Promise<Attempt> {
         name: textOrNull(group.name),
         local: group.local,
       })),
+      truncated: groups.length > limit,
       error: null,
     };
   } catch (reason) {
-    return { rows: null, error: errorText(reason) };
+    // Not truncated: nothing was read, so nothing was left out of a list.
+    return { rows: null, truncated: false, error: errorText(reason) };
   }
 }
 
@@ -162,6 +193,22 @@ function primaryGroup(
   };
 }
 
+/**
+ * The bound actually applied, from whatever the caller asked for.
+ *
+ * Lenient rather than strict, as `snapshots_list` is about its own limit: a
+ * misread bound only changes how many of the right rows come back, and the
+ * number applied is returned beside them, so a caller can see that its argument
+ * was not taken.
+ */
+function effectiveLimit(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_LIMIT;
+  // Rounded down because a fractional limit reaches the middleware as one, and
+  // floored at 1 because a limit of zero or less would return nothing while
+  // reporting the system as holding more — true, and not an answer.
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(raw)));
+}
+
 export const usersList: ReadOnlyTool = {
   name: 'users_list',
   description:
@@ -185,10 +232,13 @@ export const usersList: ReadOnlyTool = {
     'listing does not hold, or every id when the groups could not be read at ' +
     'all. THAT IS A MEMBERSHIP THAT COULD NOT BE PLACED, never one that is ' +
     'not there. The primary group is the one the account record carries whole, ' +
-    'so its `gid` and `name` come from `groups` where its id is there and from ' +
-    'that embedded record otherwise: it can be named where an auxiliary group ' +
-    'of the same id could not be, and all three of its fields are null only ' +
-    'where the record named nothing readable. `auxiliary_groups` is ' +
+    'so its `gid` and `name` are taken from `groups` and EACH FALLS BACK, ' +
+    'SEPARATELY, to that embedded record wherever the listing holds no value ' +
+    'for it — a group in `groups` with no name still reports the name its ' +
+    'account record gave. The primary group can therefore be named where an ' +
+    'auxiliary membership of the same id could not be, and all three of its ' +
+    'fields are null only where the account record named nothing readable. ' +
+    '`auxiliary_groups` is ' +
     'null where the system reported no membership at all, which is not the ' +
     'empty list it reports for an account belonging to no group beyond its ' +
     'primary one. `groups` is every group the system knows, each with its ' +
@@ -201,24 +251,51 @@ export const usersList: ReadOnlyTool = {
     'whatever else a later TrueNAS release adds to an account record. This is ' +
     'the account listing rather than live state — it does not say who is ' +
     'logged in — and it does not report what an account is permitted to do: ' +
-    'who may reach a share is `share_access`.',
-  inputSchema: { type: 'object', properties: {} },
+    'who may reach a share is `share_access`. BOTH LISTS ARE BOUNDED: `users` ' +
+    'holds at most `limit` accounts and `groups` at most `limit` groups — 100 ' +
+    'by default and 1000 at most, and the `limit` returned is the bound ' +
+    'actually applied. `users_truncated` and `groups_truncated` are true where ' +
+    'the system holds more than were returned, which a system joined to a ' +
+    'directory service usually does. Which accounts or groups a truncated list ' +
+    "holds is the system's own choice, so it is evidence about the entries it " +
+    'names and about nothing else: IT CANNOT SHOW THAT AN ACCOUNT IS ABSENT. ' +
+    'While `groups_truncated` is true, a null `gid` and `name` on a membership ' +
+    'may mean only that its group fell outside the bound rather than that the ' +
+    'id answers to no group on the system. Raise `limit` until both are false, ' +
+    'and only then read either list as everything that exists.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      limit: {
+        type: 'number',
+        minimum: 1,
+        maximum: 1000,
+        default: 100,
+        description:
+          'Return at most this many accounts, and at most this many groups. ' +
+          'Default 100, maximum 1000.',
+      },
+    },
+  },
   requiredRole: Role.ReadOnly,
   mutating: false,
-  async handler({ system }) {
+  async handler({ system }, args) {
+    const limit = effectiveLimit(args['limit']);
     // Both reads are issued before either is awaited, so neither waits on the
     // other. Only the account read may fail the tool: the groups are what the
     // memberships resolve against, and with no accounts there is nothing for
     // them to resolve for.
     const [users, groups] = await Promise.all([
-      firstValueFrom(system.client.api.query('user.query')),
-      readGroups(system),
+      // Options inlined, and one row past the bound, for the reasons
+      // `readGroups` gives.
+      firstValueFrom(system.client.api.query('user.query', [], { limit: limit + 1 })),
+      readGroups(system, limit),
     ]);
 
     const listing = new Map((groups.rows ?? []).map((group) => [group.id, group]));
 
     return {
-      users: users.map((user) => ({
+      users: users.slice(0, limit).map((user) => ({
         id: user.id,
         username: user.username,
         uid: user.uid,
@@ -236,8 +313,11 @@ export const usersList: ReadOnlyTool = {
         auxiliary_groups:
           user.groups === undefined ? null : user.groups.map((id) => reference(id, listing)),
       })),
+      users_truncated: users.length > limit,
       groups: groups.rows,
+      groups_truncated: groups.truncated,
       groups_error: groups.error,
+      limit,
     };
   },
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import { ToolCatalog } from '@/catalog/catalog';
+import { usersList } from '@/tools/accounts';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
@@ -11,7 +12,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: eighteen read-only tools plus one mutating tool. */
+/** The sketch's catalog: nineteen read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -32,6 +33,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(shareAccess);
   catalog.register(iscsiList);
   catalog.register(nvmeofList);
+  catalog.register(usersList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -56,4 +58,5 @@ export {
   snapshotTasksList,
   systemInfo,
   tasksRecentRuns,
+  usersList,
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -22,6 +22,7 @@ import {
   snapshotsList,
   snapshotTasksList,
   tasksRecentRuns,
+  usersList,
 } from '@/tools/index';
 
 /**
@@ -60,7 +61,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the nineteen sketch tools', () => {
+  it('registers the twenty sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -80,6 +81,7 @@ describe('createDefaultCatalog', () => {
       'share_access',
       'iscsi_list',
       'nvmeof_list',
+      'users_list',
       'snapshots_create',
     ]);
   });
@@ -158,6 +160,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises nvmeof_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('nvmeof_list');
+  });
+
+  it('advertises users_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('users_list');
   });
 });
 
@@ -4807,6 +4813,276 @@ describe('nvmeof_list', () => {
       'nvmet.namespace.query',
       'nvmet.host_subsys.query',
     ]);
+    await listing;
+  });
+});
+
+describe('users_list', () => {
+  /**
+   * An account as `user.query` reports one. `unixhash`, `smbhash`, `sshpubkey`,
+   * `password_history` and `api_keys` are real fields of the payload, and are
+   * here to be dropped: this fixture is what makes "no credential material"
+   * assertable rather than assumed.
+   */
+  const user = (over: Record<string, unknown> = {}) => ({
+    id: 41,
+    uid: 3001,
+    username: 'jbarnes',
+    full_name: 'Jo Barnes',
+    local: true,
+    shell: '/usr/bin/bash',
+    locked: false,
+    group: { id: 101, gid: 3001, name: 'jbarnes' },
+    groups: [102],
+    unixhash: '$6$rounds=656000$notarealhash',
+    smbhash: 'jbarnes:3001:AAD3B435B51404EE:31D6CFE0D16AE931:[U]:LCT-00000000:',
+    sshpubkey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI jo@laptop',
+    password_history: [{ changed: '2026-01-04' }],
+    password_disabled: false,
+    twofactor_auth_configured: true,
+    sid: 'S-1-5-21-1004336348-1177238915-682003330-1013',
+    email: 'jo@example.com',
+    home: '/home/jbarnes',
+    builtin: false,
+    immutable: false,
+    api_keys: [4],
+    roles: ['READONLY_ADMIN'],
+    ...over,
+  });
+
+  /** A group as `group.query` reports one. */
+  const group = (over: Record<string, unknown> = {}) => ({
+    id: 101,
+    gid: 3001,
+    name: 'jbarnes',
+    group: 'jbarnes',
+    local: true,
+    builtin: false,
+    immutable: false,
+    sid: null,
+    roles: [],
+    users: [41],
+    ...over,
+  });
+
+  type Listing = {
+    users: Record<string, unknown>[];
+    groups: Record<string, unknown>[] | null;
+    groups_error: string | null;
+  };
+
+  const listed = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Listing> => {
+    const { ctx } = failingSystem(
+      {
+        ['user.query']: [user()],
+        ['group.query']: [group(), group({ id: 102, gid: 4001, name: 'engineering' })],
+        ...rows,
+      },
+      failures,
+    );
+    return (await usersList.handler(ctx, {})) as Listing;
+  };
+
+  /** The single account of a listing, for the cases about one's fields. */
+  const onlyUser = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => (await listed(rows, failures)).users[0];
+
+  it('reports each account with its identity, its shell and its group membership', async () => {
+    expect(await listed()).toEqual({
+      users: [
+        {
+          id: 41,
+          username: 'jbarnes',
+          uid: 3001,
+          full_name: 'Jo Barnes',
+          local: true,
+          shell: '/usr/bin/bash',
+          locked: false,
+          primary_group: { id: 101, gid: 3001, name: 'jbarnes' },
+          auxiliary_groups: [{ id: 102, gid: 4001, name: 'engineering' }],
+        },
+      ],
+      groups: [
+        { id: 101, gid: 3001, name: 'jbarnes', local: true },
+        { id: 102, gid: 4001, name: 'engineering', local: true },
+      ],
+      groups_error: null,
+    });
+  });
+
+  it('returns no credential material, and no field a later release adds', async () => {
+    const listing = await listed({
+      ['user.query']: [user({ future_field: 'added by a later release' })],
+      ['group.query']: [group({ future_field: 'added by a later release' })],
+    });
+    expect(Object.keys(listing)).toEqual(['users', 'groups', 'groups_error']);
+    expect(Object.keys(listing.users[0])).toEqual([
+      'id',
+      'username',
+      'uid',
+      'full_name',
+      'local',
+      'shell',
+      'locked',
+      'primary_group',
+      'auxiliary_groups',
+    ]);
+    expect(Object.keys((listing.groups ?? [])[0])).toEqual(['id', 'gid', 'name', 'local']);
+    // Asserted against the whole serialized result rather than field by field:
+    // a credential that reached a nested object would pass a key check on the
+    // account and still be in front of the caller.
+    const serialized = JSON.stringify(listing);
+    for (const secret of [
+      'notarealhash',
+      '31D6CFE0D16AE931',
+      'ssh-ed25519',
+      'password_history',
+      'api_keys',
+      'twofactor',
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('distinguishes a directory account from a local one', async () => {
+    const listing = await listed({
+      ['user.query']: [
+        user(),
+        user({ id: 42, uid: 11002, username: 'AD\\rlee', full_name: 'R Lee', local: false }),
+      ],
+    });
+    expect(listing.users.map((one) => [one['username'], one['local']])).toEqual([
+      ['jbarnes', true],
+      ['AD\\rlee', false],
+    ]);
+  });
+
+  it('reports an unset full name, shell or lock state as null rather than as a value', async () => {
+    // A directory account is the case that carries none of the three: the
+    // middleware sends `""` for a name it does not have and omits the rest.
+    const bare = user({ full_name: '', shell: undefined, locked: undefined });
+    expect(await onlyUser({ ['user.query']: [bare] })).toMatchObject({
+      full_name: null,
+      shell: null,
+      locked: null,
+    });
+  });
+
+  it('reports an account in no group beyond its primary one as an empty list', async () => {
+    expect(await onlyUser({ ['user.query']: [user({ groups: [] })] })).toMatchObject({
+      auxiliary_groups: [],
+    });
+  });
+
+  it('reports an account whose membership the system did not send as null', async () => {
+    // Null rather than the empty list, which would say the account belongs to
+    // nothing when what is true is that nothing was said about it.
+    expect(await onlyUser({ ['user.query']: [user({ groups: undefined })] })).toMatchObject({
+      auxiliary_groups: null,
+    });
+  });
+
+  it('keeps a membership naming a group the listing does not hold', async () => {
+    // Reported with a null gid and name rather than dropped: a dropped id
+    // leaves a shorter list behind that says the account is not in the group.
+    expect(await onlyUser({ ['user.query']: [user({ groups: [102, 999] })] })).toMatchObject({
+      auxiliary_groups: [
+        { id: 102, gid: 4001, name: 'engineering' },
+        { id: 999, gid: null, name: null },
+      ],
+    });
+  });
+
+  it('reads the primary group from the listing, and falls back to the embedded record', async () => {
+    const listing = await listed({
+      ['user.query']: [
+        // Its embedded record disagrees with the listing about the name; the
+        // listing is the typed source and the one memberships resolve against.
+        user({ group: { id: 101, gid: 9, name: 'stale' } }),
+        // Not in the listing at all, so the embedded record is all there is.
+        user({ id: 42, username: 'svc', group: { id: 500, gid: 500, name: 'svc' } }),
+        // An embedded record naming nothing readable.
+        user({ id: 43, username: 'broken', group: {} }),
+      ],
+    });
+    expect(listing.users.map((one) => one['primary_group'])).toEqual([
+      { id: 101, gid: 3001, name: 'jbarnes' },
+      { id: 500, gid: 500, name: 'svc' },
+      { id: null, gid: null, name: null },
+    ]);
+  });
+
+  it('reports the groups that could not be read as null, with the reason', async () => {
+    const listing = await listed({}, { ['group.query']: new Error('group.query: access denied') });
+    expect(listing.groups).toBeNull();
+    expect(listing.groups_error).toBe('group.query: access denied');
+    // The accounts still list, still identified, and the primary group still
+    // reports from the record embedded in the account itself.
+    expect(listing.users[0]).toMatchObject({
+      username: 'jbarnes',
+      primary_group: { id: 101, gid: 3001, name: 'jbarnes' },
+      // Unresolvable, and kept as the id the account named.
+      auxiliary_groups: [{ id: 102, gid: null, name: null }],
+    });
+  });
+
+  it('names a failure however the client rejected', async () => {
+    const reasons: [unknown, string][] = [
+      [{ reason: 'group.query failed' }, 'group.query failed'],
+      [{ message: 'connection reset' }, 'connection reset'],
+      ['ENOTCONN', 'ENOTCONN'],
+      [new Error(''), 'the system reported no reason'],
+      [{ code: 42 }, 'the system reported no reason'],
+      [null, 'the system reported no reason'],
+    ];
+    for (const [reason, expected] of reasons) {
+      expect((await listed({}, { ['group.query']: reason })).groups_error).toBe(expected);
+    }
+  });
+
+  it('reports a group whose name the system did not send as null', async () => {
+    const listing = await listed({
+      ['user.query']: [user({ groups: [101] })],
+      ['group.query']: [group({ name: '' })],
+    });
+    expect(listing.groups).toEqual([{ id: 101, gid: 3001, name: null, local: true }]);
+    expect(listing.users[0]).toMatchObject({
+      // A group that is listed and has no name to give: a null name beside a
+      // gid that is there, which is not the pair of nulls of an id answering to
+      // no group at all.
+      auxiliary_groups: [{ id: 101, gid: 3001, name: null }],
+      // The primary group is the one the account record carries whole, so it
+      // still has a name to fall back to where the listing has none.
+      primary_group: { id: 101, gid: 3001, name: 'jbarnes' },
+    });
+  });
+
+  it('reports a system with no accounts and no groups as empty lists', async () => {
+    expect(await listed({ ['user.query']: [], ['group.query']: [] })).toEqual({
+      users: [],
+      groups: [],
+      groups_error: null,
+    });
+  });
+
+  it('raises when the accounts themselves cannot be read', async () => {
+    // The groups alone answer none of the question, so this one is fatal where
+    // the group read is reported.
+    await expect(listed({}, { ['user.query']: new Error('nope') })).rejects.toThrow('nope');
+  });
+
+  it('issues both reads before awaiting either of them', async () => {
+    const { ctx, query } = failingSystem({
+      ['user.query']: [user()],
+      ['group.query']: [group()],
+    });
+    const listing = usersList.handler(ctx, {});
+    expect(query.mock.calls.map((one) => one[0])).toEqual(['user.query', 'group.query']);
     await listing;
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -4867,13 +4867,17 @@ describe('users_list', () => {
 
   type Listing = {
     users: Record<string, unknown>[];
+    users_truncated: boolean;
     groups: Record<string, unknown>[] | null;
+    groups_truncated: boolean;
     groups_error: string | null;
+    limit: number;
   };
 
   const listed = async (
     rows: Partial<Record<string, unknown>> = {},
     failures: Partial<Record<string, unknown>> = {},
+    args: Record<string, unknown> = {},
   ): Promise<Listing> => {
     const { ctx } = failingSystem(
       {
@@ -4883,7 +4887,7 @@ describe('users_list', () => {
       },
       failures,
     );
-    return (await usersList.handler(ctx, {})) as Listing;
+    return (await usersList.handler(ctx, args)) as Listing;
   };
 
   /** The single account of a listing, for the cases about one's fields. */
@@ -4907,11 +4911,14 @@ describe('users_list', () => {
           auxiliary_groups: [{ id: 102, gid: 4001, name: 'engineering' }],
         },
       ],
+      users_truncated: false,
       groups: [
         { id: 101, gid: 3001, name: 'jbarnes', local: true },
         { id: 102, gid: 4001, name: 'engineering', local: true },
       ],
+      groups_truncated: false,
       groups_error: null,
+      limit: 100,
     });
   });
 
@@ -4920,7 +4927,14 @@ describe('users_list', () => {
       ['user.query']: [user({ future_field: 'added by a later release' })],
       ['group.query']: [group({ future_field: 'added by a later release' })],
     });
-    expect(Object.keys(listing)).toEqual(['users', 'groups', 'groups_error']);
+    expect(Object.keys(listing)).toEqual([
+      'users',
+      'users_truncated',
+      'groups',
+      'groups_truncated',
+      'groups_error',
+      'limit',
+    ]);
     expect(Object.keys(listing.users[0])).toEqual([
       'id',
       'username',
@@ -5065,9 +5079,66 @@ describe('users_list', () => {
   it('reports a system with no accounts and no groups as empty lists', async () => {
     expect(await listed({ ['user.query']: [], ['group.query']: [] })).toEqual({
       users: [],
+      users_truncated: false,
       groups: [],
+      groups_truncated: false,
       groups_error: null,
+      limit: 100,
     });
+  });
+
+  it('bounds both lists, and says which of them the system held more of', async () => {
+    const listing = await listed(
+      {
+        // Three of each against a bound of two: the third row is what says the
+        // system held more than fit, and it is dropped rather than reported.
+        ['user.query']: [user(), user({ id: 42, username: 'b' }), user({ id: 43, username: 'c' })],
+        ['group.query']: [group(), group({ id: 102, name: 'b' }), group({ id: 103, name: 'c' })],
+      },
+      {},
+      { limit: 2 },
+    );
+    expect(listing.users.map((one) => one['username'])).toEqual(['jbarnes', 'b']);
+    expect((listing.groups ?? []).map((one) => one['name'])).toEqual(['jbarnes', 'b']);
+    expect(listing).toMatchObject({ users_truncated: true, groups_truncated: true, limit: 2 });
+  });
+
+  it('reports one list as truncated without the other', async () => {
+    const listing = await listed(
+      { ['user.query']: [user(), user({ id: 42, username: 'b' })], ['group.query']: [group()] },
+      {},
+      { limit: 1 },
+    );
+    expect(listing).toMatchObject({ users_truncated: true, groups_truncated: false });
+  });
+
+  it('asks the system for one row past the bound, on both reads', async () => {
+    const { ctx, query } = failingSystem({ ['user.query']: [user()], ['group.query']: [group()] });
+    await usersList.handler(ctx, { limit: 5 });
+    expect(query.mock.calls).toEqual([
+      ['user.query', [], { limit: 6 }],
+      ['group.query', [], { limit: 6 }],
+    ]);
+  });
+
+  it('applies a usable bound whatever the caller asked for', async () => {
+    const applied = async (limit: unknown): Promise<number> =>
+      (await listed({}, {}, { limit })).limit;
+    expect(await applied(undefined)).toBe(100);
+    expect(await applied('lots')).toBe(100);
+    expect(await applied(Number.NaN)).toBe(100);
+    // Rounded down: a fractional limit reaches the middleware as one.
+    expect(await applied(2.7)).toBe(2);
+    // Floored at 1 rather than returning nothing while reporting more.
+    expect(await applied(0)).toBe(1);
+    expect(await applied(-5)).toBe(1);
+    expect(await applied(9000)).toBe(1000);
+  });
+
+  it('reports the groups as not truncated when they could not be read at all', async () => {
+    // Nothing was read, so nothing was left out of a list either.
+    const listing = await listed({}, { ['group.query']: new Error('denied') });
+    expect(listing).toMatchObject({ groups: null, groups_truncated: false });
   });
 
   it('raises when the accounts themselves cannot be read', async () => {
@@ -5082,6 +5153,8 @@ describe('users_list', () => {
       ['group.query']: [group()],
     });
     const listing = usersList.handler(ctx, {});
+    // Asserted before the handler is awaited at all, which is what makes this
+    // about concurrency rather than order.
     expect(query.mock.calls.map((one) => one[0])).toEqual(['user.query', 'group.query']);
     await listing;
   });


### PR DESCRIPTION
Adds `users_list`, a read-only tool returning the accounts the system knows — local and directory-provided — with the groups each belongs to, and the groups themselves.

Fixes #28

## What it returns

`users` holds one entry per account: `id`, `username`, `uid`, `full_name`, `local`, `shell`, `locked`, `primary_group` and `auxiliary_groups`. `groups` holds one entry per group: `id`, `gid`, `name`, `local`. Beside them, `users_truncated`, `groups_truncated`, `groups_error` and the `limit` actually applied.

**No credential material, by construction.** The account record is the one payload in this library where over-returning is a hazard rather than a cost — `user.query` carries `unixhash`, `smbhash`, `sshpubkey`, `password_history` and `api_keys` on every row. Every field that survives is named explicitly, so a credential a later TrueNAS release adds to the record cannot reach a caller without a change to this file. The fixture in the spec carries all five, and the test asserts against the whole serialized result rather than only against the account's key set — a secret that reached a nested object would pass a key check and still be in front of the caller.

**`local` is what distinguishes a directory account** from one defined on this system; `false` means Active Directory or LDAP, not disabled or missing.

**Memberships are kept even when they cannot be placed.** An auxiliary group naming an id no listed group answers to is reported with a null `gid` and `name` rather than dropped: a dropped id leaves a shorter list behind that says the account is not in a group it is in. `auxiliary_groups` is null where the system reported no membership at all, which is distinct from the empty list of an account in no group beyond its primary one.

**Only the account read may fail the tool.** A failed `group.query` is reported as `groups: null` with `groups_error`, leaving every account still listed and still identified — the primary group comes from the record the account embeds, so it stays named. The tool holds one secondary read, so it names that error directly instead of carrying the `failures` list `shares.ts` and `block.ts` use for their several.

## Both reads are bounded

A TrueNAS joined to a directory service answers `user.query` with the whole directory. Both lists are bounded by a `limit` argument — 100 by default, 1000 at most, applied to each separately — following what `snapshots_list` does to `pool.snapshot.query`: one row past the bound is requested so truncation is observed rather than inferred, and no `order_by` is asked for, since what the system is asked to sort on would decide *which* rows a truncated listing holds. `users_truncated` and `groups_truncated` say which list the system held more of. A truncated group listing changes what a null `gid` and `name` on a membership means, and the description says so.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test` (353 passing) and `yarn build` all pass locally. `yarn test:coverage` passes with `accounts.ts` at 100% statements and branches and the global floors up at 99.21 / 99.13.

Two local review rounds ran the project's own reviewer in a separate process. Round one raised one MEDIUM — both reads unbounded against an empty input schema — and a LOW that the description claimed the primary group is taken whole from `groups` where its id is listed and from the embedded record otherwise, when the fallback is in fact per field. Both are fixed in the second commit. Round two returned nothing at MEDIUM or above.

## What round two raised and this PR did not change

Left as-is deliberately, so the reviewer here and a later ticket can take them:

- **`user.groups` is read with a strict `=== undefined` check and no shape guard**, so a middleware sending a non-array there would throw out of the handler rather than nulling one field. Real, and it is the only unguarded shape assumption left in the file.
- **Credential material still crosses the wire.** Up to 1001 whole account records are fetched and sit in memory before the field allowlist drops them; no `select` narrows the query. The guarantee this tool makes is about its result, and a `select` would trade the typed response for `Partial<UserEntry>`, but defence in depth at the query would be better than none.
- **`limit` cannot always reach an untruncated listing.** Above 1000 accounts there is no filter and no offset to narrow with, so the description's "raise `limit` until both are false" is advice a large domain cannot take. A `username` or `uid` filter is the natural follow-up — and it is what would make this the id-to-person lookup the ticket describes `share_access` as needing.
- **`textOrNull` / `errorText` / `NO_REASON` are restated here for the fourth time**, which is the convention `shares.ts` and `block.ts` both state and follow — a tool file is read on its own. The reviewer notes the `shares.ts` copy has already diverged; consolidating them is a decision about the family rather than about this ticket.

One field is absent by choice rather than by oversight: `builtin` would let a caller tell a system account from a person, and it is not among the ticket's acceptance criteria, so it is not returned.
