### PR TITLE
feat(tools): add directory_services_status, whether Active Directory or LDAP is joined and healthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
-  `nvmeof_list`, `users_list`.
+  `nvmeof_list`, `users_list`, `directory_services_status`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,5 +79,6 @@ export {
   iscsiList,
   nvmeofList,
   usersList,
+  directoryServicesStatus,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -399,9 +399,12 @@ export const directoryServicesStatus: ReadOnlyTool = {
     'directory service is the ordinary case and is not a failure. `status` is ' +
     'the live state of the join, one of `HEALTHY` (joined and working), ' +
     '`FAULTED` (configured and NOT working), `JOINING` or `LEAVING` (a join or ' +
-    'a departure is in progress), and `DISABLED` (configured but switched ' +
-    'off); it is null where the system reported no state, WHICH IS NOT THE ' +
-    'SAME AS HEALTHY. So "no directory service" is `service_type` null, and ' +
+    'a departure is in progress), and `DISABLED` (no directory service is in ' +
+    'effect, which is what a system with none configured reports as well as ' +
+    'one that is configured and switched off — `service_type` is what tells ' +
+    'those two apart); it is null where the system reported no state, WHICH ' +
+    'IS NOT THE SAME AS HEALTHY. So "no directory service" is `service_type` ' +
+    'null, and ' +
     '"a directory service that is not working" is `service_type` set with ' +
     '`status` `FAULTED` — the two never have to be told apart by reading ' +
     'prose. `status_message` is what the system said about that state, which ' +

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -3,20 +3,29 @@ import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 
 /**
- * Accounts family: who has an account on this system, and what each belongs to.
+ * Accounts family: who has an account on this system, what each belongs to, and
+ * whether the directory service the non-local ones come from is joined.
  *
- * Two middleware namespaces answer it. `user.query` lists the accounts, local
- * and directory-provided alike, and each account carries its primary group
- * whole; `group.query` lists the groups. The second read is what the auxiliary
- * memberships are resolved against — an account names those by group record id
- * and by nothing else, so without the listing they are numbers with no meaning.
+ * `users_list` reads two middleware namespaces. `user.query` lists the
+ * accounts, local and directory-provided alike, and each account carries its
+ * primary group whole; `group.query` lists the groups. The second read is what
+ * the auxiliary memberships are resolved against — an account names those by
+ * group record id and by nothing else, so without the listing they are numbers
+ * with no meaning.
  *
- * The account record is the one place in this library where over-returning is a
- * hazard rather than a cost: it holds `unixhash`, `smbhash`, `sshpubkey` and
- * `password_history`, and passing a row through would put every one of them in
- * front of an LLM. Every field that survives is named here, so a credential a
- * later TrueNAS release adds to the record cannot reach a caller without a
- * change to this file.
+ * `directory_services_status` reads two more. `directoryservices.status` is the
+ * live join state, and it is the tool; `directoryservices.config` is where the
+ * domain and the bind method are read from, and it is reported rather than
+ * fatal for the reason `readConfig` gives.
+ *
+ * Both payloads are ones where over-returning is a hazard rather than a cost.
+ * The account record holds `unixhash`, `smbhash`, `sshpubkey` and
+ * `password_history`; the directory services configuration embeds the
+ * credential the system binds with — a Kerberos `password`, an LDAP `bindpw`.
+ * Passing either row through would put every one of them in front of an LLM.
+ * Every field that survives is named here, so a credential a later TrueNAS
+ * release adds to either record cannot reach a caller without a change to this
+ * file.
  */
 
 /**
@@ -318,6 +327,129 @@ export const usersList: ReadOnlyTool = {
       groups_truncated: groups.truncated,
       groups_error: groups.error,
       limit,
+    };
+  },
+};
+
+/** What `directoryservices.config` contributes, when it could be read. */
+interface DirectoryConfig {
+  enabled: boolean;
+  domain: string | null;
+  server_urls: string[] | null;
+  kerberos_realm: string | null;
+  credential_type: string | null;
+}
+
+/** The directory services configuration, or the failure that stopped it. */
+interface ConfigAttempt {
+  values: DirectoryConfig | null;
+  error: string | null;
+}
+
+/**
+ * What the system is configured to join, with a failure named rather than
+ * thrown.
+ *
+ * Reported rather than fatal for the reason `readGroups` is: the two reads fail
+ * independently, and the question the tool is asked — is the directory service
+ * joined and healthy — is answered by `directoryservices.status` on its own.
+ * The status read is the one that may fail the tool, because a domain with no
+ * state beside it says nothing about whether the join works.
+ *
+ * NO CREDENTIAL IS TAKEN OUT OF THIS PAYLOAD. `credential` embeds the secret
+ * the system binds with — `password` on a Kerberos user, `bindpw` on an LDAP
+ * plain bind — and only its `credential_type` discriminant is read, which names
+ * HOW the system binds and never WITH WHAT.
+ */
+async function readConfig(system: SystemHandle): Promise<ConfigAttempt> {
+  try {
+    const entry = await firstValueFrom(system.client.api.call('directoryservices.config'));
+    // The per-service configuration is a union carrying no discriminant of its
+    // own, so each field is narrowed by the presence of the field itself: an
+    // Active Directory or IPA configuration holds `domain` and an LDAP one does
+    // not; an LDAP one holds `server_urls` and the other two do not.
+    const configuration = entry.configuration ?? null;
+    return {
+      values: {
+        enabled: entry.enable,
+        domain:
+          configuration !== null && 'domain' in configuration
+            ? textOrNull(configuration.domain)
+            : null,
+        server_urls:
+          configuration !== null && 'server_urls' in configuration
+            ? configuration.server_urls
+            : null,
+        kerberos_realm: textOrNull(entry.kerberos_realm),
+        credential_type: entry.credential?.credential_type ?? null,
+      },
+      error: null,
+    };
+  } catch (reason) {
+    return { values: null, error: errorText(reason) };
+  }
+}
+
+export const directoryServicesStatus: ReadOnlyTool = {
+  name: 'directory_services_status',
+  description:
+    'Whether this system is joined to a directory service — Active Directory, ' +
+    'IPA or LDAP — and whether that join is currently working. `service_type` ' +
+    'is which one is configured, and NULL MEANS NONE IS: a system with no ' +
+    'directory service is the ordinary case and is not a failure. `status` is ' +
+    'the live state of the join, one of `HEALTHY` (joined and working), ' +
+    '`FAULTED` (configured and NOT working), `JOINING` or `LEAVING` (a join or ' +
+    'a departure is in progress), and `DISABLED` (configured but switched ' +
+    'off); it is null where the system reported no state, WHICH IS NOT THE ' +
+    'SAME AS HEALTHY. So "no directory service" is `service_type` null, and ' +
+    '"a directory service that is not working" is `service_type` set with ' +
+    '`status` `FAULTED` — the two never have to be told apart by reading ' +
+    'prose. `status_message` is what the system said about that state, which ' +
+    'is where the reason for a `FAULTED` join appears, and is null where it ' +
+    'said nothing. `enabled` is whether the configured service is switched on, ' +
+    'which is the setting rather than the state: a service can be enabled and ' +
+    '`FAULTED` at the same time. `domain` is the Active Directory or IPA ' +
+    'domain, and IS NULL FOR AN LDAP SERVICE, WHICH HAS NO DOMAIN — an LDAP ' +
+    'directory is identified by `server_urls` instead, which is in turn null ' +
+    'for Active Directory and IPA. `kerberos_realm` is the realm the join ' +
+    'authenticates against, null where none is set. `credential_type` names ' +
+    'HOW the system binds — a Kerberos user or principal, an anonymous, plain ' +
+    'or certificate LDAP bind — and is null where no credential is ' +
+    'configured. NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE IS ' +
+    'RETURNED BY THIS TOOL under any circumstances: only the fields named here ' +
+    'are returned, whatever else a later TrueNAS release adds to the ' +
+    'configuration. `config_error` names what the system said when the ' +
+    'configuration could not be read at all, and WHILE IT IS NON-NULL ' +
+    '`enabled`, `domain`, `server_urls`, `kerberos_realm` and ' +
+    '`credential_type` ARE ALL NULL BECAUSE THEY COULD NOT BE READ, not ' +
+    'because they are unset — `service_type`, `status` and `status_message` ' +
+    'come from a separate read and are unaffected. This tool reports the join; ' +
+    'it does not join, leave or reconfigure anything, and it does not list the ' +
+    'accounts the directory provides — that is `users_list`.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other. Only the status read may fail the tool, for the reason
+    // `readConfig` gives.
+    const [status, config] = await Promise.all([
+      firstValueFrom(system.client.api.call('directoryservices.status')),
+      readConfig(system),
+    ]);
+
+    return {
+      service_type: status.type,
+      // Not defaulted to a state: a status the system did not report must not
+      // read as one it did.
+      status: status.status ?? null,
+      status_message: textOrNull(status.status_msg),
+      enabled: config.values?.enabled ?? null,
+      domain: config.values?.domain ?? null,
+      server_urls: config.values?.server_urls ?? null,
+      kerberos_realm: config.values?.kerberos_realm ?? null,
+      credential_type: config.values?.credential_type ?? null,
+      config_error: config.error,
     };
   },
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,5 @@
 import { ToolCatalog } from '@/catalog/catalog';
-import { usersList } from '@/tools/accounts';
+import { directoryServicesStatus, usersList } from '@/tools/accounts';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
@@ -12,7 +12,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: nineteen read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -34,6 +34,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(iscsiList);
   catalog.register(nvmeofList);
   catalog.register(usersList);
+  catalog.register(directoryServicesStatus);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -43,6 +44,7 @@ export {
   appsList,
   cloudsyncTasksList,
   createSnapshot,
+  directoryServicesStatus,
   disksList,
   iscsiList,
   listDatasets,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8,6 +8,7 @@ import {
   cloudsyncTasksList,
   createDefaultCatalog,
   createSnapshot,
+  directoryServicesStatus,
   disksList,
   iscsiList,
   listDatasets,
@@ -44,24 +45,30 @@ function fakeSystem(responses: Partial<Record<string, unknown>>): {
 }
 
 /**
- * A SystemHandle whose queries answer independently, either with rows or by
+ * A SystemHandle whose methods answer independently, either with rows or by
  * failing — `fakeSystem` answers every method from one map and has no way to
  * make a call fail, which the tools that read several methods and return a
  * partial answer are largely about.
+ *
+ * Both seams are stubbed from the same two maps, as `fakeSystem` stubs both
+ * from its one: a tool picks `call` or `query` per verb, so a test asserts on
+ * whichever spy its tool used and names its failures under the same method
+ * either way.
  */
 function failingSystem(
   rows: Partial<Record<string, unknown>>,
   failures: Partial<Record<string, unknown>> = {},
-): { ctx: ToolContext; query: ReturnType<typeof vi.fn> } {
-  const query = vi.fn((method: string) =>
-    method in failures ? throwError(() => failures[method]) : of(rows[method]),
-  );
-  const system = { name: 'nas', client: { api: { query } } } as unknown as SystemHandle;
-  return { ctx: { system }, query };
+): { ctx: ToolContext; query: ReturnType<typeof vi.fn>; call: ReturnType<typeof vi.fn> } {
+  const answer = (method: string) =>
+    method in failures ? throwError(() => failures[method]) : of(rows[method]);
+  const query = vi.fn(answer);
+  const call = vi.fn(answer);
+  const system = { name: 'nas', client: { api: { query, call } } } as unknown as SystemHandle;
+  return { ctx: { system }, query, call };
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty sketch tools', () => {
+  it('registers the twenty-one sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -82,6 +89,7 @@ describe('createDefaultCatalog', () => {
       'iscsi_list',
       'nvmeof_list',
       'users_list',
+      'directory_services_status',
       'snapshots_create',
     ]);
   });
@@ -164,6 +172,12 @@ describe('createDefaultCatalog', () => {
 
   it('advertises users_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('users_list');
+  });
+
+  it('advertises directory_services_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'directory_services_status',
+    );
   });
 });
 
@@ -5157,5 +5171,252 @@ describe('users_list', () => {
     // about concurrency rather than order.
     expect(query.mock.calls.map((one) => one[0])).toEqual(['user.query', 'group.query']);
     await listing;
+  });
+});
+
+describe('directory_services_status', () => {
+  /** The live join state, as `directoryservices.status` reports it. */
+  const status = (over: Record<string, unknown> = {}) => ({
+    type: 'ACTIVEDIRECTORY',
+    status: 'HEALTHY',
+    status_msg: null,
+    ...over,
+  });
+
+  /**
+   * The configuration, as `directoryservices.config` reports it. `credential`
+   * carries a real password field, and is here to be dropped: this fixture is
+   * what makes "no credential material" assertable rather than assumed.
+   */
+  const config = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    service_type: 'ACTIVEDIRECTORY',
+    credential: {
+      credential_type: 'KERBEROS_USER',
+      username: 'administrator',
+      password: 'notarealbindsecret',
+    },
+    enable: true,
+    enable_account_cache: true,
+    enable_dns_updates: false,
+    timeout: 10,
+    kerberos_realm: 'EXAMPLE.COM',
+    configuration: {
+      hostname: 'nas',
+      domain: 'example.com',
+      site: null,
+      computer_account_ou: null,
+      use_default_domain: false,
+      enable_trusted_domains: false,
+      trusted_domains: [],
+    },
+    ...over,
+  });
+
+  const reported = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = failingSystem(
+      {
+        ['directoryservices.status']: status(),
+        ['directoryservices.config']: config(),
+        ...rows,
+      },
+      failures,
+    );
+    return (await directoryServicesStatus.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('reports the service, its domain and its live state', async () => {
+    expect(await reported()).toEqual({
+      service_type: 'ACTIVEDIRECTORY',
+      status: 'HEALTHY',
+      status_message: null,
+      enabled: true,
+      domain: 'example.com',
+      server_urls: null,
+      kerberos_realm: 'EXAMPLE.COM',
+      credential_type: 'KERBEROS_USER',
+      config_error: null,
+    });
+  });
+
+  it('returns no credential material, and no field a later release adds', async () => {
+    const result = await reported({
+      ['directoryservices.status']: status({ future_field: 'added by a later release' }),
+      ['directoryservices.config']: config({ future_field: 'added by a later release' }),
+    });
+    expect(Object.keys(result)).toEqual([
+      'service_type',
+      'status',
+      'status_message',
+      'enabled',
+      'domain',
+      'server_urls',
+      'kerberos_realm',
+      'credential_type',
+      'config_error',
+    ]);
+    // Asserted against the whole serialized result rather than field by field:
+    // a secret that reached a nested object would pass a key check on the top
+    // level and still be in front of the caller.
+    const serialized = JSON.stringify(result);
+    for (const secret of ['notarealbindsecret', 'administrator', 'added by a later release']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('reports a system with no directory service as a null service type', async () => {
+    // The ordinary case, and not a failure: everything the configuration would
+    // have contributed is absent rather than unreadable, so `config_error` is
+    // null too.
+    expect(
+      await reported({
+        ['directoryservices.status']: status({ type: null, status: 'DISABLED' }),
+        ['directoryservices.config']: config({
+          service_type: null,
+          credential: null,
+          enable: false,
+          kerberos_realm: null,
+          configuration: null,
+        }),
+      }),
+    ).toEqual({
+      service_type: null,
+      status: 'DISABLED',
+      status_message: null,
+      enabled: false,
+      domain: null,
+      server_urls: null,
+      kerberos_realm: null,
+      credential_type: null,
+      config_error: null,
+    });
+  });
+
+  it('distinguishes a broken join from an unconfigured system without prose', async () => {
+    const faulted = await reported({
+      ['directoryservices.status']: status({
+        status: 'FAULTED',
+        status_msg: 'kinit failed: Clock skew too great',
+      }),
+    });
+    expect(faulted).toMatchObject({
+      service_type: 'ACTIVEDIRECTORY',
+      status: 'FAULTED',
+      status_message: 'kinit failed: Clock skew too great',
+    });
+    const absent = await reported({
+      ['directoryservices.status']: status({ type: null, status: 'DISABLED' }),
+    });
+    expect(absent).toMatchObject({ service_type: null, status: 'DISABLED' });
+  });
+
+  it('identifies an LDAP directory by its server URLs, having no domain', async () => {
+    const ldap = await reported({
+      ['directoryservices.status']: status({ type: 'LDAP' }),
+      ['directoryservices.config']: config({
+        service_type: 'LDAP',
+        kerberos_realm: null,
+        credential: {
+          credential_type: 'LDAP_PLAIN',
+          binddn: 'cn=nas,dc=example,dc=com',
+          bindpw: 'notarealbindpw',
+        },
+        configuration: {
+          server_urls: ['ldaps://ldap1.example.com', 'ldaps://ldap2.example.com'],
+          basedn: 'dc=example,dc=com',
+          starttls: false,
+          validate_certificates: true,
+        },
+      }),
+    });
+    expect(ldap).toMatchObject({
+      service_type: 'LDAP',
+      // Null because an LDAP directory has no domain, not because one was
+      // configured and could not be read — `config_error` is what says that.
+      domain: null,
+      server_urls: ['ldaps://ldap1.example.com', 'ldaps://ldap2.example.com'],
+      kerberos_realm: null,
+      credential_type: 'LDAP_PLAIN',
+      config_error: null,
+    });
+    expect(JSON.stringify(ldap)).not.toContain('notarealbindpw');
+  });
+
+  it('reports an IPA domain, and no server URLs beside it', async () => {
+    expect(
+      await reported({
+        ['directoryservices.status']: status({ type: 'IPA' }),
+        ['directoryservices.config']: config({
+          service_type: 'IPA',
+          configuration: {
+            target_server: 'ipa.example.com',
+            hostname: 'nas',
+            domain: 'ipa.example.com',
+            basedn: 'dc=ipa,dc=example,dc=com',
+          },
+        }),
+      }),
+    ).toMatchObject({ service_type: 'IPA', domain: 'ipa.example.com', server_urls: null });
+  });
+
+  it('reports a state the system did not send as null rather than as healthy', async () => {
+    expect(
+      await reported({ ['directoryservices.status']: status({ status: undefined }) }),
+    ).toMatchObject({ status: null, status_message: null });
+  });
+
+  it('reports an unset message or realm as null rather than as a value', async () => {
+    // The middleware sends `""` for text it does not have; passing that through
+    // would put a field in the result that says nothing.
+    expect(
+      await reported({
+        ['directoryservices.status']: status({ status_msg: '' }),
+        ['directoryservices.config']: config({ kerberos_realm: '' }),
+      }),
+    ).toMatchObject({ status_message: null, kerberos_realm: null });
+  });
+
+  it('names the failure when the configuration cannot be read, and reports the state anyway', async () => {
+    // The join state is the question, and it comes from the other read — so a
+    // configuration that could not be read costs the domain and nothing else.
+    expect(
+      await reported({}, { ['directoryservices.config']: new Error('permission denied') }),
+    ).toEqual({
+      service_type: 'ACTIVEDIRECTORY',
+      status: 'HEALTHY',
+      status_message: null,
+      enabled: null,
+      domain: null,
+      server_urls: null,
+      kerberos_realm: null,
+      credential_type: null,
+      config_error: 'permission denied',
+    });
+  });
+
+  it('raises when the join state itself cannot be read', async () => {
+    // The configuration alone answers none of the question, so this one is
+    // fatal where the configuration read is reported.
+    await expect(
+      reported({}, { ['directoryservices.status']: new Error('nope') }),
+    ).rejects.toThrow('nope');
+  });
+
+  it('issues both reads before awaiting either of them', async () => {
+    const { ctx, call } = failingSystem({
+      ['directoryservices.status']: status(),
+      ['directoryservices.config']: config(),
+    });
+    const pending = directoryServicesStatus.handler(ctx, {});
+    // Asserted before the handler is awaited at all, which is what makes this
+    // about concurrency rather than order.
+    expect(call.mock.calls.map((one) => one[0])).toEqual([
+      'directoryservices.status',
+      'directoryservices.config',
+    ]);
+    await pending;
   });
 });


### PR DESCRIPTION
Adds `directory_services_status`, a read-only tool reporting whether Active Directory, IPA or LDAP is joined and whether that join currently works. Fixes #29.

## What it does

Two reads, in `src/tools/accounts.ts` beside `users_list`:

- **`directoryservices.status`** — the live join state (`type`, `status`, `status_msg`). This one is fatal: a domain with no state beside it says nothing about whether the join works.
- **`directoryservices.config`** — the domain, the realm and the bind method. Reported through `config_error` rather than thrown, the same split this file already makes between `user.query` (fatal) and `group.query` (reported).

Returned fields: `service_type`, `status`, `status_message`, `enabled`, `domain`, `server_urls`, `kerberos_realm`, `credential_type`, `config_error`.

## The two distinctions the ticket asked for

- **Not configured vs. configured but unreachable** — `service_type: null` against `service_type` set with `status: FAULTED`. Both are enum/null values; neither needs prose parsed.
- **Absent vs. unreadable** — while `config_error` is non-null, `enabled`, `domain`, `server_urls`, `kerberos_realm` and `credential_type` are all null *because they could not be read*, not because they are unset. The description says so, and a test asserts the whole result in that case. `service_type`, `status` and `status_message` come from the other read and are unaffected.

## Design notes, including the two the ticket flagged unconfirmed

- **`directoryservices.status` is on the pinned client, and is typed.** The ticket's note said it is absent from the endpoint enum. It is present: `ApiCallDirectory$7` (`dist/index.d.ts:9122`) declares it with response `DirectoryServicesStatusResult`, and `ApiSurface` in `src/catalog/tool.ts` resolves to that directory (`DefaultApiDirectory = ApiDirectory$7`, the oldest supported version). No version-conditional call is needed, and none is made — the second unconfirmed note is resolved the same way.
- **A system with no directory service is not a failure.** It answers `type: null`, `status: DISABLED`, and reads as "none configured" rather than as an error. Tested.
- **An LDAP directory has no domain.** `ActiveDirectoryConfig` and `IPAConfig` carry `domain`; `LDAPConfig` carries `server_urls` and no domain at all. So `domain` is null for LDAP and `server_urls` is null for AD and IPA, and the description names which service each field belongs to rather than leaving a null to be read as "not set". The per-service configuration is a union with no discriminant field, so each is narrowed by the presence of the field itself.
- **No credential material is returned.** `directoryservices.config` embeds the credential the system binds with — `password` on a Kerberos user, `bindpw` on an LDAP plain bind. Only the `credential_type` discriminant is read out of it, which names *how* the system binds and never *with what*. The spec fixtures carry those secret fields on purpose and assert they do not appear anywhere in the serialized result, nested or otherwise, plus an exact key-list assertion so a field a later TrueNAS release adds cannot appear without a change to this file.

## What I did not add, and why

- **No derived `healthy` boolean.** `status` is already a machine-readable enum, so a boolean beside it would add a field the caller pays for on every call and would have to collapse `JOINING`, `LEAVING` and `DISABLED` into either a wrong verdict or a third null state that says less than `status` already does.
- **No `basedn`.** `IPAConfig` and `LDAPConfig` both carry one, but it selects a subtree rather than identifying the directory, and it does not bear on "joined and healthy". `server_urls` is what identifies an LDAP directory, and that is included.
- **`failingSystem` in the spec now stubs `call` as well as `query`**, from the same two maps, so a tool that reads through `call` can have one of its reads fail. That is what makes the `config_error` and fatal-status cases assertable; `fakeSystem` already stubbed both seams and this brings the second helper into line. Additive — no existing test changes behaviour.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test` (365 passing) and `yarn test:coverage` all pass locally, as does `yarn build`. `src/tools/accounts.ts` reports 100% statements and 100% branches; the global floors (branches 96 / statements 97) are met at 99.15 / 99.23.

## Local review

`local-review.py` ran the project's own shared reviewer here — the same rubric, threshold and parser as the required check, in a separate process — and the round returned **nothing at MEDIUM or above**, which is what ended the work.

It returned one LOW: the description glossed `DISABLED` as "configured but switched off", while the spec in the same diff reports `DISABLED` with `service_type: null` for a system with no directory service configured at all. That is prose contradicting the fixture beside it rather than polish, so it is fixed in the second commit — `DISABLED` now covers both cases and says `service_type` is what tells them apart. Prose only; no behaviour changed, and lint, typecheck, tests and coverage were re-run after it.
