### PR TITLE
feat(tools): add network_interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
-  `nvmeof_list`, `users_list`, `directory_services_status`.
+  `nvmeof_list`, `users_list`, `directory_services_status`,
+  `network_interfaces`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,5 +80,6 @@ export {
   nvmeofList,
   usersList,
   directoryServicesStatus,
+  networkInterfaces,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
 import { disksList } from '@/tools/disks';
+import { networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
 import { shareAccess, sharesList } from '@/tools/shares';
@@ -12,7 +13,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: twenty read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-one read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -35,6 +36,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(nvmeofList);
   catalog.register(usersList);
   catalog.register(directoryServicesStatus);
+  catalog.register(networkInterfaces);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -48,6 +50,7 @@ export {
   disksList,
   iscsiList,
   listDatasets,
+  networkInterfaces,
   nvmeofList,
   poolStatus,
   poolTopology,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -1,0 +1,319 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Networking family: what interfaces this system has, whether each one has a
+ * link, and how the VLANs, bridges and link aggregations over them are built.
+ *
+ * `interface.query` answers all of it in one call — physical interfaces, VLANs,
+ * bridges and LAGGs are rows of the same listing, distinguished by `type` — so
+ * the two things the catalog wants here (interface state, and the VLANs and
+ * bridges above it) are one tool rather than two reads of the same rows.
+ *
+ * The pinned client types the query response as `Record<string, unknown>`
+ * (`InterfaceEntry` is a bare record), so every field is read rather than
+ * trusted, the way `storage.ts` reads a ZFS property. The field NAMES below come
+ * from the client's own `InterfaceEntryInput` and `InterfaceEntryState`
+ * declarations, which describe this same record on the create and event sides;
+ * they are strong evidence and not a guarantee about the query response, and a
+ * name that turns out wrong costs a null rather than a wrong value.
+ *
+ * The mapping is an allowlist rather than a trim, as in `pools.ts`. A raw
+ * interface row carries the whole `state` sub-object — supported media lists,
+ * capability flags, ND6 flags, queue counts, permanent and hardware link
+ * addresses — beside the failover configuration and both alias lists, on every
+ * interface in the system. Only the fields named here survive, so a field a
+ * later TrueNAS release adds to the record cannot reach a caller without a
+ * change to this file.
+ */
+
+/**
+ * One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters: a
+ * media subtype the system has nothing to say about arrives as `""`, and
+ * passing it through would put a field in the result that says nothing.
+ *
+ * `accounts.ts`, `shares.ts`, `tasks.ts` and `block.ts` each hold this same
+ * reading under their own names, and it is restated here for the reason those
+ * files give for restating their own guards: a tool file is read on its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** A number the system reported, or null where it reported anything else. */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * A nested object of a row, or null where the row held anything else.
+ *
+ * Every sub-object of an interface arrives as `unknown`, and `typeof null` is
+ * `'object'`, so the null check is what stops a reported-as-null `state` being
+ * indexed. An array is an object too and is excluded here: `state` and a port
+ * entry are records, and reading a list as one would answer null for every
+ * field rather than saying the shape was not what this tool reads.
+ */
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/** The entries of a list field, or an empty list where the field was not one. */
+function listOf(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * The negotiated link speed in megabits per second, read out of the media
+ * subtype the system reports, or null where no speed can be read from it.
+ *
+ * There is no numeric speed field on an interface row. The middleware reports
+ * the negotiated media as text, and the spellings differ by platform and by
+ * driver — `1000baseT <full-duplex>`, `10Gbase-SR`, `2.5GbaseT`, `1000Mb/s`,
+ * `10Gb/s` — so the leading magnitude and its optional unit are what is read: a
+ * bare number is megabits, which is the older convention every `NNNbase…` form
+ * follows, and `G` multiplies by a thousand.
+ *
+ * (unconfirmed) against a live middleware, which is why the media text itself
+ * is returned beside this rather than replaced by it. A subtype naming no speed
+ * at all — `autoselect`, `Unknown`, an empty string, a form this does not read —
+ * yields null, and null is therefore "no speed this tool could read from what
+ * the system reported" rather than "no link". `link_state` is what says whether
+ * there is a link, and the tool's description says so.
+ */
+function linkSpeedMbps(media: string | null): number | null {
+  if (media === null) return null;
+  // Anchored at the start: the magnitude of a media name is its leading token,
+  // and a number later in the string is a lane or channel count (`10Gbase-SR4`)
+  // rather than a speed. `b` after the magnitude is what distinguishes a media
+  // name from any other leading number.
+  const match = /^(\d+(?:\.\d+)?)\s*([gm])?b/i.exec(media);
+  if (match === null) return null;
+  const magnitude = Number(match[1]);
+  // Rounded because a fractional-gigabit media (`2.5GbaseT`) is a whole number
+  // of megabits.
+  const mbps = Math.round(match[2]?.toLowerCase() === 'g' ? magnitude * 1000 : magnitude);
+  // A speed of zero is no speed rather than a link running at none, and a
+  // magnitude too large to be a number at all — the regex bounds the SHAPE of
+  // the leading token and not its length — is not one either.
+  return Number.isFinite(mbps) && mbps > 0 ? mbps : null;
+}
+
+/** One address currently on an interface, as this tool reports it. */
+interface AddressRow {
+  type: string | null;
+  address: string | null;
+  netmask: string | number | null;
+}
+
+/**
+ * The addresses the interface currently carries, from the state rather than
+ * from the configuration.
+ *
+ * The row holds both lists: `aliases` at the top level is what is configured,
+ * and `state.aliases` is what is actually on the interface. The second is the
+ * one reported, because an interface addressed by DHCP has an address there and
+ * nothing at all in the configured list — and an interface whose configuration
+ * has not been applied has the reverse. What the interface is answering on is
+ * the question this tool is asked.
+ */
+function addresses(state: Record<string, unknown> | null): AddressRow[] {
+  return listOf(state?.['aliases']).map((entry) => {
+    const alias = recordOrNull(entry);
+    const netmask = alias?.['netmask'];
+    return {
+      type: textOrNull(alias?.['type']),
+      address: textOrNull(alias?.['address']),
+      // The client types this `string | number` — a prefix length on some
+      // platforms and a dotted mask on others — so both are passed through as
+      // they arrive rather than converted into one of them.
+      netmask:
+        typeof netmask === 'string' || (typeof netmask === 'number' && Number.isFinite(netmask))
+          ? netmask
+          : null,
+    };
+  });
+}
+
+/** One member of a bridge or link aggregation, as this tool reports it. */
+interface MemberRow {
+  name: string | null;
+  link_state: string | null;
+  flags: string[] | null;
+}
+
+/**
+ * The names the row gives for the interfaces it aggregates, or null where it
+ * named no member list at all.
+ *
+ * A bridge names them under `bridge_members` and a link aggregation under
+ * `lag_ports`; a physical or VLAN interface holds neither, which is the
+ * ordinary case rather than a fault. Null is therefore "the system reported no
+ * member list", and `type` is what says whether that means "does not aggregate
+ * anything" or "an aggregate whose members could not be read".
+ */
+function memberNames(row: Record<string, unknown>): string[] | null {
+  const named = row['bridge_members'] ?? row['lag_ports'];
+  if (!Array.isArray(named)) return null;
+  return named.map((name) => textOrNull(name)).filter((name): name is string => name !== null);
+}
+
+/**
+ * The per-member view the aggregate itself holds, keyed by member name.
+ *
+ * `state.ports` is what the bridge or LAGG says about each interface under it,
+ * and its `flags` are the aggregate's own verdict on that port. That is a
+ * different fact from the member's link: a LACP member can have a link and
+ * still not be carrying traffic, which is exactly the degraded aggregation this
+ * tool exists to make visible.
+ */
+function portFlags(state: Record<string, unknown> | null): Map<string, string[]> {
+  const flags = new Map<string, string[]>();
+  for (const entry of listOf(state?.['ports'])) {
+    const port = recordOrNull(entry);
+    const name = textOrNull(port?.['name']);
+    if (name === null) continue;
+    // Non-string entries are dropped rather than rendered, as `memberNames`
+    // drops a member the system did not name: a flag is the word for a state,
+    // and anything that is not one names no state.
+    flags.set(name, listOf(port?.['flags']).filter((flag) => typeof flag === 'string'));
+  }
+  return flags;
+}
+
+/**
+ * Each member of an aggregate, with the link state that member's OWN row
+ * reports and the flags the aggregate holds for it.
+ *
+ * The link state is resolved against the same response rather than read off the
+ * aggregate, because an interface under a bridge or a LAGG is itself a row of
+ * `interface.query` and that row is where its link lives. A member the response
+ * holds no row for reports null — a member this tool could not resolve, never
+ * one that is down.
+ */
+function members(
+  row: Record<string, unknown>,
+  state: Record<string, unknown> | null,
+  linkStates: Map<string, string | null>,
+): MemberRow[] | null {
+  const named = memberNames(row);
+  if (named === null) return null;
+  const flags = portFlags(state);
+  return named.map((name) => ({
+    name,
+    link_state: linkStates.get(name) ?? null,
+    // Null where the aggregate reported no port entry for this member, which is
+    // distinct from the empty list it reports for a port it holds no flags on.
+    flags: flags.get(name) ?? null,
+  }));
+}
+
+export const networkInterfaces: ReadOnlyTool = {
+  name: 'network_interfaces',
+  description:
+    'Every network interface on the system, whether each one has a link, and ' +
+    'how the VLANs, bridges and link aggregations over them are built. `name` ' +
+    'is the interface as the system names it — `eno1`, `bond0`, `vlan10` — and ' +
+    'is what every other field naming an interface refers to. `type` is ' +
+    '`PHYSICAL` (a real port), `VLAN`, `BRIDGE`, `LINK_AGGREGATION` (a LAGG or ' +
+    'bond), or `UNKNOWN`; it is null where the system reported none. ' +
+    '`link_state` is whether the interface currently has a link: ' +
+    '`LINK_STATE_UP` has one, `LINK_STATE_DOWN` does not, and null means the ' +
+    'system reported no state, WHICH IS NOT THE SAME AS DOWN. `link_media` is ' +
+    'the media the link negotiated, as text — the form varies by platform and ' +
+    'driver, and it is where duplex appears when the system reports one — and ' +
+    'is null where the system named no media. `link_speed_mbps` is the speed ' +
+    'read out of that text, in megabits per second, so 1000 is a gigabit link ' +
+    'and 10000 a ten-gigabit one. IT IS NULL WHENEVER NO SPEED COULD BE READ ' +
+    'FROM THE MEDIA TEXT, which includes an interface reporting `autoselect` ' +
+    'or nothing at all, and it IS NOT EVIDENCE OF A DOWN LINK — `link_state` ' +
+    'is the only field that says that, and `link_media` is what the speed was ' +
+    'read from, so a null speed beside media text is this tool failing to ' +
+    'parse it rather than the system failing to report it. A link that ' +
+    'renegotiated below the port it sits on is visible here and nowhere else. ' +
+    '`mtu` is the MTU CURRENTLY IN EFFECT rather than the configured value, ' +
+    'null where the system reported none. `addresses` are the addresses the ' +
+    'interface is actually carrying, not the ones configured on it, so an ' +
+    'interface addressed by DHCP lists them here; each has a `type` — `INET` ' +
+    'for IPv4, `INET6` for IPv6, `LINK` for the hardware address — an ' +
+    '`address`, and a `netmask` that is a prefix length or a dotted mask ' +
+    'depending on the platform, passed through as the system sent it. An ' +
+    'empty list is an interface carrying no address; any of the three fields ' +
+    'is null where the system reported no value for it. `vlan_parent` and ' +
+    '`vlan_tag` are the interface a VLAN sits on and the tag it carries, and ' +
+    'ARE BOTH NULL ON EVERY INTERFACE THAT IS NOT A VLAN, which `type` is what ' +
+    'identifies. `members` are the interfaces a bridge or a link aggregation ' +
+    'is built from. IT IS NULL WHERE THE SYSTEM REPORTED NO MEMBER LIST, which ' +
+    'is the ordinary case for a `PHYSICAL` or `VLAN` interface and is not a ' +
+    'failure; on a `BRIDGE` or `LINK_AGGREGATION` an empty list means the ' +
+    'aggregate currently has no members, and null means its member list could ' +
+    'not be read — `type` is what tells those apart. Each member carries its ' +
+    'own `name`, the `link_state` FROM THAT MEMBER\'S OWN ENTRY in this same ' +
+    'result — null where no entry for it was returned, which is a member that ' +
+    'could not be resolved rather than one that is down — and `flags`, which ' +
+    'is what the aggregate itself says about that port and is a DIFFERENT FACT ' +
+    'from the link: a member can have a link and still not be carrying ' +
+    'traffic, which is what a degraded LAGG looks like. `flags` is null where ' +
+    'the aggregate reported no entry for that member, and an empty list where ' +
+    'it reported one with no flags. So a single failed port inside an ' +
+    'otherwise-up bond is found by reading the members of a ' +
+    '`LINK_AGGREGATION` whose own `link_state` is `LINK_STATE_UP`. This tool ' +
+    'reports interfaces as they are; it does not create, change or delete an ' +
+    'interface, VLAN, bridge or aggregation, and it does not report the ' +
+    "system's hostname, gateway, DNS servers or routes. NO field beyond those " +
+    'named here is returned, whatever else a later TrueNAS release adds to an ' +
+    'interface record.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: an interface listing is small — one row per
+    // port, VLAN, bridge and aggregation — and every row is needed anyway,
+    // because a member's link state is resolved against the rest of the
+    // response.
+    const interfaces = await firstValueFrom(system.client.api.query('interface.query'));
+
+    // Built before the rows are mapped, so that a member named by an aggregate
+    // resolves whether its own row comes before or after the aggregate's.
+    const linkStates = new Map<string, string | null>();
+    for (const row of interfaces) {
+      const name = textOrNull(row['name']);
+      if (name === null) continue;
+      linkStates.set(name, textOrNull(recordOrNull(row['state'])?.['link_state']));
+    }
+
+    return interfaces.map((row) => {
+      const state = recordOrNull(row['state']);
+      const media = textOrNull(state?.['active_media_subtype']);
+      const type = textOrNull(row['type']);
+      return {
+        name: textOrNull(row['name']),
+        type,
+        link_state: textOrNull(state?.['link_state']),
+        link_media: media,
+        link_speed_mbps: linkSpeedMbps(media),
+        // From the state rather than the top-level `mtu`, which is the
+        // configured value and is null on an interface left at the default —
+        // an interface running at 1500 must not report as one with no MTU.
+        mtu: numberOrNull(state?.['mtu']),
+        addresses: addresses(state),
+        // Read off the row rather than the state: the state spells them
+        // `parent` and `tag`, and the row's own names are the ones the client
+        // types. Null on anything that is not a VLAN, which is where the
+        // fields are simply absent.
+        vlan_parent: textOrNull(row['vlan_parent_interface']),
+        vlan_tag: numberOrNull(row['vlan_tag']),
+        // Looked for on every row rather than only on the two aggregating
+        // types, so that an aggregate the system gave an unexpected `type`
+        // still reports what it is built from — and so that the field means
+        // "the system named a member list" throughout, which is what the
+        // description says a null `members` is.
+        members: members(row, state, linkStates),
+      };
+    });
+  },
+};

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -120,9 +120,17 @@ interface AddressRow {
  * nothing at all in the configured list — and an interface whose configuration
  * has not been applied has the reverse. What the interface is answering on is
  * the question this tool is asked.
+ *
+ * Null where no address list was read at all — the system reported no state, or
+ * no alias list within it — which is not the empty list of an interface that
+ * was read and is carrying no address. `members` keeps the same two apart, for
+ * the same reason: an interface whose addresses could not be read must not
+ * report as one that has none.
  */
-function addresses(state: Record<string, unknown> | null): AddressRow[] {
-  return listOf(state?.['aliases']).map((entry) => {
+function addresses(state: Record<string, unknown> | null): AddressRow[] | null {
+  const aliases = state?.['aliases'];
+  if (!Array.isArray(aliases)) return null;
+  return aliases.map((entry) => {
     const alias = recordOrNull(entry);
     const netmask = alias?.['netmask'];
     return {
@@ -165,7 +173,12 @@ interface MemberRow {
  * and never both, so at most one of the two lists is ever populated.
  */
 function memberNames(row: Record<string, unknown>): string[] | null {
-  const named = [row['bridge_members'], row['lag_ports']].filter((list) => Array.isArray(list));
+  // The predicate is written out rather than left to inference: `Array.isArray`
+  // narrows to `any[]`, which would make the joined list `any` and take the
+  // member names below out of the type system's reach entirely.
+  const named = [row['bridge_members'], row['lag_ports']].filter(
+    (list): list is unknown[] => Array.isArray(list),
+  );
   // Null only where NEITHER field is a list: an aggregate that named two empty
   // ones has no members, which is not the same as naming no list at all.
   if (named.length === 0) return null;
@@ -260,7 +273,10 @@ export const networkInterfaces: ReadOnlyTool = {
     'for IPv4, `INET6` for IPv6, `LINK` for the hardware address — an ' +
     '`address`, and a `netmask` that is a prefix length or a dotted mask ' +
     'depending on the platform, passed through as the system sent it. An ' +
-    'empty list is an interface carrying no address; any of the three fields ' +
+    'empty list is an interface carrying no address, and NULL IS AN INTERFACE ' +
+    'WHOSE ADDRESSES COULD NOT BE READ — the system reported no state for it, ' +
+    'or no address list within that state — WHICH IS NOT THE SAME THING. Any ' +
+    'of the three fields within an entry ' +
     'is null where the system reported no value for it. `vlan_parent` and ' +
     '`vlan_tag` are the interface a VLAN sits on and the tag it carries, and ' +
     'ARE BOTH NULL ON EVERY INTERFACE THAT IS NOT A VLAN, which `type` is what ' +

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -130,11 +130,11 @@ function addresses(state: Record<string, unknown> | null): AddressRow[] {
       address: textOrNull(alias?.['address']),
       // The client types this `string | number` — a prefix length on some
       // platforms and a dotted mask on others — so both are passed through as
-      // they arrive rather than converted into one of them.
+      // they arrive rather than converted into one of them. An empty string is
+      // no value here for the same reason it is no value in `type` and
+      // `address` beside it, rather than a mask of no characters.
       netmask:
-        typeof netmask === 'string' || (typeof netmask === 'number' && Number.isFinite(netmask))
-          ? netmask
-          : null,
+        typeof netmask === 'number' && Number.isFinite(netmask) ? netmask : textOrNull(netmask),
     };
   });
 }
@@ -155,11 +155,24 @@ interface MemberRow {
  * ordinary case rather than a fault. Null is therefore "the system reported no
  * member list", and `type` is what says whether that means "does not aggregate
  * anything" or "an aggregate whose members could not be read".
+ *
+ * Both fields are read and joined rather than one being preferred to the
+ * other. The middleware sends an interface record whole, so a LAGG can carry an
+ * empty `bridge_members` beside its populated `lag_ports` — and preferring the
+ * first field that is present would then report a live aggregation as having no
+ * members at all, which is the one answer worse than no answer. Nothing is
+ * double-counted by joining them: an interface is a bridge or an aggregation
+ * and never both, so at most one of the two lists is ever populated.
  */
 function memberNames(row: Record<string, unknown>): string[] | null {
-  const named = row['bridge_members'] ?? row['lag_ports'];
-  if (!Array.isArray(named)) return null;
-  return named.map((name) => textOrNull(name)).filter((name): name is string => name !== null);
+  const named = [row['bridge_members'], row['lag_ports']].filter((list) => Array.isArray(list));
+  // Null only where NEITHER field is a list: an aggregate that named two empty
+  // ones has no members, which is not the same as naming no list at all.
+  if (named.length === 0) return null;
+  return named.flat().flatMap((name) => {
+    const text = textOrNull(name);
+    return text === null ? [] : [text];
+  });
 }
 
 /**
@@ -191,9 +204,14 @@ function portFlags(state: Record<string, unknown> | null): Map<string, string[]>
  *
  * The link state is resolved against the same response rather than read off the
  * aggregate, because an interface under a bridge or a LAGG is itself a row of
- * `interface.query` and that row is where its link lives. A member the response
- * holds no row for reports null — a member this tool could not resolve, never
- * one that is down.
+ * `interface.query` and that row is where its link lives.
+ *
+ * Null covers both ways that can fail to produce a state — the response held no
+ * row for the member, and the row it held reported no link state of its own —
+ * because the two are the same fact to a caller: the member's link cannot be
+ * stated. Neither is a member that is DOWN, which is the distinction that
+ * matters, and the tool's description draws it that way rather than promising a
+ * finer one this cannot keep.
  */
 function members(
   row: Record<string, unknown>,
@@ -253,8 +271,9 @@ export const networkInterfaces: ReadOnlyTool = {
     'aggregate currently has no members, and null means its member list could ' +
     'not be read — `type` is what tells those apart. Each member carries its ' +
     'own `name`, the `link_state` FROM THAT MEMBER\'S OWN ENTRY in this same ' +
-    'result — null where no entry for it was returned, which is a member that ' +
-    'could not be resolved rather than one that is down — and `flags`, which ' +
+    'result — null where no entry for it was returned OR where that entry ' +
+    'reported no link state, so a null there is a member whose link CANNOT BE ' +
+    'STATED and is never a member that is down — and `flags`, which ' +
     'is what the aggregate itself says about that port and is a DIFFERENT FACT ' +
     'from the link: a member can have a link and still not be carrying ' +
     'traffic, which is what a degraded LAGG looks like. `flags` is null where ' +

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -159,18 +159,21 @@ interface MemberRow {
  * named no member list at all.
  *
  * A bridge names them under `bridge_members` and a link aggregation under
- * `lag_ports`; a physical or VLAN interface holds neither, which is the
- * ordinary case rather than a fault. Null is therefore "the system reported no
- * member list", and `type` is what says whether that means "does not aggregate
- * anything" or "an aggregate whose members could not be read".
+ * `lag_ports`. Null is therefore "the system reported no member list", and
+ * `type` is what says whether that means "does not aggregate anything" or "an
+ * aggregate whose members could not be read".
  *
  * Both fields are read and joined rather than one being preferred to the
- * other. The middleware sends an interface record whole, so a LAGG can carry an
- * empty `bridge_members` beside its populated `lag_ports` — and preferring the
- * first field that is present would then report a live aggregation as having no
- * members at all, which is the one answer worse than no answer. Nothing is
- * double-counted by joining them: an interface is a bridge or an aggregation
- * and never both, so at most one of the two lists is ever populated.
+ * other, because (unconfirmed) which of two shapes the middleware sends: if it
+ * sends an interface record whole, a LAGG carries an empty `bridge_members`
+ * beside its populated `lag_ports`, and preferring the first field that is
+ * present would report a live aggregation as having no members at all — the
+ * one answer worse than no answer. That same uncertainty is why a physical or
+ * VLAN interface may answer either null (neither field sent) or an empty list
+ * (both sent and both empty) here, and why the tool's description states both
+ * rather than promising one. Nothing is double-counted by joining them: an
+ * interface is a bridge or an aggregation and never both, so at most one of
+ * the two lists is ever populated.
  */
 function memberNames(row: Record<string, unknown>): string[] | null {
   // The predicate is written out rather than left to inference: `Array.isArray`
@@ -281,11 +284,14 @@ export const networkInterfaces: ReadOnlyTool = {
     '`vlan_tag` are the interface a VLAN sits on and the tag it carries, and ' +
     'ARE BOTH NULL ON EVERY INTERFACE THAT IS NOT A VLAN, which `type` is what ' +
     'identifies. `members` are the interfaces a bridge or a link aggregation ' +
-    'is built from. IT IS NULL WHERE THE SYSTEM REPORTED NO MEMBER LIST, which ' +
-    'is the ordinary case for a `PHYSICAL` or `VLAN` interface and is not a ' +
-    'failure; on a `BRIDGE` or `LINK_AGGREGATION` an empty list means the ' +
-    'aggregate currently has no members, and null means its member list could ' +
-    'not be read — `type` is what tells those apart. Each member carries its ' +
+    'is built from. ON A `PHYSICAL` OR `VLAN` INTERFACE IT IS EITHER NULL OR ' +
+    'AN EMPTY LIST, depending on whether the system sent member fields at all ' +
+    'for a row that aggregates nothing, and NEITHER IS A FAILURE: an interface ' +
+    'of those types is built from no other interface, and the two readings ' +
+    'carry no distinction there. ON A `BRIDGE` OR `LINK_AGGREGATION` THEY DO: ' +
+    'an empty list means the aggregate currently has no members, and null ' +
+    'means its member list could not be read — `type` is what says which of ' +
+    'the two readings applies. Each member carries its ' +
     'own `name`, the `link_state` FROM THAT MEMBER\'S OWN ENTRY in this same ' +
     'result — null where no entry for it was returned OR where that entry ' +
     'reported no link state, so a null there is a member whose link CANNOT BE ' +

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -5610,10 +5610,22 @@ describe('network_interfaces', () => {
 
   it('reports an address field the system sent nothing readable for as null', async () => {
     expect(
-      await one({}, { aliases: [{ type: '', address: null, netmask: { nested: true } }, 'not one'] }),
+      await one(
+        {},
+        {
+          aliases: [
+            { type: '', address: null, netmask: { nested: true } },
+            // An empty netmask is no value, exactly as it is in the two fields
+            // beside it, rather than a mask of no characters.
+            { type: 'INET', address: '10.0.0.5', netmask: '' },
+            'not one',
+          ],
+        },
+      ),
     ).toMatchObject({
       addresses: [
         { type: null, address: null, netmask: null },
+        { type: 'INET', address: '10.0.0.5', netmask: null },
         { type: null, address: null, netmask: null },
       ],
     });
@@ -5673,6 +5685,46 @@ describe('network_interfaces', () => {
         { name: 'missing', link_state: null, flags: null },
       ],
     });
+  });
+
+  it('reports the members of a LAGG that also carries an empty bridge member list', async () => {
+    // The middleware sends an interface record whole, so an aggregation can
+    // carry both fields with only one of them populated. Preferring whichever
+    // is present first would report this live bond as having no members.
+    const rows = await reported([
+      iface({ name: 'eno1' }, { link_state: 'LINK_STATE_UP' }),
+      iface(
+        {
+          name: 'bond0',
+          type: 'LINK_AGGREGATION',
+          bridge_members: [],
+          lag_ports: ['eno1'],
+        },
+        { ports: [{ name: 'eno1', flags: ['ACTIVE'] }] },
+      ),
+    ]);
+    expect(rows[1]).toMatchObject({
+      members: [{ name: 'eno1', link_state: 'LINK_STATE_UP', flags: ['ACTIVE'] }],
+    });
+  });
+
+  it('reports an aggregate carrying two empty member lists as having no members', async () => {
+    // Both fields are lists, so a member list WAS named — twice, and empty
+    // both times. That is an aggregate with nothing under it, not one whose
+    // members could not be read.
+    expect(
+      await one({ type: 'BRIDGE', bridge_members: [], lag_ports: [] }),
+    ).toMatchObject({ members: [] });
+  });
+
+  it('reports a member whose own entry named no link state as unstatable, not down', async () => {
+    const rows = await reported([
+      iface({ name: 'eno1' }, { link_state: null }),
+      iface({ name: 'bond0', type: 'LINK_AGGREGATION', lag_ports: ['eno1'] }, { ports: [] }),
+    ]);
+    // The same null an unresolved member gets: both are a link this tool
+    // cannot state, and neither is a link that is down.
+    expect(rows[1]).toMatchObject({ members: [{ name: 'eno1', link_state: null }] });
   });
 
   it('tells an aggregate with no members apart from one that named no list', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -12,6 +12,7 @@ import {
   disksList,
   iscsiList,
   listDatasets,
+  networkInterfaces,
   nvmeofList,
   poolStatus,
   poolTopology,
@@ -68,7 +69,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-one sketch tools', () => {
+  it('registers the twenty-two sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -90,6 +91,7 @@ describe('createDefaultCatalog', () => {
       'nvmeof_list',
       'users_list',
       'directory_services_status',
+      'network_interfaces',
       'snapshots_create',
     ]);
   });
@@ -177,6 +179,12 @@ describe('createDefaultCatalog', () => {
   it('advertises directory_services_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'directory_services_status',
+    );
+  });
+
+  it('advertises network_interfaces to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'network_interfaces',
     );
   });
 });
@@ -5418,5 +5426,334 @@ describe('directory_services_status', () => {
       'directoryservices.config',
     ]);
     await pending;
+  });
+});
+
+describe('network_interfaces', () => {
+  /**
+   * One row of `interface.query`. The nested `state` is spread over the default
+   * rather than replaced, so a test naming one state field keeps the rest —
+   * every field of the response is read out of that sub-object, and a fixture
+   * that dropped it wholesale would test the absent-state path by accident.
+   */
+  const iface = (
+    over: Record<string, unknown> = {},
+    state: Record<string, unknown> | null = {},
+  ) => ({
+    id: 'eno1',
+    name: 'eno1',
+    fake: false,
+    type: 'PHYSICAL',
+    aliases: [],
+    ipv4_dhcp: false,
+    ipv6_auto: false,
+    // The configured MTU, null on an interface left at the default. The
+    // operational one lives in the state, and telling them apart is what the
+    // fixture's two different numbers are for.
+    mtu: null,
+    state:
+      state === null
+        ? null
+        : {
+            name: 'eno1',
+            orig_name: 'eno1',
+            mtu: 1500,
+            cloned: false,
+            flags: ['UP', 'BROADCAST', 'RUNNING'],
+            link_state: 'LINK_STATE_UP',
+            media_type: 'Ethernet',
+            media_subtype: 'autoselect',
+            active_media_type: 'Ethernet',
+            active_media_subtype: '1000baseT <full-duplex>',
+            link_address: '00:11:22:33:44:55',
+            permanent_link_address: '00:11:22:33:44:55',
+            hardware_link_address: '00:11:22:33:44:55',
+            aliases: [{ type: 'INET', address: '192.168.1.10', netmask: 24 }],
+            ...state,
+          },
+    ...over,
+  });
+
+  const reported = async (rows: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['interface.query']: rows });
+    return (await networkInterfaces.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  const one = async (over: Record<string, unknown> = {}, state: Record<string, unknown> | null = {}) =>
+    (await reported([iface(over, state)]))[0] as Record<string, unknown>;
+
+  it('reports the name, type, link, speed, MTU and addresses of an interface', async () => {
+    expect(await one()).toEqual({
+      name: 'eno1',
+      type: 'PHYSICAL',
+      link_state: 'LINK_STATE_UP',
+      link_media: '1000baseT <full-duplex>',
+      link_speed_mbps: 1000,
+      mtu: 1500,
+      addresses: [{ type: 'INET', address: '192.168.1.10', netmask: 24 }],
+      vlan_parent: null,
+      vlan_tag: null,
+      members: null,
+    });
+  });
+
+  it('returns no field the tool does not name, on the row or in the state', async () => {
+    const result = await one(
+      { future_field: 'added by a later release' },
+      { future_state_field: 'added by a later release' },
+    );
+    expect(Object.keys(result)).toEqual([
+      'name',
+      'type',
+      'link_state',
+      'link_media',
+      'link_speed_mbps',
+      'mtu',
+      'addresses',
+      'vlan_parent',
+      'vlan_tag',
+      'members',
+    ]);
+    // Against the whole serialized row rather than its top-level keys: a field
+    // that reached a nested address or member entry would pass a key check and
+    // still be in front of the caller. The hardware address is in the fixture's
+    // state and is not a field this tool names.
+    const serialized = JSON.stringify(result);
+    for (const dropped of ['added by a later release', '00:11:22:33:44:55', 'BROADCAST']) {
+      expect(serialized).not.toContain(dropped);
+    }
+  });
+
+  it('reads the negotiated speed out of every media spelling it can', async () => {
+    const speeds = await Promise.all(
+      [
+        '1000baseT <full-duplex>',
+        '100baseTX',
+        '10Gbase-SR4',
+        '2.5GbaseT',
+        '1000Mb/s',
+        '10Gb/s',
+        '40GBASE-LR4',
+      ].map(async (active_media_subtype) =>
+        (await one({}, { active_media_subtype }))['link_speed_mbps'],
+      ),
+    );
+    expect(speeds).toEqual([1000, 100, 10000, 2500, 1000, 10000, 40000]);
+  });
+
+  it('reports no speed, and keeps the media text, where no speed can be read', async () => {
+    // Each of these is a media name the system genuinely sends and this tool
+    // cannot read a magnitude from. The text survives so that a caller can see
+    // what the null was read from.
+    for (const active_media_subtype of ['autoselect', 'Unknown', 'baseT', '0baseT']) {
+      expect(await one({}, { active_media_subtype })).toMatchObject({
+        link_media: active_media_subtype,
+        link_speed_mbps: null,
+      });
+    }
+  });
+
+  it('reports no speed where the magnitude is too large to be a number', async () => {
+    // The regex bounds the shape of the leading token and not its length, so a
+    // long enough run of digits overflows to Infinity — which is not a speed,
+    // and must not be reported as one.
+    expect(await one({}, { active_media_subtype: `${'9'.repeat(400)}baseT` })).toMatchObject({
+      link_media: expect.stringContaining('9'),
+      link_speed_mbps: null,
+    });
+  });
+
+  it('reports a null link state and no media where the system named neither', async () => {
+    // Null rather than down: an interface whose link the system did not report
+    // must not read as one that is definitely without a link.
+    expect(await one({}, { link_state: null, active_media_subtype: '' })).toMatchObject({
+      link_state: null,
+      link_media: null,
+      link_speed_mbps: null,
+    });
+  });
+
+  it('reports the operational MTU rather than the configured one', async () => {
+    // The row's own `mtu` is null — the fixture's default, an interface left at
+    // the system default — and the state's is 9000. An interface running at a
+    // jumbo MTU must not report as one with no MTU.
+    expect(await one({ mtu: null }, { mtu: 9000 })).toMatchObject({ mtu: 9000 });
+  });
+
+  it('reports the VLAN parent and tag, and null for both on anything else', async () => {
+    expect(
+      await one({ name: 'vlan10', type: 'VLAN', vlan_parent_interface: 'eno1', vlan_tag: 10 }),
+    ).toMatchObject({ type: 'VLAN', vlan_parent: 'eno1', vlan_tag: 10 });
+    expect(await one()).toMatchObject({ vlan_parent: null, vlan_tag: null });
+  });
+
+  it('reports every address the interface carries, whatever the netmask is', async () => {
+    expect(
+      await one(
+        {},
+        {
+          aliases: [
+            { type: 'INET', address: '192.168.1.10', netmask: 24 },
+            { type: 'INET', address: '10.0.0.5', netmask: '255.255.255.0' },
+            { type: 'INET6', address: 'fe80::1', netmask: 64 },
+          ],
+        },
+      ),
+    ).toMatchObject({
+      addresses: [
+        { type: 'INET', address: '192.168.1.10', netmask: 24 },
+        { type: 'INET', address: '10.0.0.5', netmask: '255.255.255.0' },
+        { type: 'INET6', address: 'fe80::1', netmask: 64 },
+      ],
+    });
+  });
+
+  it('reports an address field the system sent nothing readable for as null', async () => {
+    expect(
+      await one({}, { aliases: [{ type: '', address: null, netmask: { nested: true } }, 'not one'] }),
+    ).toMatchObject({
+      addresses: [
+        { type: null, address: null, netmask: null },
+        { type: null, address: null, netmask: null },
+      ],
+    });
+  });
+
+  it('reports an interface carrying no address as an empty list', async () => {
+    expect(await one({}, { aliases: [] })).toMatchObject({ addresses: [] });
+  });
+
+  it('reports a member that is down inside an otherwise-up aggregation', async () => {
+    // The acceptance criterion this tool exists for. The bond has a link, so
+    // nothing at its own level says anything is wrong; the failed port is
+    // visible only in `members`.
+    const rows = await reported([
+      iface({ name: 'eno1' }, { link_state: 'LINK_STATE_UP' }),
+      iface({ name: 'eno2' }, { link_state: 'LINK_STATE_DOWN' }),
+      iface(
+        { name: 'bond0', type: 'LINK_AGGREGATION', lag_ports: ['eno1', 'eno2'] },
+        {
+          link_state: 'LINK_STATE_UP',
+          ports: [
+            { name: 'eno1', flags: ['ACTIVE'] },
+            { name: 'eno2', flags: [] },
+          ],
+        },
+      ),
+    ]);
+    expect(rows[2]).toMatchObject({
+      name: 'bond0',
+      link_state: 'LINK_STATE_UP',
+      members: [
+        { name: 'eno1', link_state: 'LINK_STATE_UP', flags: ['ACTIVE'] },
+        { name: 'eno2', link_state: 'LINK_STATE_DOWN', flags: [] },
+      ],
+    });
+  });
+
+  it('reports the members of a bridge, resolved the same way', async () => {
+    const rows = await reported([
+      iface({ name: 'br0', type: 'BRIDGE', bridge_members: ['eno1'] }, { ports: [] }),
+      iface({ name: 'eno1' }, { link_state: 'LINK_STATE_DOWN' }),
+    ]);
+    // Named before its member's own row appears, which is why the link states
+    // are collected across the whole response before any row is mapped.
+    expect(rows[0]).toMatchObject({
+      members: [{ name: 'eno1', link_state: 'LINK_STATE_DOWN', flags: null }],
+    });
+  });
+
+  it('reports a member the response holds no entry for as unresolved, not down', async () => {
+    const rows = await reported([
+      iface({ name: 'bond0', type: 'LINK_AGGREGATION', lag_ports: ['eno1', 'missing'] }, { ports: [] }),
+    ]);
+    expect(rows[0]).toMatchObject({
+      members: [
+        { name: 'eno1', link_state: null, flags: null },
+        { name: 'missing', link_state: null, flags: null },
+      ],
+    });
+  });
+
+  it('tells an aggregate with no members apart from one that named no list', async () => {
+    const [empty, none] = await reported([
+      iface({ name: 'br0', type: 'BRIDGE', bridge_members: [] }),
+      // A bridge whose member list the system did not report at all: an empty
+      // list would claim it is built from nothing, which is a different fact.
+      iface({ name: 'br1', type: 'BRIDGE' }),
+    ]);
+    expect(empty).toMatchObject({ type: 'BRIDGE', members: [] });
+    expect(none).toMatchObject({ type: 'BRIDGE', members: null });
+  });
+
+  it('drops a member entry and a flag the system did not name', async () => {
+    const rows = await reported([
+      iface(
+        { name: 'bond0', type: 'LINK_AGGREGATION', lag_ports: ['eno1', 7, null] },
+        { ports: [{ name: 'eno1', flags: ['ACTIVE', 4] }, { name: '' }, 'not a port'] },
+      ),
+    ]);
+    expect(rows[0]).toMatchObject({ members: [{ name: 'eno1', flags: ['ACTIVE'] }] });
+  });
+
+  it('reports a member list the system sent as something other than a list as absent', async () => {
+    expect(await one({ type: 'BRIDGE', bridge_members: 'eno1' })).toMatchObject({ members: null });
+  });
+
+  it('reports every state-derived field as absent where there is no state', async () => {
+    // Null rather than fatal: the row still names the interface, its type and
+    // its VLAN configuration, and losing all of that to answer none of the
+    // question is the trade this refuses.
+    expect(await one({ name: 'eno9', type: 'PHYSICAL' }, null)).toEqual({
+      name: 'eno9',
+      type: 'PHYSICAL',
+      link_state: null,
+      link_media: null,
+      link_speed_mbps: null,
+      mtu: null,
+      addresses: [],
+      vlan_parent: null,
+      vlan_tag: null,
+      members: null,
+    });
+  });
+
+  it('reads a state the system sent as a list as no state at all', async () => {
+    // An array is an object too, so this is the case the null check alone does
+    // not cover: read as a record it would answer null for every field without
+    // saying the shape was not the one this tool reads.
+    // Set through the row override rather than the state one, which is spread
+    // over the default state and so cannot carry a value that is not a record.
+    expect(await one({ state: [] })).toMatchObject({
+      link_state: null,
+      addresses: [],
+      mtu: null,
+    });
+  });
+
+  it('reports an interface the system did not name, and never resolves against it', async () => {
+    const rows = await reported([
+      iface({ name: null }, { link_state: 'LINK_STATE_DOWN' }),
+      iface({ name: 'bond0', type: 'LINK_AGGREGATION', lag_ports: ['eno1'] }, { ports: [] }),
+    ]);
+    // Still reported — a nameless interface is one the caller can see exists —
+    // and it contributes no entry to the map the members resolve against, so
+    // its link state cannot be attributed to a member.
+    expect(rows[0]).toMatchObject({ name: null, link_state: 'LINK_STATE_DOWN' });
+    expect(rows[1]).toMatchObject({ members: [{ name: 'eno1', link_state: null }] });
+  });
+
+  it('reports a type the system did not name as null', async () => {
+    expect(await one({ type: null })).toMatchObject({ type: null });
+  });
+
+  it('reports an empty listing as an empty result', async () => {
+    expect(await reported([])).toEqual([]);
+  });
+
+  it('asks for the interfaces with no filter, so that members resolve', async () => {
+    const { ctx, query } = fakeSystem({ ['interface.query']: [] });
+    await networkInterfaces.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('interface.query');
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -5500,7 +5500,18 @@ describe('network_interfaces', () => {
   it('returns no field the tool does not name, on the row or in the state', async () => {
     const result = await one(
       { future_field: 'added by a later release' },
-      { future_state_field: 'added by a later release' },
+      {
+        future_state_field: 'added by a later release',
+        // The state's three own link-address fields, all given one value that
+        // nothing else in this fixture carries. A LINK-type alias holds a
+        // hardware address too and IS returned, as the description says, so it
+        // is given a different one: what must not appear below is the address
+        // only the dropped fields carry, which a shared value could not show.
+        link_address: 'aa:bb:cc:dd:ee:ff',
+        permanent_link_address: 'aa:bb:cc:dd:ee:ff',
+        hardware_link_address: 'aa:bb:cc:dd:ee:ff',
+        aliases: [{ type: 'LINK', address: '00:11:22:33:44:55', netmask: null }],
+      },
     );
     expect(Object.keys(result)).toEqual([
       'name',
@@ -5519,9 +5530,13 @@ describe('network_interfaces', () => {
     // still be in front of the caller. The hardware address is in the fixture's
     // state and is not a field this tool names.
     const serialized = JSON.stringify(result);
-    for (const dropped of ['added by a later release', '00:11:22:33:44:55', 'BROADCAST']) {
+    for (const dropped of ['added by a later release', 'aa:bb:cc:dd:ee:ff', 'BROADCAST']) {
       expect(serialized).not.toContain(dropped);
     }
+    // And the alias that legitimately carries a hardware address survives, so
+    // the assertion above is about the fields this tool drops rather than about
+    // the fixture happening to hold no LINK alias.
+    expect(serialized).toContain('00:11:22:33:44:55');
   });
 
   it('reads the negotiated speed out of every media spelling it can', async () => {
@@ -5631,8 +5646,14 @@ describe('network_interfaces', () => {
     });
   });
 
-  it('reports an interface carrying no address as an empty list', async () => {
+  it('tells an interface carrying no address apart from one whose addresses could not be read', async () => {
+    // The empty list is a state that was read and holds no address; null is a
+    // state that named no address list at all. Reporting the second as the
+    // first would claim an interface has no address on no evidence.
     expect(await one({}, { aliases: [] })).toMatchObject({ addresses: [] });
+    expect(await one({ state: { link_state: 'LINK_STATE_UP' } })).toMatchObject({
+      addresses: null,
+    });
   });
 
   it('reports a member that is down inside an otherwise-up aggregation', async () => {
@@ -5763,7 +5784,7 @@ describe('network_interfaces', () => {
       link_media: null,
       link_speed_mbps: null,
       mtu: null,
-      addresses: [],
+      addresses: null,
       vlan_parent: null,
       vlan_tag: null,
       members: null,
@@ -5778,7 +5799,7 @@ describe('network_interfaces', () => {
     // over the default state and so cannot carry a value that is not a record.
     expect(await one({ state: [] })).toMatchObject({
       link_state: null,
-      addresses: [],
+      addresses: null,
       mtu: null,
     });
   });


### PR DESCRIPTION
Adds `network_interfaces`, a read-only tool over `interface.query`.

Fixes #30

## What it does

`interface.query` returns physical interfaces, VLANs, bridges and link
aggregations from one call, distinguished by `type` — which is why the two
appendix rows the ticket cites ("interface status and link health" and "list
VLANs and bridge interfaces") are one tool rather than two reads of the same
rows.

Each interface reports `name`, `type`, `link_state`, `link_media`,
`link_speed_mbps`, `mtu`, `addresses`, `vlan_parent`, `vlan_tag` and `members`.
The mapping is an allowlist, as in `pools.ts`: a raw interface row carries the
whole `state` sub-object — supported media, capability and ND6 flags, queue
counts, three hardware link addresses — beside the failover configuration and
both alias lists, on every interface in the system. Only the named fields
survive, so a field a later TrueNAS release adds cannot reach a caller without
a change to this file. There is a test for that, and it asserts on the whole
serialized row rather than its top-level keys.

**Link speed.** An interface row carries no numeric speed field — the one
`speed` the client types is on the `reporting.realtime` event source, which is
a subscription and a different tool's territory. The middleware reports the
negotiated media as text, so the speed is read out of that: the leading
magnitude and its optional unit, covering `1000baseT <full-duplex>`,
`10Gbase-SR4`, `2.5GbaseT`, `1000Mb/s` and `10Gb/s`. This is **unconfirmed
against a live middleware**, which is why `link_media` is returned beside the
parsed number rather than replaced by it: a null speed next to media text is
this tool failing to parse it, and the caller can see exactly what it was read
from. A null speed is never evidence of a down link — `link_state` is the only
field that says that, and the description says so.

**Members.** A bridge or aggregation reports each member with the link state
from that member's **own row** in the same response, plus the `flags` the
aggregate holds for it. Those are deliberately two facts: a LAGG member can
have a link and still not be carrying traffic, which is what the degraded
aggregation in the ticket's "Why" looks like and is invisible at the
aggregate's own level. Link states are collected across the whole response
before any row is mapped, so a member resolves whether its row comes before or
after the aggregate's.

`bridge_members` and `lag_ports` are both read and joined rather than one being
preferred to the other, because **it is not established which of two shapes the
middleware sends**. If it sends an interface record whole, an aggregation
carries an empty `bridge_members` beside its populated `lag_ports`, and
preferring the first field that is present would report a live LAGG as having
no members at all. Joining them is correct under either shape: an interface is
a bridge or an aggregation and never both, so at most one of the two lists is
ever populated and nothing is double-counted.

The client types the query response as a bare `Record<string, unknown>`
(`InterfaceEntry` is an alias for exactly that), so every field is read rather
than trusted, the way `storage.ts` reads a ZFS property. Field *names* come
from the client's own `InterfaceEntryInput` and `InterfaceEntryState`
declarations, which describe this same record on the create and event sides —
strong evidence, not a guarantee about the query response. A name that turns
out wrong costs a null rather than a wrong value.

## Nulls

Every field that can be absent keeps "could not be read" apart from "is not
set", which is where most of the review rounds landed:

- `members` — on a **`BRIDGE` or `LINK_AGGREGATION`**, `[]` means the aggregate
  currently has no members and null means its member list could not be read;
  `type` is what says the distinction applies. On a **`PHYSICAL` or `VLAN`**
  interface it is null or `[]` depending on whether the system sent member
  fields at all for a row that aggregates nothing — the two carry no
  distinction there, and neither is a failure. The description states both
  readings rather than promising one, because the record shape above is
  unconfirmed.
- `addresses` — null where no address list was read (no state, or no alias list
  within it); `[]` where the state was read and the interface carries nothing.
- A member's `link_state` — null where no entry for it was returned **or**
  where that entry named no state. Both are "the link cannot be stated";
  neither is "down".
- `link_speed_mbps` — null wherever no speed could be read from the media text.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test` and `yarn build` all pass locally,
and `yarn test:coverage` passed on the round that last changed behaviour. 392
tests; `src/tools/network.ts` is at 100% statements and 100% branches, and the
global floors (branches 96 / statements 97) are met at 99.21 / 99.27. Nothing
in this project's CI needs anything this machine does not have, so every gating
job ran here.

## Review

Five local rounds with the project's own reviewer — the same script, rubric and
threshold as the required check, in a separate process. The last round returned
nothing at or above MEDIUM, which is where the work stopped.

Fixed along the way:

- **HIGH** — `memberNames` preferred `bridge_members` over `lag_ports` with
  `??`, so an aggregation carrying an empty `bridge_members` beside its
  populated `lag_ports` reported a live LAGG as having **no members at all**.
  Both fields are now read and joined, as described under **Members** above.
  There is a test for the exact failing input.
- **MEDIUM** — the tool description called a null `members` "the ordinary case
  for a `PHYSICAL` or `VLAN` interface", while `memberNames`' own rationale for
  joining both fields asserted that the middleware sends a record whole — under
  which a physical row carries two empty lists and `members` is `[]` there,
  never null. Both statements were in this one file and they could not both be
  true. Neither is asserted now: the record shape is marked unconfirmed, and the
  description states both readings for a non-aggregating row while keeping the
  load-bearing `[]`-versus-null contract on an aggregate exactly as it was. The
  only change was prose — no behaviour and no tests.
- **MEDIUM** — `addresses` returned `[]` where the state could not be read,
  which the description defines as an interface carrying no address. Now null,
  matching how `members` beside it already worked.
- Three LOWs taken in earlier rounds, because each shared a commit with a
  finding that already required one and so cost no extra round: a member's null
  `link_state` was described as naming only one of its two causes; `netmask`
  passed an empty string through while `type` and `address` beside it read one
  as no value; and `Array.isArray` in a `filter` narrowed to `any[]`, taking
  the member-name path out of the type system's reach.
- A test correction worth naming, since it weakened a guarantee rather than a
  behaviour: the dropped-field assertion used one hardware address for both the
  state's `link_address` and any LINK alias, so it passed only because the
  fixture held no LINK alias. A LINK-type alias **is** returned by design. The
  two now differ, and the test asserts both directions.

## Not changed

LOWs left standing. Each is worth a reviewer's eye here; none contradicts the
code it sits beside, and fixing one after a clean round would start another.

- `MemberRow.name` is typed `string | null`, wider than the value: every row is
  built from the `string[]` `memberNames` returns, which already drops any entry
  without a name, so null is unreachable there. The tool's description does not
  promise a member without a name, so narrowing it to `string` would be a type
  change only.
- `vlan_parent` and `vlan_tag` are read off every row with no gate on `type`,
  while the description says both are null on every interface that is not a
  VLAN. The fields are simply absent on a non-VLAN row, so the behaviour holds
  under either middleware shape — but nothing in the code enforces it.
- `addresses` uses `Array.isArray` to narrow `aliases`, which yields `any[]` and
  makes the map callback parameter `any` — the same trap `memberNames` avoids
  with an explicit `unknown[]` predicate. It is inconsistent rather than wrong;
  every field within the entry is read through a guard.
- The `type` local in the handler is bound and used once, as a shorthand
  property. It gates nothing and can be inlined.
- The doc comment on `linkSpeedMbps` opens a sentence with "(unconfirmed)
  against a live middleware" and reads as having lost its subject clause. The
  claim it makes is correct and is restated in full under **Link speed** above.

## Notes

- `app/CLAUDE.md` still does not exist in this repository, so there was no
  project map to check the conventions against — they were read from
  `storage.ts`, `pools.ts` and `accounts.ts`. Nothing this ticket introduced is
  a new decision worth recording there: the tool follows the existing
  read-only-tool shape throughout.
- The tool takes no arguments and applies no bound. An interface listing is one
  row per port, VLAN, bridge and aggregation, and every row is needed anyway
  because a member's link state is resolved against the rest of the response.
