### PR TITLE
feat(tools): add certificates_list with expiry dates and an expiring-soon filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
   `nvmeof_list`, `users_list`, `directory_services_status`,
-  `network_interfaces`, `network_config`.
+  `network_interfaces`, `network_config`, `certificates_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,5 +82,6 @@ export {
   directoryServicesStatus,
   networkInterfaces,
   networkConfig,
+  certificatesList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/certificates.ts
+++ b/src/tools/certificates.ts
@@ -1,0 +1,303 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Certificates family: which certificates this system holds, and when each one
+ * stops being valid.
+ *
+ * `certificate.query` answers all of it in one call, and unlike the interface
+ * and network-configuration listings the pinned client TYPES the entity it
+ * returns — `certificate.query` carries an `entity` in the client's own call
+ * directory for the version this is written against, so `name`, `common`,
+ * `san`, `from`, `until` and `expired` are read as declared fields rather than
+ * guessed off a bare record the way `network.ts` has to read one. What is read
+ * defensively here is the CONTENT of those fields, not their names: a date the
+ * middleware formatted is still text this file has to parse, and `issuerName`
+ * below is the one field with no declaration behind it at all.
+ *
+ * The mapping is an allowlist, as in `pools.ts` and `network.ts`. A raw
+ * certificate row carries the PEM certificate, its private key, the CSR, the
+ * ACME account and authenticator configuration, the full chain, the key length
+ * and type, and every component of the subject separately — on every
+ * certificate on the system. Only the fields named below survive, so neither a
+ * private key nor a field a later TrueNAS release adds can reach a caller
+ * without a change to this file.
+ */
+
+/**
+ * One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters: the
+ * middleware sends `""` for a subject component a certificate does not carry,
+ * and passing it through would put a field in the result that says nothing.
+ *
+ * `network.ts`, `accounts.ts`, `shares.ts`, `tasks.ts` and `block.ts` each hold
+ * this same reading under their own names, and it is restated here for the
+ * reason those files give for restating it: a tool file is read on its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * The non-empty strings of a list field, or null where the field was not a list
+ * at all.
+ *
+ * The two are kept apart for the reason `network.ts` keeps them apart: a
+ * certificate that reported an empty SAN list carries no alternative name, and
+ * one that reported no list said nothing about them.
+ */
+function textList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.flatMap((entry) => {
+    const text = textOrNull(entry);
+    return text === null ? [] : [text];
+  });
+}
+
+/** Month names in the order the C `asctime` format abbreviates them. */
+const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+
+/**
+ * A timestamp that ends in an explicit zone — `Z`, or an offset in either of
+ * the two spellings. `Date.parse` is well defined on these and is used for
+ * them; every other form below is read here rather than handed to it.
+ */
+const ZONED = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+/** ISO 8601 carrying no zone, including the date-only form. */
+const BARE_ISO = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/;
+
+/**
+ * The C library's `asctime` form, which is what the middleware's own date
+ * formatting produces: `Mon Feb 24 12:00:00 2025`, with a single-digit day
+ * padded by a second space.
+ */
+const ASCTIME = /^[A-Za-z]{3} ([A-Za-z]{3}) {1,2}(\d{1,2}) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/;
+
+/**
+ * A validity date as milliseconds since the epoch, or null where the text was
+ * not a form this reads.
+ *
+ * The middleware sends these as formatted text rather than as a timestamp, and
+ * the spelling is not guaranteed — (unconfirmed) against a live system, which
+ * is why `not_before` and `not_after` are also returned verbatim beside the day
+ * count computed from them rather than replaced by it.
+ *
+ * A ZONE-LESS timestamp is read as UTC, and that is the whole reason this is
+ * not one call to `Date.parse`. An x509 validity date IS UTC — the certificate
+ * encodes it that way and the middleware formats it without saying so — while
+ * ECMAScript defines a zone-less date-and-time string as LOCAL time, so
+ * `Date.parse` would move every expiry by the offset of whatever machine this
+ * happens to run on. Up to fourteen hours, silently, in whichever direction
+ * that machine's zone lies, which is enough to move a day count across a
+ * boundary. `tasks.ts` refuses to read such a string at all for the same
+ * reason; here it cannot refuse, because the string is the system's own answer
+ * rather than a caller's argument, so it is read in the zone it was written in.
+ *
+ * Nothing checks that the components name a date that exists, unlike the
+ * caller-supplied bound in `tasks.ts`: this value comes from a certificate the
+ * system parsed rather than from something a caller typed, and a middleware
+ * sending `2026-02-30` is a fault of a different kind from a user mistyping
+ * one. A date that rolls over is reported as the instant it rolls to, beside
+ * the text it was read from.
+ */
+function instantOf(text: string | null): number | null {
+  if (text === null) return null;
+  if (ZONED.test(text)) {
+    const millis = Date.parse(text);
+    return Number.isNaN(millis) ? null : millis;
+  }
+  const iso = BARE_ISO.exec(text);
+  if (iso !== null) {
+    // The time groups are absent on the date-only form, where midnight UTC is
+    // what ECMAScript itself reads that form as.
+    return Date.UTC(
+      Number(iso[1]),
+      Number(iso[2]) - 1,
+      Number(iso[3]),
+      Number(iso[4] ?? 0),
+      Number(iso[5] ?? 0),
+      Number(iso[6] ?? 0),
+    );
+  }
+  const asctime = ASCTIME.exec(text);
+  if (asctime === null) return null;
+  const month = MONTHS.indexOf(asctime[1].toLowerCase());
+  // A three-letter word in the month's position that is not a month name means
+  // this is not the form it looked like.
+  if (month < 0) return null;
+  return Date.UTC(
+    Number(asctime[6]),
+    month,
+    Number(asctime[2]),
+    Number(asctime[3]),
+    Number(asctime[4]),
+    Number(asctime[5]),
+  );
+}
+
+/** Milliseconds in a day. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whole days from now until the certificate stops being valid, or null where no
+ * expiry date could be read.
+ *
+ * Floored, so the number is days the certificate has LEFT rather than days
+ * rounded to the nearest: `0` is a certificate that expires within the next
+ * twenty-four hours and has not expired yet, and anything negative has already
+ * expired — which is what makes an expired certificate answer a non-positive
+ * number instead of dropping out of a result that is asked for the ones
+ * expiring soon.
+ */
+function daysUntil(expiry: number | null, now: number): number | null {
+  return expiry === null ? null : Math.floor((expiry - now) / DAY_MS);
+}
+
+/**
+ * The issuer, as the system named it, or null where it named none.
+ *
+ * The one field here with no declaration behind it. The pinned client declares
+ * NO `issuer` on a certificate entry — not on the version this is written
+ * against and not on any of the seven others it carries — so it is read off the
+ * row rather than taken from the type, the way every field in `network.ts` is
+ * read.
+ *
+ * It is read at all because the middleware has historically added an issuer
+ * when it READS a certificate, which is exactly the kind of field a type
+ * generated from the stored model does not carry — `hostname_local` in
+ * `network.ts` is the same shape of fact, and is read there with the same
+ * reasoning. A release that sends one is reported; a release that does not
+ * costs a null rather than a wrong value.
+ *
+ * An issuer the system names as an object rather than as text is reported by
+ * that object's `name`, which is how a certificate authority is named
+ * everywhere else in the API. Any other shape names no issuer this tool can
+ * report.
+ *
+ * NULL IS THEREFORE "THIS SYSTEM REPORTED NO ISSUER" AND NEVER "SELF-SIGNED",
+ * and the tool's description says so: the two are not distinguishable from
+ * here, and reporting a certificate signed by a CA this tool simply could not
+ * read as self-signed would be worse than reporting nothing.
+ */
+function issuerName(row: object): string | null {
+  const issuer = (row as Record<string, unknown>)['issuer'];
+  const text = textOrNull(issuer);
+  if (text !== null) return text;
+  if (typeof issuer !== 'object' || issuer === null || Array.isArray(issuer)) return null;
+  return textOrNull((issuer as Record<string, unknown>)['name']);
+}
+
+/**
+ * How far ahead the caller asked to look, in days, or null where it asked for
+ * everything.
+ *
+ * Strict rather than lenient, as `tasks_recent_runs` is about `since` and for
+ * the same reason, which is sharper here than it is there: a bound that is
+ * quietly ignored returns EVERY certificate on the system under a call that
+ * asked for the ones expiring soon, and a model reading that answer will report
+ * every certificate as expiring within the window. Answering more than was
+ * asked for is the dangerous direction, so an argument that cannot be read
+ * stops the call rather than widening it. Null and undefined are the argument
+ * being absent, which is a caller asking for all of them.
+ */
+function withinDays(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error('"expiring_within_days" must be a number of days, such as 30');
+  }
+  return raw;
+}
+
+export const certificatesList: ReadOnlyTool = {
+  name: 'certificates_list',
+  description:
+    'Every certificate this system holds, with the dates it is valid between ' +
+    'and how long each one has left. An expired certificate takes the web UI ' +
+    'and every API client down at once, on a date that was knowable months ' +
+    'earlier, so this is the tool that answers "what is about to break". ' +
+    '`name` is the certificate as the system names it, which is what the ' +
+    'web UI shows and what other settings refer to. `common_name` is the ' +
+    "certificate's own common name and `subject_alternative_names` are the " +
+    'other names it is valid for; MODERN CLIENTS MATCH ON THE ALTERNATIVE ' +
+    'NAMES AND NOT ON THE COMMON NAME, so a certificate whose common name ' +
+    'looks right may still not cover the hostname in use. An empty list is a ' +
+    'certificate that carries no alternative name, and NULL IS ONE WHOSE ' +
+    'NAMES COULD NOT BE READ. `issuer` is who signed the certificate, where ' +
+    'the system reported one. NULL MEANS THIS SYSTEM REPORTED NO ISSUER AND ' +
+    'IS NEVER EVIDENCE THAT A CERTIFICATE IS SELF-SIGNED — the two cannot be ' +
+    'told apart from here, and not every TrueNAS release reports an issuer at ' +
+    'all. `not_before` and `not_after` are the dates the certificate is valid ' +
+    'between, PASSED THROUGH EXACTLY AS THE SYSTEM FORMATTED THEM rather than ' +
+    'converted, so their spelling varies by release; each is null where the ' +
+    'system reported none, which is ordinary on a signing request that has ' +
+    'not been signed yet. `days_until_expiry` is whole days from now until ' +
+    '`not_after`, so 0 means it expires within the next twenty-four hours and ' +
+    'A NEGATIVE NUMBER MEANS IT HAS ALREADY EXPIRED, by that many days. It is ' +
+    'null where `not_after` was absent or in a form this tool could not read, ' +
+    'WHICH IS NOT "DOES NOT EXPIRE" — every certificate expires, so a null ' +
+    'there is a certificate whose expiry is UNKNOWN and worth looking at ' +
+    'directly. It is computed here from `not_after`, read as UTC, and is ' +
+    'accurate to the day rather than to the hour. `expired` is the ' +
+    "SYSTEM'S OWN verdict, and is null where it gave none. The two can " +
+    'disagree — a clock that differs, or a date this tool could not read — ' +
+    'and where they do, `expired` is what the system believes and ' +
+    '`days_until_expiry` is what this tool computed from the date beside it. ' +
+    '`expiring_within_days` restricts the result to certificates with that ' +
+    'many days or fewer left, and ALREADY-EXPIRED CERTIFICATES ARE ALWAYS ' +
+    'INCLUDED because their day count is negative and so below any threshold. ' +
+    'Omitted, every certificate is returned. A CERTIFICATE WHOSE EXPIRY COULD ' +
+    'NOT BE READ IS NOT RETURNED WHEN THIS ARGUMENT IS GIVEN, since no ' +
+    'threshold can be applied to it — call without the argument to see those. ' +
+    'This tool reports certificates as they are: it does not import, create, ' +
+    'renew or delete a certificate or a signing request, and IT DOES NOT ' +
+    'RETURN ANY CERTIFICATE OR PRIVATE KEY MATERIAL. It does not say which ' +
+    'service uses which certificate. NO field beyond those named here is ' +
+    'returned, whatever else a later TrueNAS release adds to a certificate ' +
+    'record.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      expiring_within_days: {
+        type: 'number',
+        description:
+          'Only report certificates with this many days or fewer left before ' +
+          'they expire. Already-expired certificates are always included. ' +
+          'Omitted, every certificate is reported.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // Read before the query is issued, so a threshold that cannot be read stops
+    // the call rather than spending it.
+    const threshold = withinDays(args['expiring_within_days']);
+    // No filters and no options: a certificate listing is a handful of rows on
+    // any system, and the threshold is applied against a day count the
+    // middleware has no notion of comparing, so there is no filter that could
+    // express it.
+    const certificates = await firstValueFrom(system.client.api.query('certificate.query'));
+    // One reading of the clock for the whole result, so that two certificates
+    // expiring at the same instant cannot answer different day counts.
+    const now = Date.now();
+    const rows = certificates.map((certificate) => ({
+      name: textOrNull(certificate.name),
+      common_name: textOrNull(certificate.common),
+      subject_alternative_names: textList(certificate.san),
+      issuer: issuerName(certificate),
+      not_before: textOrNull(certificate.from),
+      not_after: textOrNull(certificate.until),
+      days_until_expiry: daysUntil(instantOf(textOrNull(certificate.until)), now),
+      expired: certificate.expired,
+    }));
+    if (threshold === null) return rows;
+    // A row with no day count is dropped rather than kept: the caller asked for
+    // the certificates inside a window, and one whose expiry cannot be read is
+    // not known to be inside it. The description says so, and says which call
+    // finds them.
+    return rows.filter((row) => row.days_until_expiry !== null && row.days_until_expiry <= threshold);
+  },
+};

--- a/src/tools/certificates.ts
+++ b/src/tools/certificates.ts
@@ -246,8 +246,11 @@ export const certificatesList: ReadOnlyTool = {
     'and where they do, `expired` is what the system believes and ' +
     '`days_until_expiry` is what this tool computed from the date beside it. ' +
     '`expiring_within_days` restricts the result to certificates with that ' +
-    'many days or fewer left, and ALREADY-EXPIRED CERTIFICATES ARE ALWAYS ' +
-    'INCLUDED because their day count is negative and so below any threshold. ' +
+    'many days or fewer left. An already-expired certificate has a NEGATIVE ' +
+    'day count, so ANY THRESHOLD OF ZERO OR MORE INCLUDES IT, which is what ' +
+    'makes one call answer "what is about to break, and what already has". A ' +
+    'NEGATIVE THRESHOLD asks the narrower question instead — the certificates ' +
+    'that expired at least that many days ago — and returns only those. ' +
     'Omitted, every certificate is returned. A CERTIFICATE WHOSE EXPIRY COULD ' +
     'NOT BE READ IS NOT RETURNED WHEN THIS ARGUMENT IS GIVEN, since no ' +
     'threshold can be applied to it — call without the argument to see those. ' +
@@ -264,7 +267,8 @@ export const certificatesList: ReadOnlyTool = {
         type: 'number',
         description:
           'Only report certificates with this many days or fewer left before ' +
-          'they expire. Already-expired certificates are always included. ' +
+          'they expire. An already-expired certificate counts as a negative ' +
+          'number of days, so any threshold of zero or more includes it. ' +
           'Omitted, every certificate is reported.',
       },
     },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import { directoryServicesStatus, usersList } from '@/tools/accounts';
 import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
+import { certificatesList } from '@/tools/certificates';
 import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
@@ -13,7 +14,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: twenty-two read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-three read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -38,6 +39,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(directoryServicesStatus);
   catalog.register(networkInterfaces);
   catalog.register(networkConfig);
+  catalog.register(certificatesList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -45,6 +47,7 @@ export function createDefaultCatalog(): ToolCatalog {
 export {
   alertsList,
   appsList,
+  certificatesList,
   cloudsyncTasksList,
   createSnapshot,
   directoryServicesStatus,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -5,6 +5,7 @@ import { Role } from '@/interfaces';
 import {
   alertsList,
   appsList,
+  certificatesList,
   cloudsyncTasksList,
   createDefaultCatalog,
   createSnapshot,
@@ -70,7 +71,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-three sketch tools', () => {
+  it('registers the twenty-four sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -94,8 +95,15 @@ describe('createDefaultCatalog', () => {
       'directory_services_status',
       'network_interfaces',
       'network_config',
+      'certificates_list',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises certificates_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'certificates_list',
+    );
   });
 
   it('advertises alerts_list to a read-only credential', () => {
@@ -6218,5 +6226,284 @@ describe('network_config', () => {
     expect(call).toHaveBeenCalledWith('network.configuration.config');
     expect(call).toHaveBeenCalledWith('network.general.summary');
     expect(query).toHaveBeenCalledWith('staticroute.query');
+  });
+});
+
+describe('certificates_list', () => {
+  /**
+   * A fixed present, so a day count is a fixed number rather than one that
+   * moves with the clock. Only `Date` is faked, as in `tasks_recent_runs`: the
+   * tool reads the clock and nothing here schedules anything.
+   */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * A certificate as `certificate.query` reports one, valid until five days
+   * after {@link NOW}.
+   *
+   * `certificate`, `privatekey` and `chain_list` carry real-looking material
+   * for the reason the job fixture's arguments carry a password: the test that
+   * no key material survives the mapping is only worth anything if some was
+   * there to survive. `renew_days`, `key_length`, `DN`, `serial` and
+   * `fingerprint` are fields of the real payload that the tool does not name.
+   */
+  const cert = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    type: 8,
+    name: 'truenas_default',
+    certificate: '-----BEGIN CERTIFICATE-----\nSECRET-CERTIFICATE-MATERIAL\n-----END-----',
+    privatekey: '-----BEGIN PRIVATE KEY-----\nSECRET-PRIVATE-KEY-MATERIAL\n-----END-----',
+    CSR: null,
+    acme_uri: null,
+    domains_authenticators: null,
+    renew_days: 10,
+    acme: null,
+    add_to_trusted_store: false,
+    root_path: '/etc/certificates',
+    certificate_path: '/etc/certificates/truenas_default.crt',
+    privatekey_path: '/etc/certificates/truenas_default.key',
+    csr_path: null,
+    cert_type: 'CERTIFICATE',
+    cert_type_existing: true,
+    cert_type_CSR: false,
+    cert_type_CA: false,
+    chain_list: ['-----BEGIN CERTIFICATE-----\nSECRET-CHAIN-MATERIAL\n-----END-----'],
+    key_length: 2048,
+    key_type: 'RSA',
+    country: 'US',
+    state: 'Tennessee',
+    city: 'Maryville',
+    organization: 'iXsystems',
+    organizational_unit: '',
+    common: 'truenas.local',
+    san: ['DNS:truenas.local', 'DNS:nas.local'],
+    email: 'info@example.invalid',
+    DN: '/C=US/ST=Tennessee/CN=truenas.local',
+    subject_name_hash: 123456,
+    extensions: {},
+    digest_algorithm: 'SHA256',
+    lifetime: 397,
+    from: 'Tue Nov 14 12:00:00 2023',
+    until: 'Mon Nov 20 12:00:00 2023',
+    serial: 1,
+    chain: false,
+    fingerprint: 'AA:BB:CC',
+    expired: false,
+    parsed: true,
+    issuer: 'Lets Encrypt',
+    ...over,
+  });
+
+  const listed = async (
+    rows: unknown[],
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['certificate.query']: rows });
+    return (await certificatesList.handler(ctx, args)) as Record<string, unknown>[];
+  };
+
+  /** One certificate, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([cert(over)]))[0];
+
+  /** The day count of one certificate expiring at `until`. */
+  const days = async (until: unknown): Promise<unknown> =>
+    (await one({ until }))['days_until_expiry'];
+
+  it('maps a certificate to its names, issuer, validity dates and days left', async () => {
+    expect(await listed([cert()])).toEqual([
+      {
+        name: 'truenas_default',
+        common_name: 'truenas.local',
+        subject_alternative_names: ['DNS:truenas.local', 'DNS:nas.local'],
+        issuer: 'Lets Encrypt',
+        not_before: 'Tue Nov 14 12:00:00 2023',
+        not_after: 'Mon Nov 20 12:00:00 2023',
+        days_until_expiry: 5,
+        expired: false,
+      },
+    ]);
+  });
+
+  it('returns no certificate or private key material, and no field a later release adds', async () => {
+    const rows = await listed([
+      cert({ renewable: true, signed_certificates: 3, extensions_thing: 'new' }),
+    ]);
+    expect(Object.keys(rows[0])).toEqual([
+      'name',
+      'common_name',
+      'subject_alternative_names',
+      'issuer',
+      'not_before',
+      'not_after',
+      'days_until_expiry',
+      'expired',
+    ]);
+    expect(JSON.stringify(rows)).not.toContain('SECRET');
+  });
+
+  it('reports a certificate with no alternative name as having none', async () => {
+    expect(await one({ san: [] })).toMatchObject({ subject_alternative_names: [] });
+  });
+
+  it('reports alternative names the system did not send as a list as unread', async () => {
+    // Null rather than the empty list of a certificate that was read and
+    // carries no alternative name.
+    expect(await one({ san: null })).toMatchObject({ subject_alternative_names: null });
+  });
+
+  it('drops an alternative name the system named with nothing', async () => {
+    expect(await one({ san: ['DNS:nas.local', '', 7] })).toMatchObject({
+      subject_alternative_names: ['DNS:nas.local'],
+    });
+  });
+
+  it('reports an issuer the system named as an object by that object name', async () => {
+    expect(await one({ issuer: { id: 4, name: 'internal-ca' } })).toMatchObject({
+      issuer: 'internal-ca',
+    });
+  });
+
+  it('reports an issuer object that names nothing as no issuer', async () => {
+    expect(await one({ issuer: { id: 4 } })).toMatchObject({ issuer: null });
+  });
+
+  it('reports an issuer the system sent in a shape this tool cannot read as none', async () => {
+    // A list is an object too, and reading one as a record would answer null
+    // for its `name` anyway — this states that it is the null of "no issuer
+    // reported" rather than an accident.
+    expect(await one({ issuer: ['internal-ca'] })).toMatchObject({ issuer: null });
+  });
+
+  it('reports a release that sends no issuer at all as reporting none', async () => {
+    const without: Record<string, unknown> = { ...cert() };
+    delete without['issuer'];
+    expect((await listed([without]))[0]).toMatchObject({ issuer: null });
+  });
+
+  it('reports a name, common name or validity date the system left empty as null', async () => {
+    expect(await one({ name: '', common: '', from: '', until: '' })).toMatchObject({
+      name: null,
+      common_name: null,
+      not_before: null,
+      not_after: null,
+      days_until_expiry: null,
+    });
+  });
+
+  it('passes the validity dates through as the system formatted them', async () => {
+    expect(await one({ from: '2023-11-14T12:00:00Z', until: '2023-11-20T12:00:00Z' })).toMatchObject(
+      { not_before: '2023-11-14T12:00:00Z', not_after: '2023-11-20T12:00:00Z' },
+    );
+  });
+
+  it('counts the days left from an expiry carrying an explicit zone', async () => {
+    expect(await days('2023-11-15T22:13:20+00:00')).toBe(1);
+  });
+
+  it('reads an expiry carrying no zone as UTC rather than as local time', async () => {
+    // Exactly thirty days after NOW when read as UTC. Read as local time it
+    // would move by this machine's offset, which is what the test pins.
+    expect(await days('2023-12-14 22:13:20')).toBe(30);
+  });
+
+  it('reads a date with no time at all as midnight UTC', async () => {
+    // Under two hours away, which is nought whole days rather than one.
+    expect(await days('2023-11-15')).toBe(0);
+  });
+
+  it('reads the padded single-digit day of the middleware date format', async () => {
+    expect(await days('Sun Nov  5 12:00:00 2023')).toBe(-10);
+  });
+
+  it('reports an expiry in a form it cannot read as unknown', async () => {
+    expect(await days('whenever')).toBeNull();
+  });
+
+  it('reports an expiry whose month is not a month as unknown', async () => {
+    expect(await days('Mon Foo 20 12:00:00 2023')).toBeNull();
+  });
+
+  it('reports an unreadable expiry that ends in a zone as unknown', async () => {
+    // The zone is what sends this one to Date.parse, which answers NaN.
+    expect(await days('whenever+01:00')).toBeNull();
+  });
+
+  it('reports a certificate with no expiry date as unknown rather than as unexpiring', async () => {
+    expect(await days(null)).toBeNull();
+  });
+
+  it('reports an expired certificate with a negative day count', async () => {
+    expect(await one({ until: 'Fri Nov 10 12:00:00 2023', expired: true })).toMatchObject({
+      days_until_expiry: -5,
+      expired: true,
+    });
+  });
+
+  it("reports the system's own expiry verdict where it gave none as null", async () => {
+    expect(await one({ expired: null })).toMatchObject({ expired: null });
+  });
+
+  it('returns every certificate when no window is asked for', async () => {
+    const rows = await listed([
+      cert({ name: 'soon' }),
+      cert({ name: 'later', until: '2024-11-20 12:00:00' }),
+      cert({ name: 'unknown', until: null }),
+    ]);
+    expect(rows.map((row) => row['name'])).toEqual(['soon', 'later', 'unknown']);
+  });
+
+  it('restricts the result to certificates inside the window, expired ones included', async () => {
+    const rows = await listed(
+      [
+        cert({ name: 'expired', until: 'Fri Nov 10 12:00:00 2023' }),
+        cert({ name: 'five-days' }),
+        cert({ name: 'on-the-boundary', until: '2023-12-14 22:13:20' }),
+        cert({ name: 'past-the-boundary', until: '2023-12-15 22:13:20' }),
+      ],
+      { expiring_within_days: 30 },
+    );
+    expect(rows.map((row) => row['name'])).toEqual(['expired', 'five-days', 'on-the-boundary']);
+  });
+
+  it('leaves a certificate whose expiry could not be read out of a window', async () => {
+    const rows = await listed([cert({ name: 'unknown', until: null })], {
+      expiring_within_days: 30,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('treats an absent window as no window rather than as zero days', async () => {
+    expect(await listed([cert()], { expiring_within_days: null })).toHaveLength(1);
+  });
+
+  it('refuses a window it cannot read rather than answering about every certificate', async () => {
+    const { ctx, query } = fakeSystem({ ['certificate.query']: [cert()] });
+    await expect(certificatesList.handler(ctx, { expiring_within_days: '30' })).rejects.toThrow(
+      'must be a number of days',
+    );
+    // Refused before the call is spent, not after.
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('refuses a window that is a number naming no quantity', async () => {
+    await expect(listed([cert()], { expiring_within_days: Number.NaN })).rejects.toThrow(
+      'must be a number of days',
+    );
+  });
+
+  it('asks for the certificates', async () => {
+    const { ctx, query } = fakeSystem({ ['certificate.query']: [] });
+    await certificatesList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('certificate.query');
   });
 });


### PR DESCRIPTION
Adds `certificates_list`, a read-only tool reporting every certificate the system holds with the dates it is valid between and how many whole days each one has left, plus an optional `expiring_within_days` window over that day count.

Fixes #32

## What it returns

`name`, `common_name`, `subject_alternative_names`, `issuer`, `not_before`, `not_after`, `days_until_expiry`, `expired`. Nothing else — the mapping is an allowlist, as in `pools.ts` and `network.ts`, so neither the PEM certificate, the private key, the chain, the ACME configuration nor a field a later TrueNAS release adds can reach a caller without a change to this file. A test asserts the exact key list and that no key material survives the mapping.

## The ticket's unconfirmed note, corrected

> **(unconfirmed)** `certificate.query` is not in the pinned client's `TrueNasEndpoint` enum.

**It is there.** `certificate.query` is declared in `ApiCallDirectory$7` — the call directory behind `DefaultApiDirectory`, which is the surface `ApiSurface` in `catalog/tool.ts` resolves to — and it carries a typed `entity`, `CertificateEntry`. So unlike `interface.query` and `network.configuration.config`, which the client types as bare records and `network.ts` therefore reads field by field, the fields here are read as declarations. `yarn typecheck` is what confirms it.

**What the client does *not* declare is `issuer`.** No certificate entity on any of its eight versioned directories carries one, and the string `issuer` appears nowhere in `dist/index.d.ts`. The middleware has historically added an issuer when it *reads* a certificate, which is exactly the kind of field a type generated from the stored model does not carry — `hostname_local` in `network.ts` is the same shape of fact — so it is read off the row with the same reasoning: a release that sends one is reported, and a release that does not costs a null rather than a wrong value. `null` there therefore means **"this system reported no issuer"** and never "self-signed", and the tool's description says so, because the two are not distinguishable from here.

## Dates are parsed here rather than by `Date.parse`

`from` and `until` arrive as formatted text, and the spelling is **(unconfirmed)** against a live middleware — which is why both are also returned verbatim beside the day count computed from them rather than replaced by it.

A zone-less timestamp is read as **UTC**. An x509 validity date is UTC — the certificate encodes it that way and the middleware formats it without saying so — while ECMAScript defines a zone-less date-and-time string as *local* time, so one call to `Date.parse` would move every expiry by the offset of whatever machine this happens to run on. Up to fourteen hours, silently, which is enough to move a day count across a boundary. `tasks.ts` refuses to read such a string at all for the same reason; here it cannot refuse, because the string is the system's own answer rather than a caller's argument.

Three forms are read: a timestamp ending in an explicit zone (handed to `Date.parse`, which is well defined on those), zone-less ISO 8601 including the date-only form, and the C `asctime` form the middleware's own formatting produces. Anything else yields `null`, which the description states is **"expiry unknown"** and never "does not expire".

Unlike `tasks.ts`, nothing checks that the components name a date that exists. That value came from a caller; this one comes from a certificate the system parsed, and guarding against a middleware sending `2026-02-30` is error handling for a state the system itself would have to be broken to reach.

## The window argument is strict

A `expiring_within_days` that is not a finite number throws rather than being ignored, and it throws *before* the query is issued. `datasets_quota_report` ignores an unreadable `threshold_percent`; `tasks_recent_runs` throws on an unreadable `since`, and its reasoning is the one that applies here: a bound that is quietly ignored returns **every** certificate on the system under a call that asked for the ones expiring soon, and a model reading that answer will report all of them as expiring within the window. Answering more than was asked for is the dangerous direction.

A certificate whose expiry could not be read is **not** returned when the argument is given — no threshold can be applied to it — and the description says so and says which call finds them.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass locally, on this machine, against this diff. `src/tools/certificates.ts` reports 100% statements, branches, functions and lines; the global floors (branches 96 / statements 97) are unchanged and still met at 99.28 / 99.33.

The local review ran the project's own shared reviewer in a separate process — the same rubric, threshold and parser as the required check — and **returned nothing at MEDIUM or above** in one round.

## What I did not change, and why

The clean round returned three LOWs. Two are left for a later ticket rather than fixed here, because every fix is a new diff and a new diff opens another review round:

- **`expired` is passed through unread while every neighbouring field is guarded.** The client types it `boolean | null`, so a release that sends the key answers correctly; a release that omitted it entirely would yield `undefined`, which drops out of the JSON rather than appearing as the `null` the description promises. Real, and narrow.
- **`certificate.query` also returns signing requests, and `cert_type` is declared but not surfaced.** A caller cannot tell a CSR from a leaf certificate; one that has not been signed shows as a row with null validity dates and an unknown day count. Adding the field is a scope question rather than a bug fix — the ticket names the fields to report, and this is not one of them.

The third LOW *did* make this diff's own prose false, so it is fixed in the second commit: the description asserted that an already-expired certificate is always returned when a window is given, and it is not — an expired certificate's day count is negative, so a *negative* threshold ("what expired at least thirty days ago") excludes one that expired five days ago. The sentence's own reasoning was right and the absolute claim over it was not. Two description strings changed; the filter is untouched.

## Not in scope

Importing, creating, renewing or deleting a certificate or CSR — mutating, and not filed. The tool also does not say which service uses which certificate.
