### PR TITLE
feat(tools): add cloud_credentials_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
   `nvmeof_list`, `users_list`, `directory_services_status`,
-  `network_interfaces`, `network_config`, `certificates_list`.
+  `network_interfaces`, `network_config`, `certificates_list`,
+  `cloud_credentials_list`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,5 +83,6 @@ export {
   networkInterfaces,
   networkConfig,
   certificatesList,
+  cloudCredentialsList,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -100,13 +100,13 @@ export const cloudCredentialsList: ReadOnlyTool = {
     'looking at directly. THIS TOOL RETURNS NO SECRET MATERIAL AND NO ' +
     'CREDENTIAL CONFIGURATION OF ANY KIND. The stored record holds the access ' +
     'key, secret key, account key, OAuth token, password or private key the ' +
-    'credential authenticates with, and also its endpoint, region, bucket, ' +
-    'host and account name; NONE of that appears here, and no field a later ' +
+    'credential authenticates with, and also its endpoint, region, host and ' +
+    'account name; NONE of that appears here, and no field a later ' +
     'TrueNAS release adds to a credential — including a whole new provider ' +
     'with secrets spelled some new way — can appear without a code change, ' +
     'because the three fields above are named explicitly rather than copied ' +
     'with the known secrets removed. It follows that this tool cannot answer ' +
-    'which account, bucket or host a credential points at: the NAME is the ' +
+    'which account or host a credential authenticates to: the NAME is the ' +
     'only account of that, and a name is whatever a person typed. This tool ' +
     'also does not say whether a credential still works — nothing here ' +
     'contacts the provider — and does not create, update, delete or verify ' +

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -1,0 +1,133 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Cloud credentials family: which stored cloud credentials this system holds,
+ * by name and provider only.
+ *
+ * `cloudsync_tasks_list` in `tasks.ts` names the credential a task
+ * authenticates with by id and name and stops there; this file is the other
+ * half of that answer — the list a `credential_id` can be looked up in, so that
+ * "the backup is configured" can become "the backup is configured to an account
+ * you still recognise".
+ *
+ * THE ROW THIS READS IS ALMOST ENTIRELY SECRET MATERIAL. A cloud credential's
+ * `provider` holds, depending on the provider, an access key and secret access
+ * key, an account key, an OAuth token, an SSH password or private key, or a
+ * WebDAV password — and the client's own type names nineteen provider shapes,
+ * with more arriving in any release. So the mapping below is an ALLOWLIST, as
+ * in `certificates.ts` and `pools.ts`, and it is one for a sharper reason than
+ * either: a copy with the known secret fields removed would leak the next
+ * provider's secret the day TrueNAS adds one. Three fields are named, and
+ * nothing that is not named can reach a caller without a change to this file.
+ *
+ * `cloudsync.credentials.query` IS in the pinned client's call directory for
+ * the version this is written against — the ticket's design note recorded it as
+ * absent from an endpoint enum and unconfirmed; it is present, and the entity
+ * it returns is typed. What is read defensively here is not the field names but
+ * the CONTENT of two of them: `provider` has been a bare provider name in
+ * releases before the one the pinned types describe, and is an object carrying
+ * the configuration in this one.
+ */
+
+/**
+ * One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters, the
+ * same reading `certificates.ts`, `network.ts`, `accounts.ts`, `shares.ts`,
+ * `tasks.ts` and `block.ts` each hold under their own names — and restated here
+ * for the reason those files give for restating it: a tool file is read on its
+ * own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * The credential's numeric id, or null where the system reported none this
+ * tool could read.
+ *
+ * Read defensively although the client's type declares a plain `number`,
+ * because this is the field `cloudsync_tasks_list` joins on and that tool reads
+ * the same id off a task's `credentials` the same way. Two readings of one
+ * identity that disagree about what an unreadable id looks like would make a
+ * lookup that silently fails look like a credential that is simply missing.
+ */
+function credentialId(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * The provider type as the system names it — `S3`, `AZUREBLOB`, `SFTP` — or
+ * null where it named none this tool could read.
+ *
+ * Read off the row rather than taken from the type, because its SHAPE has
+ * changed across releases while its name has not: releases before the one the
+ * pinned client describes send `provider` as a bare provider name beside a
+ * separate `attributes` object, and the version here sends an object whose
+ * `type` is that same name. Both are read, and neither reading carries anything
+ * out of the object beyond that one string.
+ *
+ * NULL IS "THIS SYSTEM NAMED NO PROVIDER TYPE THIS TOOL COULD READ" AND NEVER
+ * "A CREDENTIAL WITH NO PROVIDER". Every stored credential has one — it is what
+ * decides how the credential is used — so a null here is a credential worth
+ * looking at directly rather than one that is somehow provider-less.
+ */
+function providerType(row: object): string | null {
+  const provider = (row as Record<string, unknown>)['provider'];
+  const named = textOrNull(provider);
+  if (named !== null) return named;
+  if (typeof provider !== 'object' || provider === null || Array.isArray(provider)) return null;
+  return textOrNull((provider as Record<string, unknown>)['type']);
+}
+
+export const cloudCredentialsList: ReadOnlyTool = {
+  name: 'cloud_credentials_list',
+  description:
+    'Every cloud credential stored on this system, by name and provider only. ' +
+    '`id` is the credential\'s numeric identity and is what `credential_id` ' +
+    'on a task from `cloudsync_tasks_list` refers to, so the two together ' +
+    'answer which account a backup is actually going to. It is null where the ' +
+    'system reported no id this tool could read, and such a credential cannot ' +
+    'be matched to a task from here. `name` is the credential as the system ' +
+    'names it, which is what the web UI shows and what `credential_name` on a ' +
+    'task repeats; it is null where the system reported none. `provider` is ' +
+    'the provider type as the system spells it — `S3`, `AZUREBLOB`, `SFTP`, ' +
+    '`GOOGLE_DRIVE` and so on — and is null where the system named no provider ' +
+    'type this tool could read. A NULL PROVIDER IS NOT A CREDENTIAL WITHOUT ' +
+    'ONE: every stored credential has a provider, so a null there is one worth ' +
+    'looking at directly. THIS TOOL RETURNS NO SECRET MATERIAL AND NO ' +
+    'CREDENTIAL CONFIGURATION OF ANY KIND. The stored record holds the access ' +
+    'key, secret key, account key, OAuth token, password or private key the ' +
+    'credential authenticates with, and also its endpoint, region, bucket, ' +
+    'host and account name; NONE of that appears here, and no field a later ' +
+    'TrueNAS release adds to a credential — including a whole new provider ' +
+    'with secrets spelled some new way — can appear without a code change, ' +
+    'because the three fields above are named explicitly rather than copied ' +
+    'with the known secrets removed. It follows that this tool cannot answer ' +
+    'which account, bucket or host a credential points at: the NAME is the ' +
+    'only account of that, and a name is whatever a person typed. This tool ' +
+    'also does not say whether a credential still works — nothing here ' +
+    'contacts the provider — and does not create, update, delete or verify ' +
+    'one. A credential listed here is not evidence that anything uses it; ' +
+    '`cloudsync_tasks_list` is what says which tasks reference which ' +
+    'credential.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: a system holds a handful of cloud credentials
+    // at most, and all three fields reported are part of a credential row as it
+    // stands — there is nothing to bound and no option that changes how it
+    // arrives.
+    const credentials = await firstValueFrom(
+      system.client.api.query('cloudsync.credentials.query'),
+    );
+    return credentials.map((credential) => ({
+      id: credentialId(credential.id),
+      name: textOrNull(credential.name),
+      provider: providerType(credential),
+    }));
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
 import { certificatesList } from '@/tools/certificates';
+import { cloudCredentialsList } from '@/tools/credentials';
 import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
@@ -14,7 +15,7 @@ import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 
-/** The sketch's catalog: twenty-three read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-four read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -40,6 +41,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(networkInterfaces);
   catalog.register(networkConfig);
   catalog.register(certificatesList);
+  catalog.register(cloudCredentialsList);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -48,6 +50,7 @@ export {
   alertsList,
   appsList,
   certificatesList,
+  cloudCredentialsList,
   cloudsyncTasksList,
   createSnapshot,
   directoryServicesStatus,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -6,6 +6,7 @@ import {
   alertsList,
   appsList,
   certificatesList,
+  cloudCredentialsList,
   cloudsyncTasksList,
   createDefaultCatalog,
   createSnapshot,
@@ -71,7 +72,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-four sketch tools', () => {
+  it('registers the twenty-five sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -96,8 +97,15 @@ describe('createDefaultCatalog', () => {
       'network_interfaces',
       'network_config',
       'certificates_list',
+      'cloud_credentials_list',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises cloud_credentials_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'cloud_credentials_list',
+    );
   });
 
   it('advertises certificates_list to a read-only credential', () => {
@@ -6505,5 +6513,143 @@ describe('certificates_list', () => {
     const { ctx, query } = fakeSystem({ ['certificate.query']: [] });
     await certificatesList.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('certificate.query');
+  });
+});
+
+describe('cloud_credentials_list', () => {
+  /**
+   * A cloud credential as `cloudsync.credentials.query` reports one on the
+   * version the client's types describe: `provider` an object whose `type`
+   * names the provider and whose other fields are the secret.
+   *
+   * The secret fields carry real-looking material for the reason the
+   * certificate fixture carries a private key — the test that no secret
+   * survives the mapping is only worth anything if some was there to survive.
+   */
+  const credential = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    name: 'offsite-backups',
+    provider: {
+      type: 'S3',
+      access_key_id: 'SECRET-ACCESS-KEY-ID',
+      secret_access_key: 'SECRET-SECRET-ACCESS-KEY',
+      endpoint: 's3.example.invalid',
+      region: 'us-east-1',
+    },
+    ...over,
+  });
+
+  const listed = async (rows: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['cloudsync.credentials.query']: rows });
+    return (await cloudCredentialsList.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  /** One credential, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([credential(over)]))[0];
+
+  it('maps a credential to its id, name and provider type', async () => {
+    expect(await listed([credential()])).toEqual([
+      { id: 3, name: 'offsite-backups', provider: 'S3' },
+    ]);
+  });
+
+  it('returns no key, token or other secret material, whatever the provider is', async () => {
+    const rows = await listed([
+      credential({
+        provider: {
+          type: 'SFTP',
+          host: 'sftp.example.invalid',
+          user: 'backup',
+          pass: 'SECRET-PASSWORD',
+          private_key: 'SECRET-PRIVATE-KEY',
+        },
+      }),
+      credential({
+        id: 4,
+        provider: { type: 'AZUREBLOB', account: 'acct', key: 'SECRET-ACCOUNT-KEY' },
+      }),
+    ]);
+    expect(JSON.stringify(rows)).not.toContain('SECRET');
+    expect(rows.map((row) => row['provider'])).toEqual(['SFTP', 'AZUREBLOB']);
+  });
+
+  it('carries no field the tool does not name, including one a later release adds', async () => {
+    const rows = await listed([
+      credential({
+        attributes: { token: 'SECRET-OAUTH-TOKEN' },
+        // A provider TrueNAS has not shipped yet, spelling its secret a way
+        // this file has never seen. An allowlist keeps it out; a copy with the
+        // known secrets removed would not.
+        provider: { type: 'FUTURE_PROVIDER', unheard_of_secret: 'SECRET-NEW-SHAPE' },
+        renewable: true,
+      }),
+    ]);
+    expect(Object.keys(rows[0])).toEqual(['id', 'name', 'provider']);
+    expect(JSON.stringify(rows)).not.toContain('SECRET');
+  });
+
+  it('reads a provider the system named as a bare string, as older releases send it', async () => {
+    expect(
+      await one({ provider: 'GOOGLE_DRIVE', attributes: { token: 'SECRET-OAUTH-TOKEN' } }),
+    ).toEqual({ id: 3, name: 'offsite-backups', provider: 'GOOGLE_DRIVE' });
+  });
+
+  it('reports a provider it could not read as null rather than as no provider', async () => {
+    expect(await one({ provider: null })).toMatchObject({ provider: null });
+    expect(await one({ provider: 42 })).toMatchObject({ provider: null });
+    expect(await one({ provider: ['S3'] })).toMatchObject({ provider: null });
+    expect(await one({ provider: {} })).toMatchObject({ provider: null });
+    expect(await one({ provider: { type: '' } })).toMatchObject({ provider: null });
+    expect(await one({ provider: { type: 7 } })).toMatchObject({ provider: null });
+  });
+
+  it('reports a name the system gave no value for as null', async () => {
+    expect(await one({ name: '' })).toMatchObject({ name: null });
+    expect(await one({ name: null })).toMatchObject({ name: null });
+  });
+
+  it('reports an id it could not read as null, so no task can be joined to it', async () => {
+    expect(await one({ id: null })).toMatchObject({ id: null });
+    expect(await one({ id: '3' })).toMatchObject({ id: null });
+    expect(await one({ id: Number.NaN })).toMatchObject({ id: null });
+  });
+
+  it('reads the same id cloudsync_tasks_list joins on', async () => {
+    // The point of the tool: a task names its credential by id, and this is
+    // what that id is looked up in. A test that only asserted the shape of each
+    // result separately would not notice the two reading that id differently.
+    const { ctx } = fakeSystem({
+      ['cloudsync.query']: [
+        {
+          id: 1,
+          description: 'Nightly offsite',
+          direction: 'PUSH',
+          path: '/mnt/tank/media',
+          attributes: {},
+          credentials: { id: 3, name: 'offsite-backups' },
+          schedule: null,
+          job: null,
+        },
+      ],
+      ['cloudsync.credentials.query']: [credential({ id: 3 })],
+    });
+    const tasks = (await cloudsyncTasksList.handler(ctx, {})) as Record<string, unknown>[];
+    const credentials = (await cloudCredentialsList.handler(ctx, {})) as Record<
+      string,
+      unknown
+    >[];
+    expect(tasks[0]['credential_id']).toBe(3);
+    expect(credentials.map((row) => row['id'])).toContain(tasks[0]['credential_id']);
+  });
+
+  it('returns nothing for a system holding no cloud credentials', async () => {
+    expect(await listed([])).toEqual([]);
+  });
+
+  it('asks for the cloud credentials', async () => {
+    const { ctx, query } = fakeSystem({ ['cloudsync.credentials.query']: [] });
+    await cloudCredentialsList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('cloudsync.credentials.query');
   });
 });


### PR DESCRIPTION
Adds `cloud_credentials_list`, a read-only tool returning which cloud credentials this system holds — by id, name and provider type only.

`cloudsync_tasks_list` names the credential a task authenticates with by id and name and stops there. This is the list that `credential_id` is looked up in, so the two together answer which account a backup is actually going to, rather than only that a task is configured.

Fixes #33.

## What it returns

Three fields per credential, and nothing else:

- `id` — the credential's numeric identity, and what `credential_id` on a task from `cloudsync_tasks_list` refers to. Null where the system reported no id this tool could read; such a credential cannot be joined to a task.
- `name` — the credential as the system names it. Null where the system reported none.
- `provider` — the provider type as the system spells it (`S3`, `AZUREBLOB`, `SFTP`). Null where the system named no readable provider type, which the description states is **not** "a credential without a provider" — every stored credential has one.

## Why the mapping is an allowlist rather than a redaction

The row this reads is almost entirely secret material: a credential's `provider` carries an access key and secret access key, an account key, an OAuth token, an SSH password or private key, or a WebDAV password, depending on which of the client's nineteen provider models it is.

So the three fields are named explicitly rather than the row being copied with the known secret fields removed. A removal list leaks the next provider's secret the day TrueNAS ships one — and there is a test for exactly that case, with a `FUTURE_PROVIDER` spelling its secret a way this file has never seen.

The secret test asserts **by value**, not by field name: the fixtures carry real-looking material and the assertion is that `SECRET` appears nowhere in the serialised result.

## The design note's unconfirmed claim, corrected

The ticket recorded, marked unconfirmed, that `cloudsync.credentials.query` is not in the pinned client's endpoint enum. **It is present.** `ApiCallDirectory$7` — the call directory behind `DefaultApiDirectory`, which `ApiSurface` in `src/catalog/tool.ts` resolves to — declares `cloudsync.credentials.query` with `entity: CredentialsEntry$1`, so the entity is typed rather than read off a bare record. The narrower list the ticket's note likely refers to is `ApiCallDirectoryBase` (the version-stable `Pick<>`), which carries `cloudsync.credentials.delete` but not `.query`; it is not what a version-parameterised client resolves against, and `certificate.query` is absent from it too while `certificates_list` calls it fine.

What is read defensively here is therefore not the field names but the content of two of them:

- **`provider`** — its *shape* has changed across releases while its name has not. Releases before the one the pinned types describe send a bare provider name beside a separate `attributes` object; this one sends an object whose `type` is that same name. Both are read, and neither reading carries anything else out of the object. Same shape as `issuerName` in `certificates.ts`.
- **`id`** — read defensively although the client types it as a plain `number`, so that this tool and the `credential_id` `cloudsync_tasks_list` reports agree about what an unreadable id looks like. Two readings of one identity that disagreed would make a lookup that silently fails look like a credential that is simply missing. A test drives both tools off one fixture and asserts the join holds.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run locally and pass. Coverage: `src/tools/credentials.ts` at 100% statements, branches, functions and lines; the global floors (branches 96 / statements 97) are met at 99.29 / 99.34. No CI step was skipped.

`./scripts/local-review.py 33` ran the **project's own reviewer** (exit 0 — the same rubric, threshold and parser as the required check, in a separate process), and the round returned **nothing at MEDIUM or above**.

## What was reviewed and not changed

The clean round named two LOWs.

1. **The description claimed the credential record holds a `bucket`.** It does not — `bucket` is a field of a cloud sync task's `attributes`, not of any of the nineteen provider models. That one is a false statement about the record being described, so it was fixed (second commit, prose only; nothing the tool returns changed) and the word was dropped from both places it appeared.
2. **`credentials.ts` is scoped entirely to cloud sync credentials**, while `keychaincredential` entries and the unrelated `CredentialProvider` interface in `src/interfaces.ts` make the bare filename ambiguous. Not changed here: renaming the file is an executable change touching imports in `src/tools/index.ts` and `src/index.ts`, it is a naming judgement rather than a defect, and the ticket names `src/tools/credentials.ts` explicitly. Worth taking as its own ticket if a second credential family (SSH keychain credentials) is ever added, which is when the ambiguity would start costing something.

## Out of scope, per the ticket

No tool to add, update or delete a credential — mutating, and it would take a secret as an argument, which the catalog forbids outright. No connection test, which reaches a third party. Nothing here contacts a provider, so this tool cannot say whether a credential still works.
