### PR TITLE
feat(tools): add network_config, hostname, gateway, DNS and static routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
   `nvmeof_list`, `users_list`, `directory_services_status`,
-  `network_interfaces`.
+  `network_interfaces`, `network_config`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,5 +81,6 @@ export {
   usersList,
   directoryServicesStatus,
   networkInterfaces,
+  networkConfig,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,7 +4,7 @@ import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
 import { disksList } from '@/tools/disks';
-import { networkInterfaces } from '@/tools/network';
+import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
 import { shareAccess, sharesList } from '@/tools/shares';
@@ -13,7 +13,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: twenty-one read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-two read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -37,6 +37,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(usersList);
   catalog.register(directoryServicesStatus);
   catalog.register(networkInterfaces);
+  catalog.register(networkConfig);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -50,6 +51,7 @@ export {
   disksList,
   iscsiList,
   listDatasets,
+  networkConfig,
   networkInterfaces,
   nvmeofList,
   poolStatus,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -631,9 +631,11 @@ export const networkConfig: ReadOnlyTool = {
     'SYSTEM THAT REPORTED NO LIST AT ALL. `ipv4_gateway` and `ipv6_gateway` ' +
     'each carry `configured`, the gateway set on this system and null where ' +
     'none is; `in_effect`, the default route of that family the system ' +
-    'reports as currently in use and null where there is none; and `source`. ' +
-    'A `source` of null means neither a configured gateway nor one in effect ' +
-    'was found for that family. `nameservers` lists every DNS server this ' +
+    'reports as currently in use, WHICH IS NULL BOTH WHERE THERE IS NONE AND ' +
+    'WHERE THE EFFECTIVE SIDE COULD NOT BE READ; and `source`. A `source` of ' +
+    'null means no gateway of that family is configured here and none was ' +
+    'seen in effect, so on a system whose effective side could not be read it ' +
+    'says only that none is configured. `nameservers` lists every DNS server this ' +
     'system is using or has been given, THOSE IN USE FIRST AND IN THE ORDER ' +
     'THE SYSTEM TRIES THEM, followed by any configured server that is not in ' +
     'use. Each carries its `address`, its `source`, and `in_effect`: true ' +
@@ -647,7 +649,9 @@ export const networkConfig: ReadOnlyTool = {
     'is configured rather than that the system has no routes. NULL IS A ' +
     'LISTING THAT COULD NOT BE READ. `failures` names each read that did not ' +
     'complete, with the reason the system gave; it is empty where every read ' +
-    'completed, and A FIELD IT NAMES AS UNREADABLE MUST NOT BE READ AS ' +
+    'completed, SO IT DOES NOT NAME A READ THAT COMPLETED AND ANSWERED A ' +
+    'SHAPE THIS TOOL COULD NOT READ — that shows as the nulls described ' +
+    'above instead. A FIELD IT NAMES AS UNREADABLE MUST NOT BE READ AS ' +
     'ABSENT — when it names `effective_values`, every `in_effect` is null and ' +
     'no value can be reported as `AUTOMATIC`, so a `STATIC` gateway or ' +
     'nameserver is still correct there while the absence of one is not ' +

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -385,10 +385,13 @@ export const networkInterfaces: ReadOnlyTool = {
  * is guaranteed by the types — while `NetworkGeneralSummaryResult` IS typed,
  * with `default_routes` and `nameservers` on it. So the effective side is the
  * grounded half and the configured side is read defensively, field by field,
- * the way an interface row is read above. The configured field NAMES come from
+ * the way an interface row is read above. Most configured field NAMES come from
  * the client's own `NetWorkConfigurationUpdate`, which describes this same
  * record on the update side: strong evidence rather than a guarantee, and a
- * name that turns out wrong costs a null rather than a wrong value.
+ * name that turns out wrong costs a null rather than a wrong value. The
+ * exception is `hostname_local`, which the middleware adds when it READS the
+ * record and so cannot appear on an update type — see `localHostname`, which
+ * is why that one is read with a fallback rather than on its own.
  *
  * Only the configuration read can fail the tool. A system whose configuration
  * read and whose routes did not still has most of an answer, and `failures` is
@@ -607,6 +610,26 @@ function staticRouteRows(routes: unknown): StaticRouteRow[] | null {
   });
 }
 
+/**
+ * The hostname of the node answering this call, which is not always `hostname`.
+ *
+ * The configuration carries a hostname per HA node — `hostname` and
+ * `hostname_b` — plus `hostname_virtual` for the address the pair answers on.
+ * `hostname` is node A's on BOTH nodes, so reading it on node B reports the
+ * peer's name under a field this tool defines as this system's. The middleware
+ * resolves that on the read side into `hostname_local`, which is `hostname` on
+ * node A and on every single-node system and `hostname_b` on node B, so
+ * preferring it is right everywhere rather than only on HA.
+ *
+ * It falls back to `hostname` because `hostname_local` is added by an extend
+ * rather than stored: a release that does not add it, or a response this tool
+ * could not read it from, still has the field that was correct before HA — and
+ * on a single-node system the two are the same value anyway.
+ */
+function localHostname(config: Record<string, unknown>): string | null {
+  return textOrNull(config['hostname_local']) ?? textOrNull(config['hostname']);
+}
+
 export const networkConfig: ReadOnlyTool = {
   name: 'network_config',
   description:
@@ -624,9 +647,17 @@ export const networkConfig: ReadOnlyTool = {
     'effect WITHOUT being configured here — DHCP on IPv4, and DHCPv6 or a ' +
     'router advertisement on IPv6, WHICH THIS TOOL CANNOT TELL APART and so ' +
     'does not name. `hostname` and `domain` are the configured hostname and ' +
-    'DNS domain of this system, each null where it reported none; the ' +
-    'hostnames of an HA peer and of an HA virtual address are not reported ' +
-    'here. `search_domains` are the additional domains appended when a bare ' +
+    'DNS domain of this system, each null where it reported none. WHERE THE ' +
+    'SYSTEM REPORTS A PER-NODE HOSTNAME, `hostname` is the node ANSWERING ' +
+    'THIS CALL, so on an HA pair the same tool run against each node reports a ' +
+    'different name. WHERE IT REPORTS NONE the pair-wide configured hostname ' +
+    'is reported instead, WHICH ON AN HA PAIR IS THE SAME NAME ON BOTH NODES ' +
+    'and so may not be the answering one; that is every single-node system, ' +
+    'where the two are the same value anyway, and any release that does not ' +
+    'resolve a per-node hostname. THIS TOOL DOES NOT SAY WHICH OF THE TWO IT ' +
+    'REPORTED. The hostname of the HA PEER and the hostname of the HA VIRTUAL ' +
+    'ADDRESS are not reported here at all. `search_domains` are the additional ' +
+    'domains appended when a bare ' +
     'name is resolved: an empty list is a system with none, and NULL IS A ' +
     'SYSTEM THAT REPORTED NO LIST AT ALL. `ipv4_gateway` and `ipv6_gateway` ' +
     'each carry `configured`, the gateway set on this system and null where ' +
@@ -682,7 +713,7 @@ export const networkConfig: ReadOnlyTool = {
     if (routes.failure !== null) failures.push(routes.failure);
 
     return {
-      hostname: textOrNull(config['hostname']),
+      hostname: localHostname(config),
       domain: textOrNull(config['domain']),
       search_domains: textList(config['domains']),
       ipv4_gateway: gatewayReport(textOrNull(config['ipv4gateway']), effective.default_routes, false),

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -3,8 +3,16 @@ import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
 
 /**
- * Networking family: what interfaces this system has, whether each one has a
- * link, and how the VLANs, bridges and link aggregations over them are built.
+ * Networking family. Two tools split it by what is being asked about:
+ * `network_interfaces` answers for the interfaces themselves, and
+ * `network_config` at the foot of this file answers for the system-wide
+ * settings over them — hostname, DNS servers, default gateways and static
+ * routes. The guards between them are shared; each tool's own reasoning sits
+ * with it.
+ *
+ * `network_interfaces`: what interfaces this system has, whether each one has
+ * a link, and how the VLANs, bridges and link aggregations over them are
+ * built.
  *
  * `interface.query` answers all of it in one call — physical interfaces, VLANs,
  * bridges and LAGGs are rows of the same listing, distinguished by `type` — so
@@ -356,5 +364,328 @@ export const networkInterfaces: ReadOnlyTool = {
         members: members(row, state, linkStates),
       };
     });
+  },
+};
+
+/**
+ * The settings over the interfaces: hostname, DNS, gateways and static routes.
+ *
+ * Three reads, and only the first is the answer. `network.configuration.config`
+ * holds what is CONFIGURED on this system; `network.general.summary` holds the
+ * default routes and nameservers actually IN EFFECT; `staticroute.query` holds
+ * the routes configured by hand. The first two are the same facts read from two
+ * sides, and the difference between them is the question this tool exists to
+ * answer: a system addressed by DHCP has a gateway and nameservers in effect
+ * and nothing configured, and a system whose configuration has not been applied
+ * has the reverse.
+ *
+ * That comparison is what distinguishes an inherited value from a configured
+ * one, rather than a field on the configuration saying so. The client types the
+ * configuration response as a bare `Record<string, unknown>` — nothing about it
+ * is guaranteed by the types — while `NetworkGeneralSummaryResult` IS typed,
+ * with `default_routes` and `nameservers` on it. So the effective side is the
+ * grounded half and the configured side is read defensively, field by field,
+ * the way an interface row is read above. The configured field NAMES come from
+ * the client's own `NetWorkConfigurationUpdate`, which describes this same
+ * record on the update side: strong evidence rather than a guarantee, and a
+ * name that turns out wrong costs a null rather than a wrong value.
+ *
+ * Only the configuration read can fail the tool. A system whose configuration
+ * read and whose routes did not still has most of an answer, and `failures` is
+ * what stops the missing part reading as "none configured".
+ */
+
+/** One read that did not complete, and why. */
+interface ConfigFailure {
+  source: 'effective_values' | 'static_routes';
+  error: string;
+}
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/**
+ * Why a read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. `block.ts` and
+ * `shares.ts` each hold this same reading under their own names, and it is
+ * restated here for the reason those files give: a tool file is read on its
+ * own. The result is never empty, because a failure with no text still has to
+ * read as a failure.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/** A read that produced a value, or the failure that stopped it. */
+interface Attempt<T> {
+  value: T | null;
+  failure: ConfigFailure | null;
+}
+
+/**
+ * One supplementary read, with a failure caught and named rather than thrown.
+ *
+ * The read is passed as a thunk so that the call is made inside the `try`,
+ * which keeps this correct for a read that throws before it returns a promise
+ * at all.
+ */
+async function attempt<T>(
+  source: ConfigFailure['source'],
+  read: () => Promise<T>,
+): Promise<Attempt<T>> {
+  try {
+    return { value: await read(), failure: null };
+  } catch (reason) {
+    return { value: null, failure: { source, error: errorText(reason) } };
+  }
+}
+
+/**
+ * The non-empty strings of a list field, or null where the field was not a list
+ * at all.
+ *
+ * The two are kept apart everywhere this is used: a system that reported an
+ * empty search-domain list has none, and one that reported no list said
+ * nothing. An entry that is not a string, or is the empty string the middleware
+ * sends for "no value", names nothing and is dropped — the same reading
+ * `textOrNull` holds above.
+ */
+function textList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.flatMap((entry) => {
+    const text = textOrNull(entry);
+    return text === null ? [] : [text];
+  });
+}
+
+/** Where a value in effect came from, as far as this tool can tell. */
+type ValueSource = 'STATIC' | 'AUTOMATIC';
+
+/** What the system reports as being in effect, as far as it could be read. */
+interface EffectiveValues {
+  default_routes: string[] | null;
+  nameservers: string[] | null;
+}
+
+/**
+ * The effective side, read from the summary, with null throughout where it
+ * could not be read.
+ *
+ * Null rather than an empty list, because every attribution below turns on the
+ * difference: an empty effective list means the system is using no nameserver,
+ * and a null one means nothing can be said about what it is using. Reading the
+ * second as the first would report every configured server as not in use.
+ */
+function effectiveValues(summary: unknown): EffectiveValues {
+  const record = recordOrNull(summary);
+  return {
+    default_routes: textList(record?.['default_routes']),
+    nameservers: textList(record?.['nameservers']),
+  };
+}
+
+/** A default gateway of one address family, from both sides. */
+interface GatewayReport {
+  configured: string | null;
+  in_effect: string | null;
+  source: ValueSource | null;
+}
+
+/**
+ * The default gateway of one family: what is configured, what is in effect, and
+ * which of the two the effective value came from.
+ *
+ * The summary reports default routes as one list of addresses, without saying
+ * which family each belongs to, so they are split on the colon: an IPv6 address
+ * always contains one and an IPv4 address never does. The first match wins —
+ * a system with two default routes of one family has an equal-cost pair, and
+ * either is the gateway of that family.
+ *
+ * `source` is `STATIC` whenever a gateway is configured here, whether or not it
+ * is the one in effect; the two fields beside it are what show a configuration
+ * that has not been applied. It is `AUTOMATIC` only where a gateway is in
+ * effect and none is configured, which is DHCP on IPv4 and DHCPv6 or a router
+ * advertisement on IPv6 — this tool cannot tell those apart, so it does not
+ * name one.
+ */
+function gatewayReport(
+  configured: string | null,
+  routes: string[] | null,
+  ipv6: boolean,
+): GatewayReport {
+  const inEffect = routes?.find((route) => route.includes(':') === ipv6) ?? null;
+  return {
+    configured,
+    in_effect: inEffect,
+    source: configured !== null ? 'STATIC' : inEffect !== null ? 'AUTOMATIC' : null,
+  };
+}
+
+/** One DNS server, and what this tool can say about where it came from. */
+interface NameserverReport {
+  address: string;
+  source: ValueSource;
+  in_effect: boolean | null;
+}
+
+/**
+ * Every DNS server this system is using or has been given, from both sides.
+ *
+ * The servers in effect come first, in the order the system reports them —
+ * resolution is tried in that order, so it is a fact rather than a
+ * presentation — and any configured server that is not among them follows.
+ *
+ * `STATIC` is decided by the configured side alone, so it is stated the same
+ * way whether or not the effective list could be read. `in_effect` is the field
+ * that goes null there: a configured server whose use cannot be confirmed must
+ * not report as one that is definitely unused.
+ */
+function nameserverReports(
+  config: Record<string, unknown>,
+  effective: string[] | null,
+): NameserverReport[] {
+  // Three numbered fields rather than a list: that is the shape the middleware
+  // holds them in, and a server configured in the third slot with the second
+  // left empty is ordinary.
+  const configured = ['nameserver1', 'nameserver2', 'nameserver3'].flatMap((key) => {
+    const address = textOrNull(config[key]);
+    return address === null ? [] : [address];
+  });
+  const isConfigured = new Set(configured);
+  const seen = new Set<string>();
+  const rows: NameserverReport[] = [];
+  for (const address of effective ?? []) {
+    if (seen.has(address)) continue;
+    seen.add(address);
+    rows.push({
+      address,
+      source: isConfigured.has(address) ? 'STATIC' : 'AUTOMATIC',
+      in_effect: true,
+    });
+  }
+  for (const address of configured) {
+    if (seen.has(address)) continue;
+    seen.add(address);
+    // False only where the effective list was actually read and this address
+    // was not in it.
+    rows.push({ address, source: 'STATIC', in_effect: effective === null ? null : false });
+  }
+  return rows;
+}
+
+/** One route configured by hand on this system. */
+interface StaticRouteRow {
+  destination: string | null;
+  gateway: string | null;
+}
+
+/**
+ * The static routes, or null where the listing could not be read.
+ *
+ * Null covers the read that failed and the response that was not a list, which
+ * are the same fact to a caller: the static routes cannot be stated. Neither is
+ * the empty list of a system that has none, and `failures` is what names the
+ * first of the two.
+ */
+function staticRouteRows(routes: unknown): StaticRouteRow[] | null {
+  if (!Array.isArray(routes)) return null;
+  return routes.map((entry) => {
+    const route = recordOrNull(entry);
+    return {
+      destination: textOrNull(route?.['destination']),
+      gateway: textOrNull(route?.['gateway']),
+    };
+  });
+}
+
+export const networkConfig: ReadOnlyTool = {
+  name: 'network_config',
+  description:
+    "This system's network settings: hostname, DNS servers, default gateways " +
+    'and the routes configured by hand. These are the settings OVER the ' +
+    'interfaces; `network_interfaces` is what reports the interfaces ' +
+    'themselves, their links and their addresses, and neither tool reports ' +
+    'the other. Wherever the system can say both, a value is reported from ' +
+    'BOTH SIDES: what is CONFIGURED on this system, and what is IN EFFECT ' +
+    'right now. The two differ in both directions — a system addressed by ' +
+    'DHCP has a gateway and nameservers in effect with nothing configured, ' +
+    'and a system whose configuration has not been applied has a configured ' +
+    'value that nothing is using. `source` is what states which: `STATIC` ' +
+    'means the value IS CONFIGURED HERE, and `AUTOMATIC` means it is in ' +
+    'effect WITHOUT being configured here — DHCP on IPv4, and DHCPv6 or a ' +
+    'router advertisement on IPv6, WHICH THIS TOOL CANNOT TELL APART and so ' +
+    'does not name. `hostname` and `domain` are the configured hostname and ' +
+    'DNS domain of this system, each null where it reported none; the ' +
+    'hostnames of an HA peer and of an HA virtual address are not reported ' +
+    'here. `search_domains` are the additional domains appended when a bare ' +
+    'name is resolved: an empty list is a system with none, and NULL IS A ' +
+    'SYSTEM THAT REPORTED NO LIST AT ALL. `ipv4_gateway` and `ipv6_gateway` ' +
+    'each carry `configured`, the gateway set on this system and null where ' +
+    'none is; `in_effect`, the default route of that family the system ' +
+    'reports as currently in use and null where there is none; and `source`. ' +
+    'A `source` of null means neither a configured gateway nor one in effect ' +
+    'was found for that family. `nameservers` lists every DNS server this ' +
+    'system is using or has been given, THOSE IN USE FIRST AND IN THE ORDER ' +
+    'THE SYSTEM TRIES THEM, followed by any configured server that is not in ' +
+    'use. Each carries its `address`, its `source`, and `in_effect`: true ' +
+    'where the system is actually using it, false where it is configured and ' +
+    'NOT in use, and NULL WHERE THE EFFECTIVE LIST COULD NOT BE READ — a null ' +
+    'is never "not in use". An empty list is a system with no DNS server ' +
+    'configured and none in effect. `static_routes` are the routes configured ' +
+    'by hand, each with its `destination` and `gateway`; the interface and ' +
+    'default routes the kernel derives on its own ARE NOT ROUTES CONFIGURED ' +
+    'BY HAND and are not listed here, so an empty list means no static route ' +
+    'is configured rather than that the system has no routes. NULL IS A ' +
+    'LISTING THAT COULD NOT BE READ. `failures` names each read that did not ' +
+    'complete, with the reason the system gave; it is empty where every read ' +
+    'completed, and A FIELD IT NAMES AS UNREADABLE MUST NOT BE READ AS ' +
+    'ABSENT — when it names `effective_values`, every `in_effect` is null and ' +
+    'no value can be reported as `AUTOMATIC`, so a `STATIC` gateway or ' +
+    'nameserver is still correct there while the absence of one is not ' +
+    'evidence of anything. This tool reports settings as they are: it does ' +
+    'not change any network setting, and IT DOES NOT TEST whether a name ' +
+    'resolves, a gateway answers or a host is reachable — a nameserver ' +
+    'reported here is one the system is configured to use, not one confirmed ' +
+    'to be working. NO field beyond those named here is returned, whatever ' +
+    'else a later TrueNAS release adds to the network configuration.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Every read is issued before any is awaited, so none waits on another.
+    // Only the configuration is allowed to fail the tool: it is the answer,
+    // and the other two sharpen it.
+    const [config, summary, routes] = await Promise.all([
+      firstValueFrom(system.client.api.call('network.configuration.config')),
+      attempt('effective_values', () =>
+        firstValueFrom(system.client.api.call('network.general.summary')),
+      ),
+      attempt('static_routes', () => firstValueFrom(system.client.api.query('staticroute.query'))),
+    ]);
+
+    const effective = effectiveValues(summary.value);
+    const failures: ConfigFailure[] = [];
+    if (summary.failure !== null) failures.push(summary.failure);
+    if (routes.failure !== null) failures.push(routes.failure);
+
+    return {
+      hostname: textOrNull(config['hostname']),
+      domain: textOrNull(config['domain']),
+      search_domains: textList(config['domains']),
+      ipv4_gateway: gatewayReport(textOrNull(config['ipv4gateway']), effective.default_routes, false),
+      ipv6_gateway: gatewayReport(textOrNull(config['ipv6gateway']), effective.default_routes, true),
+      nameservers: nameserverReports(config, effective.nameservers),
+      static_routes: staticRouteRows(routes.value),
+      failures,
+    };
   },
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -12,6 +12,7 @@ import {
   disksList,
   iscsiList,
   listDatasets,
+  networkConfig,
   networkInterfaces,
   nvmeofList,
   poolStatus,
@@ -69,7 +70,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-two sketch tools', () => {
+  it('registers the twenty-three sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -92,6 +93,7 @@ describe('createDefaultCatalog', () => {
       'users_list',
       'directory_services_status',
       'network_interfaces',
+      'network_config',
       'snapshots_create',
     ]);
   });
@@ -185,6 +187,12 @@ describe('createDefaultCatalog', () => {
   it('advertises network_interfaces to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'network_interfaces',
+    );
+  });
+
+  it('advertises network_config to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'network_config',
     );
   });
 });
@@ -5828,5 +5836,355 @@ describe('network_interfaces', () => {
     const { ctx, query } = fakeSystem({ ['interface.query']: [] });
     await networkInterfaces.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('interface.query');
+  });
+});
+
+describe('network_config', () => {
+  /**
+   * The configured side, as `network.configuration.config` sends it. The fields
+   * this tool does not name are here on purpose — the middleware sends them on
+   * every call, and the test that nothing beyond the named fields survives is
+   * only worth anything against a fixture that carries some.
+   */
+  const CONFIG = {
+    id: 1,
+    hostname: 'nas',
+    domain: 'example.com',
+    domains: ['lab.example.com'],
+    ipv4gateway: '192.168.1.1',
+    ipv6gateway: '',
+    nameserver1: '192.168.1.1',
+    nameserver2: '',
+    nameserver3: '',
+    httpproxy: 'http://proxy.invalid:3128',
+    hosts: ['10.0.0.9 buildbox'],
+    service_announcement: { netbios: false, mdns: true, wsd: true },
+  };
+
+  /** The effective side, as `network.general.summary` sends it. */
+  const SUMMARY = {
+    ips: { eno1: { IPV4: ['192.168.1.10/24'] } },
+    default_routes: ['192.168.1.1'],
+    nameservers: ['192.168.1.1'],
+  };
+
+  const route = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    destination: '10.0.0.0/8',
+    gateway: '192.168.1.254',
+    ...over,
+  });
+
+  /**
+   * The three reads, canned. `config` and `summary` are spread over their
+   * defaults so a test naming one field keeps the rest; passing `null` for the
+   * summary is how a test says the system answered with nothing this tool can
+   * read, which is a different case from a summary missing one field.
+   */
+  const read = async (
+    config: Record<string, unknown> = {},
+    summary: Record<string, unknown> | null = {},
+    routes: unknown = [route()],
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({
+      ['network.configuration.config']: { ...CONFIG, ...config },
+      ['network.general.summary']: summary === null ? null : { ...SUMMARY, ...summary },
+      ['staticroute.query']: routes,
+    });
+    return (await networkConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  /** The same three reads, with the named ones rejecting instead. */
+  const readFailing = async (
+    failures: Partial<Record<string, unknown>>,
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = failingSystem(
+      {
+        ['network.configuration.config']: CONFIG,
+        ['network.general.summary']: SUMMARY,
+        ['staticroute.query']: [route()],
+      },
+      failures,
+    );
+    return (await networkConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('reports the hostname, DNS, gateways and static routes from both sides', async () => {
+    expect(await read()).toEqual({
+      hostname: 'nas',
+      domain: 'example.com',
+      search_domains: ['lab.example.com'],
+      ipv4_gateway: { configured: '192.168.1.1', in_effect: '192.168.1.1', source: 'STATIC' },
+      // Nothing configured and no IPv6 default route in effect: the family is
+      // absent rather than unreadable, which is what a null source says.
+      ipv6_gateway: { configured: null, in_effect: null, source: null },
+      nameservers: [{ address: '192.168.1.1', source: 'STATIC', in_effect: true }],
+      static_routes: [{ destination: '10.0.0.0/8', gateway: '192.168.1.254' }],
+      failures: [],
+    });
+  });
+
+  it('returns no field the tool does not name, from either side', async () => {
+    const result = await read(
+      { future_field: 'added by a later release' },
+      { future_field: 'added by a later release' },
+    );
+    expect(Object.keys(result)).toEqual([
+      'hostname',
+      'domain',
+      'search_domains',
+      'ipv4_gateway',
+      'ipv6_gateway',
+      'nameservers',
+      'static_routes',
+      'failures',
+    ]);
+    // Against the whole serialized result rather than its top-level keys: a
+    // field that reached a gateway, nameserver or route entry would pass a key
+    // check and still be in front of the caller. The proxy, the hosts entries,
+    // the service announcement and the row id are all fields the middleware
+    // sends and this tool does not name.
+    const serialized = JSON.stringify(result);
+    for (const dropped of [
+      'added by a later release',
+      'proxy.invalid',
+      'buildbox',
+      'netbios',
+      'IPV4',
+    ]) {
+      expect(serialized).not.toContain(dropped);
+    }
+  });
+
+  it('reports a value in effect and not configured here as automatic', async () => {
+    // The DHCP case: nothing set on this system, and a gateway and two
+    // nameservers in use regardless.
+    expect(
+      await read(
+        { ipv4gateway: '', nameserver1: '', nameserver2: '', nameserver3: '' },
+        { default_routes: ['192.168.1.254'], nameservers: ['1.1.1.1', '8.8.8.8'] },
+      ),
+    ).toMatchObject({
+      ipv4_gateway: { configured: null, in_effect: '192.168.1.254', source: 'AUTOMATIC' },
+      // In the order the system reported them: resolution is tried in that
+      // order, so it is a fact rather than a presentation.
+      nameservers: [
+        { address: '1.1.1.1', source: 'AUTOMATIC', in_effect: true },
+        { address: '8.8.8.8', source: 'AUTOMATIC', in_effect: true },
+      ],
+    });
+  });
+
+  it('reports a configured value that nothing is using as static and not in effect', async () => {
+    // A configuration that has not been applied: `source` is decided by the
+    // configured side alone, and `in_effect` is what shows it is not the value
+    // the system is actually using.
+    expect(
+      await read(
+        { ipv4gateway: '192.168.1.1', nameserver1: '9.9.9.9' },
+        { default_routes: ['10.0.0.1'], nameservers: ['1.1.1.1'] },
+      ),
+    ).toMatchObject({
+      ipv4_gateway: { configured: '192.168.1.1', in_effect: '10.0.0.1', source: 'STATIC' },
+      nameservers: [
+        { address: '1.1.1.1', source: 'AUTOMATIC', in_effect: true },
+        { address: '9.9.9.9', source: 'STATIC', in_effect: false },
+      ],
+    });
+  });
+
+  it('splits the default routes it is given by address family', async () => {
+    // One list carrying both, which is how the summary reports them.
+    expect(
+      await read(
+        { ipv4gateway: '', ipv6gateway: 'fe80::1' },
+        { default_routes: ['192.168.1.254', 'fe80::1'] },
+      ),
+    ).toMatchObject({
+      ipv4_gateway: { configured: null, in_effect: '192.168.1.254', source: 'AUTOMATIC' },
+      ipv6_gateway: { configured: 'fe80::1', in_effect: 'fe80::1', source: 'STATIC' },
+    });
+  });
+
+  it('reports an IPv6 gateway in effect and not configured here as automatic', async () => {
+    // DHCPv6 or a router advertisement — the tool cannot tell those apart and
+    // names neither.
+    expect(await read({}, { default_routes: ['2001:db8::1'] })).toMatchObject({
+      ipv6_gateway: { configured: null, in_effect: '2001:db8::1', source: 'AUTOMATIC' },
+    });
+  });
+
+  it('cannot confirm a configured value where the effective side says nothing', async () => {
+    // Null rather than false: a server whose use cannot be confirmed must not
+    // report as one that is definitely unused, and a gateway that is configured
+    // is still configured.
+    expect(await read({ nameserver1: '9.9.9.9' }, null)).toMatchObject({
+      ipv4_gateway: { configured: '192.168.1.1', in_effect: null, source: 'STATIC' },
+      nameservers: [{ address: '9.9.9.9', source: 'STATIC', in_effect: null }],
+    });
+  });
+
+  it('names an effective read that failed, and reports nothing as automatic', async () => {
+    expect(await readFailing({ ['network.general.summary']: new Error('summary refused') })).toMatchObject(
+      {
+        ipv4_gateway: { configured: '192.168.1.1', in_effect: null, source: 'STATIC' },
+        nameservers: [{ address: '192.168.1.1', source: 'STATIC', in_effect: null }],
+        failures: [{ source: 'effective_values', error: 'summary refused' }],
+      },
+    );
+  });
+
+  it('names a static route read that failed, and reports the routes as unreadable', async () => {
+    // Null rather than the empty list of a system with no static route: the two
+    // readings are opposite and only one of them is true here.
+    expect(await readFailing({ ['staticroute.query']: new Error('routes refused') })).toMatchObject({
+      static_routes: null,
+      failures: [{ source: 'static_routes', error: 'routes refused' }],
+    });
+  });
+
+  it('reports both failures where both supplementary reads fail', async () => {
+    const result = await readFailing({
+      ['network.general.summary']: new Error('summary refused'),
+      ['staticroute.query']: new Error('routes refused'),
+    });
+    expect(result['failures']).toEqual([
+      { source: 'effective_values', error: 'summary refused' },
+      { source: 'static_routes', error: 'routes refused' },
+    ]);
+    // And the configured side is still answered in full, which is the whole
+    // point of not letting either failure take the tool down.
+    expect(result).toMatchObject({ hostname: 'nas', domain: 'example.com' });
+  });
+
+  it('fails the tool where the configuration itself cannot be read', async () => {
+    // The one read that is the answer rather than a sharpening of it.
+    const { ctx } = failingSystem({}, { ['network.configuration.config']: new Error('denied') });
+    await expect(networkConfig.handler(ctx, {})).rejects.toThrow('denied');
+  });
+
+  it('states a reason for a failure however the client rejected', async () => {
+    // A rejection is not necessarily an Error: the client rejects with whatever
+    // the transport gave it, and a middleware error carries `reason` where a
+    // JSON-RPC one carries `message`.
+    const reasons = await Promise.all(
+      [
+        new Error('an error'),
+        { reason: 'a middleware error' },
+        { message: 'a json-rpc error' },
+        'a bare string',
+        new Error(''),
+        {},
+        null,
+      ].map(async (rejection) => {
+        const result = await readFailing({ ['staticroute.query']: rejection });
+        return (result['failures'] as { error: string }[])[0].error;
+      }),
+    );
+    expect(reasons).toEqual([
+      'an error',
+      'a middleware error',
+      'a json-rpc error',
+      'a bare string',
+      'the system reported no reason',
+      'the system reported no reason',
+      'the system reported no reason',
+    ]);
+  });
+
+  it('reports no static route configured as an empty list', async () => {
+    expect(await read({}, {}, [])).toMatchObject({ static_routes: [], failures: [] });
+  });
+
+  it('reports a route listing sent as something other than a list as unreadable', async () => {
+    // The read completed, so there is no failure to name — it simply answered
+    // nothing this tool can read, and null says exactly that.
+    expect(await read({}, {}, 'not a listing')).toMatchObject({
+      static_routes: null,
+      failures: [],
+    });
+  });
+
+  it('reports a route destination or gateway the system did not name as null', async () => {
+    expect(
+      await read({}, {}, [route({ destination: '', gateway: null }), 'not a route']),
+    ).toMatchObject({
+      static_routes: [
+        { destination: null, gateway: null },
+        { destination: null, gateway: null },
+      ],
+    });
+  });
+
+  it('keeps no search domains apart from no search domain list at all', async () => {
+    expect(await read({ domains: [] })).toMatchObject({ search_domains: [] });
+    expect(await read({ domains: 'lab.example.com' })).toMatchObject({ search_domains: null });
+  });
+
+  it('drops a search domain the system did not name', async () => {
+    expect(await read({ domains: ['lab.example.com', '', 7, null] })).toMatchObject({
+      search_domains: ['lab.example.com'],
+    });
+  });
+
+  it('reports a nameserver the system named twice once', async () => {
+    expect(
+      await read({ nameserver1: '' }, { nameservers: ['1.1.1.1', '1.1.1.1'] }),
+    ).toMatchObject({
+      nameservers: [{ address: '1.1.1.1', source: 'AUTOMATIC', in_effect: true }],
+    });
+  });
+
+  it('reports a system with no DNS server at all as having none', async () => {
+    expect(
+      await read({ nameserver1: '', nameserver2: '', nameserver3: '' }, { nameservers: [] }),
+    ).toMatchObject({ nameservers: [] });
+  });
+
+  it('reads every numbered nameserver slot, whichever are filled', async () => {
+    // A third slot filled with the second left empty is ordinary rather than a
+    // malformed configuration.
+    expect(
+      await read(
+        { nameserver1: '1.1.1.1', nameserver2: '', nameserver3: '9.9.9.9' },
+        { nameservers: [] },
+      ),
+    ).toMatchObject({
+      nameservers: [
+        { address: '1.1.1.1', source: 'STATIC', in_effect: false },
+        { address: '9.9.9.9', source: 'STATIC', in_effect: false },
+      ],
+    });
+  });
+
+  it('reports a hostname or domain the system did not name as null', async () => {
+    expect(await read({ hostname: '', domain: null })).toMatchObject({
+      hostname: null,
+      domain: null,
+    });
+  });
+
+  it('reports an effective list sent as something other than a list as unread', async () => {
+    // The summary is a record and its two fields are not lists: nothing can be
+    // said about what is in effect, which is not the same as nothing being in
+    // effect.
+    expect(
+      await read({}, { default_routes: '192.168.1.1', nameservers: '192.168.1.1' }),
+    ).toMatchObject({
+      ipv4_gateway: { configured: '192.168.1.1', in_effect: null, source: 'STATIC' },
+      nameservers: [{ address: '192.168.1.1', source: 'STATIC', in_effect: null }],
+    });
+  });
+
+  it('asks for the configuration, the summary and the static routes', async () => {
+    const { ctx, call, query } = fakeSystem({
+      ['network.configuration.config']: CONFIG,
+      ['network.general.summary']: SUMMARY,
+      ['staticroute.query']: [],
+    });
+    await networkConfig.handler(ctx, {});
+    expect(call).toHaveBeenCalledWith('network.configuration.config');
+    expect(call).toHaveBeenCalledWith('network.general.summary');
+    expect(query).toHaveBeenCalledWith('staticroute.query');
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -5924,6 +5924,38 @@ describe('network_config', () => {
     });
   });
 
+  it('reports the answering node of an HA pair, not the pair-wide `hostname`', async () => {
+    // What node B of an HA pair sends: `hostname` stays node A's on both
+    // nodes, and `hostname_local` is what the middleware resolves per node.
+    // Reading `hostname` here would report the PEER under a field the
+    // description defines as this system's.
+    expect(
+      await read({ hostname: 'nas-a', hostname_b: 'nas-b', hostname_local: 'nas-b' }),
+    ).toMatchObject({ hostname: 'nas-b' });
+  });
+
+  it('falls back to `hostname` where the system reports no local one', async () => {
+    // `hostname_local` is added by a read-side extend rather than stored, so a
+    // response without it is not a system without a hostname. The empty string
+    // is how the middleware sends "no value" and must fall back the same way.
+    expect(await read({ hostname: 'nas', hostname_local: '' })).toMatchObject({ hostname: 'nas' });
+    expect(await read({ hostname: 'nas' })).toMatchObject({ hostname: 'nas' });
+  });
+
+  it('reports neither the HA peer nor the HA virtual hostname', async () => {
+    const result = await read({
+      hostname: 'nas-a',
+      hostname_b: 'nas-b',
+      hostname_virtual: 'nas-ha',
+      hostname_local: 'nas-a',
+    });
+    expect(result).toMatchObject({ hostname: 'nas-a' });
+    // Against the serialized result, not the keys: either could only reach a
+    // caller as a value under a field this tool does name.
+    expect(JSON.stringify(result)).not.toContain('nas-b');
+    expect(JSON.stringify(result)).not.toContain('nas-ha');
+  });
+
   it('returns no field the tool does not name, from either side', async () => {
     const result = await read(
       { future_field: 'added by a later release' },


### PR DESCRIPTION
Adds `network_config` to the networking family: the system-wide settings over the interfaces, where `network_interfaces` (merged as #65) reports the interfaces themselves. Read-only, `Role.ReadOnly`, `mutating: false`.

Fixes #31

## How the DHCP-vs-static distinction is made

No single field on the configuration says where a value came from, so the tool reads both sides and compares them:

| read | holds | fails the tool |
|---|---|---|
| `network.configuration.config` | what is **configured** on this system | yes — it is the answer |
| `network.general.summary` | the default routes and nameservers **in effect** | no |
| `staticroute.query` | the routes configured by hand | no |

A system addressed by DHCP has a gateway and nameservers in effect and nothing configured; a system whose configuration has not been applied has the reverse. Each gateway is reported as `configured` / `in_effect` / `source`, and each nameserver as `address` / `source` / `in_effect`. `source` is `STATIC` where the value is set here — decided by the configured side alone, so it is stated the same way whether or not the effective side could be read — and `AUTOMATIC` where the value is in effect **without** being set here.

`AUTOMATIC` rather than `DHCP`: on IPv6 the same evidence is produced by DHCPv6 and by a router advertisement, and the tool cannot tell those apart. Naming one would be a guarantee the normalization does not deliver.

The summary reports default routes as one list without saying which family each belongs to, so they are split on the colon — an IPv6 address always contains one and an IPv4 address never does.

## `hostname` on an HA pair

The configuration carries a hostname **per HA node** — `hostname` and `hostname_b` — plus `hostname_virtual` for the address the pair answers on. `hostname` is node A's value on **both** nodes, so reading it directly meant node B of an HA pair reported its **peer's** name under a field this tool defines as this system's, two clauses before the description promises an HA peer's hostname is not reported here.

The middleware resolves that on the read side into `hostname_local`, which is `hostname` on node A and on every single-node system and `hostname_b` on node B, so preferring it is correct everywhere rather than only on HA. `localHostname` reads it with a fallback to `hostname`, because it is added by an **extend** rather than stored: a release that does not add it, or a response it could not be read from, still has the field that was correct before HA, and on a single-node system the two are the same value anyway.

The description states both halves, including what the fallback costs: where the system reports a per-node hostname this is the answering node, and where it reports none the pair-wide name is reported instead and may not be the answering node's. **The tool does not say which of the two it reported** — a caller that must know is asking a question `#45` (HA state) owns.

`hostname_b` and `hostname_virtual` are still not reported, and a test asserts neither reaches a caller under any field.

## Grounding, and what is unconfirmed

`network.configuration.config` is typed `Record<string, unknown>` on the pinned client, so every field is read defensively, as an interface row is in the same file. Most configured field **names** (`hostname`, `domain`, `domains`, `ipv4gateway`, `ipv6gateway`, `nameserver1..3`) come from the client's own `NetWorkConfigurationUpdate`, which describes this same record on the update side — strong evidence rather than a guarantee, and a name that turns out wrong costs a null rather than a wrong value.

`hostname_local` is the exception, and deliberately so: a field the middleware adds when it **reads** the record cannot appear on an update type, so its absence there is not evidence against it. That is exactly why it is read with a fallback rather than on its own — the fallback is what makes a wrong guess cost nothing.

`NetworkGeneralSummaryResult` **is** typed, with `default_routes` and `nameservers` on it, so the effective half is the grounded one. None of this has been exercised against a live middleware.

## The judgement call in the ticket

The tool **reports configuration and does not probe.** No opt-in resolution test was added, and the description says so in terms: it does not test whether a name resolves, a gateway answers or a host is reachable, so a nameserver reported here is one the system is configured to use rather than one confirmed to be working. Adding a probe would put a tool that reaches the network behind a read-only role, and the ticket already treats that as needing an explicit argument — worth its own ticket with its own review rather than a flag on this one.

## Nulls

Every null in the result is documented as *unreadable* or as *absent*, never as both — the field that keeps recurring on this project's reviews:

- `search_domains` — `[]` is a system with no search domain; `null` is a system that reported no list at all.
- gateway `in_effect` — `null` both where there is no route of that family **and** where the effective side could not be read; `source` is what remains reliable there, and it still reads `STATIC` off the configured side alone.
- nameserver `in_effect` — `true` in use, `false` configured and not in use, `null` where the effective list could not be read. Never "not in use".
- `static_routes` — `[]` is no static route configured; `null` is a listing that could not be read. Kernel-derived interface and default routes are not static routes and are not listed.
- `failures` — one entry per supplementary read that did **not complete**, so it does not name a read that completed and answered a shape the tool cannot read; that shows as the nulls above.

## Scope

Reported: hostname, domain, search domains, both default gateways, nameservers, static routes. Not reported, deliberately, since the acceptance criteria do not ask and every surviving field is one the LLM pays for on every call: `httpproxy`, the `hosts` overrides, `service_announcement`, and the HA peer and virtual hostnames (`hostname_b`, `hostname_virtual`) — #45 owns HA. `hostname_local` is **read** but not reported as a field of its own; it only decides which name `hostname` carries. The result is an allowlist, so nothing a later TrueNAS release adds reaches a caller without a change to this file; a test asserts that against the whole serialized result rather than its top-level keys.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (419 pass) and `yarn test:coverage` all run locally and pass, as does `yarn build`. `src/tools/network.ts` is at 100% statements and 100% branches, and the global floors (branches 96 / statements 97) are unchanged. Nothing in CI was unrunnable here.

## Review

`local-review.py` ran the project's own reviewer in a separate process — the same rubric, threshold and parser as the required check — on each round.

**The required check's MEDIUM on `35ac93b` is fixed in `588408d`**: `config['hostname']` is not the answering node's hostname on an HA pair. The reviewer asked for it to be checked against the pinned client and flagged that it could not do so itself. Checked: `NetworkConfigurationEntry` is `type NetworkConfigurationEntry = Record<string, unknown>` (`dist/index.d.ts:1085`), so the types neither confirm nor refute `hostname_local` — they do not name `hostname` either. `hostname_b` and `hostname_virtual` **are** on `NetWorkConfigurationUpdate`, which confirms the per-node hostname shape the finding rests on. The fallback is what makes the change safe under that residual uncertainty; see the HA section above.

The local round on that fix then raised its own MEDIUM — the first wording of the new description asserted `hostname` is always the answering node, which the fallback does not deliver — and that is fixed in the same commit. The round after it **returned nothing at or above MEDIUM**, which is where the local loop stops.

### LOWs left unfixed, and why

Fixing a LOW is a new diff, and a new diff is unreviewed. These are recorded rather than acted on:

1. **`hostname` here is the configured hostname, while `system_info.hostname` is the running one; the description cross-references `network_interfaces` but not `system_info`.** A real cross-tool ambiguity for a caller holding both results, and one that only exists once this PR lands. Not changed here because the fix touches a description in another file.
2. **The gateway paragraph does not say that `source` is decided by `configured` alone**, so on an un-applied configuration (`{configured: '192.168.1.1', in_effect: '10.0.0.1', source: 'STATIC'}`) "the value" has two referents and a caller may read the effective gateway as the statically configured one. The code comment on `gatewayReport` states the rule; the description leaves it to a general sentence. Description text only.
3. **`config` is the only read whose top-level shape is unguarded** — a non-object configuration response throws a `TypeError` rather than taking the tool's own failure path, unlike its two guarded siblings.
4. **`gatewayReport` reports only the first default route per family**, and the description says "the default route of that family" without noting that an equal-cost pair shows one of several.
5. **The `failures` paragraph names only `effective_values`**, never the `static_routes` source value nor the `source`/`error` field names of an entry.
6. **`errorText` / `NO_REASON` / `Attempt` / `attempt` are a fourth copy** of a helper set that already exists in `block.ts`, which parameterises `Attempt`/`attempt` over the source union where this file hard-codes `ConfigFailure`. A shared-helper extraction across four files is its own change with its own blast radius, not a tail-end edit to this one.

3–6 are pre-existing in this diff rather than introduced by the HA fix; 6 spans files this ticket does not own.
