### PR TITLE
feat(tools): add vms_list, virtual machines with state and resource allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `storage_pool_status`, `storage_pool_topology`,
   `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
-  `disks_list`, `apps_list`, `alerts_list`, `snapshots_list`,
+  `disks_list`, `apps_list`, `vms_list`, `alerts_list`, `snapshots_list`,
   `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
   `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
   `nvmeof_list`, `users_list`, `directory_services_status`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export {
   quotaReport,
   disksList,
   appsList,
+  vmsList,
   alertsList,
   alertSettings,
   snapshotsList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,8 +14,9 @@ import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { systemInfo } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
+import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: twenty-five read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-six read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -26,6 +27,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(quotaReport);
   catalog.register(disksList);
   catalog.register(appsList);
+  catalog.register(vmsList);
   catalog.register(alertsList);
   catalog.register(snapshotsList);
   catalog.register(replicationStatus);
@@ -74,4 +76,5 @@ export {
   systemInfo,
   tasksRecentRuns,
   usersList,
+  vmsList,
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -29,6 +29,7 @@ import {
   snapshotTasksList,
   tasksRecentRuns,
   usersList,
+  vmsList,
 } from '@/tools/index';
 
 /**
@@ -73,7 +74,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-six sketch tools', () => {
+  it('registers the twenty-seven sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'storage_pool_status',
@@ -83,6 +84,7 @@ describe('createDefaultCatalog', () => {
       'datasets_quota_report',
       'disks_list',
       'apps_list',
+      'vms_list',
       'alerts_list',
       'snapshots_list',
       'replication_status',
@@ -128,6 +130,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises disks_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('disks_list');
+  });
+
+  it('advertises vms_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('vms_list');
   });
 
   it('advertises apps_list to a read-only credential', () => {
@@ -6914,5 +6920,257 @@ describe('alert_settings', () => {
     await alertSettings.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('alertservice.query');
     expect(call).toHaveBeenCalledWith('alertclasses.config');
+  });
+});
+
+describe('vms_list', () => {
+  /**
+   * A libvirt-backed VM as `vm.query` reports one: memory in MiB, the vCPU
+   * allocation split across three fields, and the state nested in `status`
+   * beside libvirt's own.
+   *
+   * The devices are on the fixture because they are the bulk of a real row and
+   * the allowlist is what keeps them out.
+   */
+  const vm = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'buildbox',
+    vcpus: 1,
+    cores: 2,
+    threads: 2,
+    memory: 4096,
+    min_memory: null,
+    autostart: true,
+    status: { state: 'RUNNING', pid: 1234, domain_state: 'RUNNING' },
+    devices: [{ dtype: 'DISK', attributes: { path: '/dev/zvol/tank/buildbox' } }],
+    ...over,
+  });
+
+  /**
+   * An incus-backed VM as `virt.instance.query` reports one: memory already in
+   * bytes, the CPU allocation a single string, and one flat status word.
+   *
+   * `environment` carries real-looking material for the reason the alert
+   * destination fixture does — the test that it does not survive the mapping is
+   * only worth anything if some was there to survive.
+   */
+  const instance = (over: Record<string, unknown> = {}) => ({
+    id: 'web',
+    name: 'web',
+    type: 'VM',
+    status: 'STOPPED',
+    cpu: '4',
+    memory: 8589934592,
+    autostart: false,
+    environment: { API_TOKEN: 'SECRET-GUEST-TOKEN' },
+    raw: { config: { 'limits.memory': '8GiB' } },
+    aliases: [],
+    image: { os: 'Debian' },
+    ...over,
+  });
+
+  const read = async (
+    vms: unknown[] = [vm()],
+    instances: unknown[] = [instance()],
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['vm.query']: vms, ['virt.instance.query']: instances });
+    return (await vmsList.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  const rows = async (vms?: unknown[], instances?: unknown[]): Promise<Record<string, unknown>[]> =>
+    (await read(vms, instances))['vms'] as Record<string, unknown>[];
+
+  /** One libvirt VM, differing only in the fields the case is about. */
+  const oneVm = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await rows([vm(over)], []))[0];
+
+  /** One incus VM, the same way. */
+  const oneInstance = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await rows([], [instance(over)]))[0];
+
+  /** The same two reads, with one of them rejecting instead. */
+  const readFailing = async (
+    failures: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = failingSystem(
+      { ['vm.query']: [vm()], ['virt.instance.query']: [instance()] },
+      failures,
+    );
+    return (await vmsList.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('reports a VM from each stack, tagged with the stack it came from', async () => {
+    expect(await read()).toEqual({
+      vms: [
+        {
+          source: 'vm',
+          id: 1,
+          name: 'buildbox',
+          state: 'RUNNING',
+          domain_state: 'RUNNING',
+          vcpus: 4,
+          cpu_set: null,
+          memory_bytes: 4294967296,
+          min_memory_bytes: null,
+          autostart: true,
+        },
+        {
+          source: 'virt_instance',
+          id: 'web',
+          name: 'web',
+          state: 'STOPPED',
+          domain_state: null,
+          vcpus: 4,
+          cpu_set: null,
+          memory_bytes: 8589934592,
+          min_memory_bytes: null,
+          autostart: false,
+        },
+      ],
+      failures: [],
+    });
+  });
+
+  it('reports memory in bytes from both stacks, converting the MiB the vm stack stores', async () => {
+    // 4096 MiB and 8 GiB, which is the whole point of converting: without it
+    // the smaller VM reports the larger number.
+    expect(await oneVm({ memory: 4096 })).toMatchObject({ memory_bytes: 4294967296 });
+    expect(await oneInstance({ memory: 8589934592 })).toMatchObject({
+      memory_bytes: 8589934592,
+    });
+    // Unreadable stays unreadable rather than being converted into a zero the
+    // caller would read as a VM with no memory.
+    expect(await oneVm({ memory: null })).toMatchObject({ memory_bytes: null });
+    expect(await oneInstance({ memory: null })).toMatchObject({ memory_bytes: null });
+  });
+
+  it('reports a memory floor where the vm stack has one, in the same unit', async () => {
+    expect(await oneVm({ min_memory: 1024 })).toMatchObject({ min_memory_bytes: 1073741824 });
+  });
+
+  it('counts vCPUs as sockets times cores times threads', async () => {
+    // The guest sees four CPUs; `vcpus` alone says one.
+    expect(await oneVm({ vcpus: 1, cores: 2, threads: 2 })).toMatchObject({ vcpus: 4 });
+  });
+
+  it('states no vCPU count where the vm stack did not report all three', async () => {
+    // Not defaulted to 1: a guessed component is indistinguishable in the
+    // result from one the system reported.
+    expect(await oneVm({ threads: undefined })).toMatchObject({ vcpus: null });
+    expect(await oneVm({ cores: 'two' })).toMatchObject({ vcpus: null });
+  });
+
+  it('reports a pinned CPU set verbatim and states no count for it', async () => {
+    // How many CPUs `0-3` comes to is an inference about the host, not
+    // something the system said.
+    expect(await oneInstance({ cpu: '0-3' })).toMatchObject({ vcpus: null, cpu_set: '0-3' });
+    expect(await oneInstance({ cpu: '1,3' })).toMatchObject({ vcpus: null, cpu_set: '1,3' });
+    expect(await oneInstance({ cpu: '4' })).toMatchObject({ vcpus: 4, cpu_set: null });
+    expect(await oneInstance({ cpu: null })).toMatchObject({ vcpus: null, cpu_set: null });
+  });
+
+  it('distinguishes a stopped VM from one in an error state', async () => {
+    // On the incus stack the state word does it on its own.
+    expect(await oneInstance({ status: 'ERROR' })).toMatchObject({ state: 'ERROR' });
+    expect(await oneInstance({ status: 'STOPPED' })).toMatchObject({ state: 'STOPPED' });
+    // On the libvirt stack both VMs read STOPPED and only the domain state
+    // separates them, which is why it is reported beside rather than merged.
+    const shutdown = await oneVm({ status: { state: 'STOPPED', domain_state: 'SHUTOFF' } });
+    const crashed = await oneVm({ status: { state: 'STOPPED', domain_state: 'CRASHED' } });
+    expect(shutdown).toMatchObject({ state: 'STOPPED', domain_state: 'SHUTOFF' });
+    expect(crashed).toMatchObject({ state: 'STOPPED', domain_state: 'CRASHED' });
+  });
+
+  it('reports a state it could not read as null rather than as a state', async () => {
+    expect(await oneVm({ status: null })).toMatchObject({ state: null, domain_state: null });
+    expect(await oneVm({ status: ['RUNNING'] })).toMatchObject({ state: null });
+    expect(await oneVm({ status: {} })).toMatchObject({ state: null, domain_state: null });
+    expect(await oneVm({ name: '', id: null, autostart: 'yes' })).toMatchObject({
+      name: null,
+      id: null,
+      autostart: null,
+    });
+  });
+
+  it('returns no VMs and no failures on a system with none in either stack', async () => {
+    expect(await read([], [])).toEqual({ vms: [], failures: [] });
+  });
+
+  it('reports a stack it could not read as a failure rather than as no VMs', async () => {
+    // The distinction the empty list cannot carry: a system whose VMs all live
+    // in the stack that failed is not a system without any.
+    expect(await readFailing({ ['virt.instance.query']: new Error('unknown method') })).toEqual({
+      vms: [expect.objectContaining({ source: 'vm', name: 'buildbox' })],
+      failures: [{ source: 'virt_instance', error: 'unknown method' }],
+    });
+  });
+
+  it('keeps the VMs of the stack that answered when the other one fails', async () => {
+    const result = await readFailing({ ['vm.query']: new Error('service not running') });
+    expect(result['vms']).toEqual([expect.objectContaining({ source: 'virt_instance' })]);
+    expect(result['failures']).toEqual([{ source: 'vm', error: 'service not running' }]);
+  });
+
+  it('returns no VMs and both failures where neither stack could be read', async () => {
+    const result = await readFailing({
+      ['vm.query']: new Error('down'),
+      ['virt.instance.query']: new Error('down'),
+    });
+    expect(result['vms']).toEqual([]);
+    expect(result['failures']).toEqual([
+      { source: 'vm', error: 'down' },
+      { source: 'virt_instance', error: 'down' },
+    ]);
+  });
+
+  it('names the reason whatever shape the client rejected with', async () => {
+    const error = async (reason: unknown): Promise<unknown> =>
+      ((await readFailing({ ['vm.query']: reason }))['failures'] as Record<string, unknown>[])[0][
+        'error'
+      ];
+    expect(await error(new Error('an Error'))).toBe('an Error');
+    expect(await error({ reason: 'a middleware error' })).toBe('a middleware error');
+    expect(await error({ message: 'a JSON-RPC error' })).toBe('a JSON-RPC error');
+    expect(await error('a bare string')).toBe('a bare string');
+    // A failure with no text still has to read as a failure.
+    expect(await error({})).toBe('the system reported no reason');
+    expect(await error(new Error(''))).toBe('the system reported no reason');
+    expect(await error(null)).toBe('the system reported no reason');
+  });
+
+  it('excludes containers, whether or not the middleware applied the filter', async () => {
+    // An unrecognised filter is dropped rather than refused, and the result of
+    // that is containers in a list of virtual machines.
+    const listed = await rows([], [instance(), instance({ id: 'plex', type: 'CONTAINER' })]);
+    expect(listed.map((row) => row['id'])).toEqual(['web']);
+  });
+
+  it('carries no field the tool does not name, including one a later release adds', async () => {
+    const [libvirt, incus] = await rows(
+      [vm({ enable_secure_boot: true })],
+      [instance({ vnc_password: 'SECRET-VNC-PASSWORD', unheard_of_field: 'SECRET-NEW-SHAPE' })],
+    );
+    const named = [
+      'source',
+      'id',
+      'name',
+      'state',
+      'domain_state',
+      'vcpus',
+      'cpu_set',
+      'memory_bytes',
+      'min_memory_bytes',
+      'autostart',
+    ];
+    expect(Object.keys(libvirt)).toEqual(named);
+    expect(Object.keys(incus)).toEqual(named);
+    expect(JSON.stringify([libvirt, incus])).not.toContain('SECRET');
+  });
+
+  it('asks each stack for its own VMs', async () => {
+    const { ctx, query } = fakeSystem({ ['vm.query']: [], ['virt.instance.query']: [] });
+    await vmsList.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('vm.query');
+    expect(query).toHaveBeenCalledWith('virt.instance.query', [['type', '=', 'VM']]);
   });
 });

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -285,10 +285,10 @@ export const vmsList: ReadOnlyTool = {
     'stack that failed reports no VMs and a failure, which is not a system ' +
     'without any. A stack that is simply absent from a given TrueNAS release ' +
     'appears here as a failure for that reason. This tool reports only virtual ' +
-    'machines: incus containers are excluded, applications are `apps_list`, ' +
-    'and the log output of one VM is `vm_logs`. It does not report a VM\'s ' +
-    'disks, network interfaces, display or passthrough devices, and it does ' +
-    'not create, start, stop or change one. NO field beyond those named here ' +
+    'machines: incus containers are excluded and applications are ' +
+    "`apps_list`. It does not report a VM's log output, disks, network " +
+    'interfaces, display or passthrough devices, and it does not create, ' +
+    'start, stop or change one. NO field beyond those named here ' +
     'is returned, whatever a later TrueNAS release adds to either record.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -1,6 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool } from '@/catalog/tool';
 
 /**
  * Virtual machines a system runs, with the state each is in and the CPU and
@@ -128,6 +128,26 @@ async function attempt<T>(source: VmSource, read: () => Promise<T>): Promise<Att
 /** MiB to bytes, the one unit conversion this file makes. */
 const BYTES_PER_MIB = 1024 * 1024;
 
+/**
+ * The row each stack answers with, taken from the API surface the tools are
+ * typed against rather than named or restated here.
+ *
+ * Derived rather than declared so that the field names below are checked
+ * against the generated client. Reading a row as a bare `Record<string,
+ * unknown>` would compile whatever it was asked for, so a regenerated client
+ * that renames a field — which is how these types have moved before — would
+ * turn every value read under the old name into a null, with no build error
+ * and with tests that pass because their fixtures are written by hand against
+ * the same old names.
+ *
+ * The values are still read through the guards below rather than trusted. The
+ * types describe what the middleware is documented to send, and a tool that
+ * throws because a system sent something else is worse than one that reports
+ * the field it could not read.
+ */
+type VmEntry = ApiSurface['call']['vm.query']['entity'];
+type VirtInstanceEntry = ApiSurface['call']['virt.instance.query']['entity'];
+
 /** One virtual machine, in the shape this tool reports it, whichever stack it
  * was read from. */
 interface VmRow {
@@ -177,29 +197,34 @@ function totalVcpus(sockets: unknown, cores: unknown, threads: unknown): number 
  * guaranteed that much and may be given up to `memory`, so reporting the
  * maximum alone would overstate what the VM is actually holding.
  */
-function fromVmStack(entry: object): VmRow {
-  const row = entry as Record<string, unknown>;
-  const status = recordOrNull(row['status']);
-  const memory = numberOrNull(row['memory']);
-  const minMemory = numberOrNull(row['min_memory']);
+function fromVmStack(entry: VmEntry): VmRow {
+  // The type declares `status` present and non-null; a system that reported
+  // neither must answer null states rather than throw. Read back as a partial
+  // of its own type so that the two names below are checked too.
+  const status = (recordOrNull(entry.status) ?? {}) as Partial<VmEntry['status']>;
+  const memory = numberOrNull(entry.memory);
+  const minMemory = numberOrNull(entry.min_memory);
   return {
     source: 'vm',
-    id: numberOrNull(row['id']),
-    name: textOrNull(row['name']),
+    id: numberOrNull(entry.id),
+    name: textOrNull(entry.name),
     // The middleware's own word for the state. `domain_state` beside it is
     // libvirt's, and the two are reported separately rather than merged
     // because they are different vocabularies and a caller cannot tell which
     // one arrived once they share a field.
-    state: textOrNull(status?.['state']),
-    domain_state: textOrNull(status?.['domain_state']),
-    vcpus: totalVcpus(row['vcpus'], row['cores'], row['threads']),
-    // A CPU set is a `virt.instance` notion; this stack pins with `cpuset`,
-    // which is a different field and is not reported. Null keeps the column
-    // meaning one thing across both stacks.
+    state: textOrNull(status.state),
+    domain_state: textOrNull(status.domain_state),
+    vcpus: totalVcpus(entry.vcpus, entry.cores, entry.threads),
+    // This stack has a `cpuset` of its own, and it is deliberately not
+    // reported here: on this stack pinning is a separate fact from the vCPU
+    // count, which `vcpus` above always states, whereas `cpu_set` exists to
+    // say that a count could not be stated BECAUSE a set was given instead.
+    // Filling it from `cpuset` would make the column mean two things. Which
+    // host CPUs a VM is pinned to is a question this tool does not answer.
     cpu_set: null,
     memory_bytes: memory === null ? null : memory * BYTES_PER_MIB,
     min_memory_bytes: minMemory === null ? null : minMemory * BYTES_PER_MIB,
-    autostart: booleanOrNull(row['autostart']),
+    autostart: booleanOrNull(entry.autostart),
   };
 }
 
@@ -217,23 +242,22 @@ function fromVmStack(entry: object): VmRow {
  * memory floor in this record, so `min_memory_bytes` is null — which is the
  * absence of a range rather than an unreadable one, and the description says so.
  */
-function fromVirtStack(entry: object): VmRow {
-  const row = entry as Record<string, unknown>;
-  const cpu = textOrNull(row['cpu']);
+function fromVirtStack(entry: VirtInstanceEntry): VmRow {
+  const cpu = textOrNull(entry.cpu);
   const plainCount = cpu !== null && /^\d+$/.test(cpu) ? Number(cpu) : null;
   return {
     source: 'virt_instance',
-    id: textOrNull(row['id']),
-    name: textOrNull(row['name']),
-    state: textOrNull(row['status']),
+    id: textOrNull(entry.id),
+    name: textOrNull(entry.name),
+    state: textOrNull(entry.status),
     // libvirt's domain state has no counterpart on this stack; `status` above
     // already distinguishes ERROR from STOPPED on its own.
     domain_state: null,
     vcpus: plainCount,
     cpu_set: plainCount === null ? cpu : null,
-    memory_bytes: numberOrNull(row['memory']),
+    memory_bytes: numberOrNull(entry.memory),
     min_memory_bytes: null,
-    autostart: booleanOrNull(row['autostart']),
+    autostart: booleanOrNull(entry.autostart),
   };
 }
 

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -1,0 +1,329 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+
+/**
+ * Virtual machines a system runs, with the state each is in and the CPU and
+ * memory it has been given.
+ *
+ * `apps_list` covers half of what runs on a modern TrueNAS. This is the other
+ * half, and without it an assistant asked what a system is doing answers from
+ * the apps alone and reports an incomplete picture as a complete one.
+ *
+ * TWO STACKS, BOTH PRESENT ON THE VERSION THE CLIENT IS TYPED AGAINST. TrueNAS
+ * carries the older libvirt-backed VMs under `vm.*` and the newer
+ * incus-backed instances under `virt.*`, and both `vm.query` and
+ * `virt.instance.query` are in the pinned client's call directory for the
+ * default (oldest supported) API surface. Which one a given system's VMs
+ * actually live in is a per-system fact this cannot know in advance, so both
+ * are read and every row says which stack it came from. Reading one alone
+ * would answer "no virtual machines" on a system whose VMs are all in the
+ * other, which is the failure this tool exists to prevent.
+ *
+ * `virt.instance.query` also returns containers. They are filtered out: this
+ * tool is about virtual machines, and an incus container is closer to what
+ * `apps_list` already reports than to a VM.
+ *
+ * The mapping is an allowlist rather than a trim, as in `apps.ts` and
+ * `disks.ts`. Size is the reason here rather than secrecy: a `virt.instance`
+ * row carries the whole `raw` incus configuration, its `environment` map, its
+ * image metadata and its aliases, and a `vm.query` row carries every device
+ * attached to the VM. Naming the output fields is what keeps all of that out of
+ * the tool result, and what stops a field a later TrueNAS release adds
+ * appearing without a change to this file.
+ */
+
+/** Which of the two stacks a row was read from. */
+type VmSource = 'vm' | 'virt_instance';
+
+/** One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters, the
+ * same reading `alerts.ts`, `credentials.ts`, `network.ts`, `block.ts` and
+ * `shares.ts` each hold under their own names — and restated here for the
+ * reason those files give for restating it: a tool file is read on its own. */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** A finite number the system reported, or null where it reported anything
+ * else. Infinite and NaN are not counts or byte totals, whatever else they
+ * are. */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** A boolean the system reported, or null where it reported anything else. */
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+/** A nested object of a row, or null where the row held anything else.
+ *
+ * `typeof null` is `'object'`, so the null check is what stops a reported-as-null
+ * `status` being indexed. An array is an object too and is excluded: the one
+ * thing read through this is a VM's status record, and reading a list as one
+ * would answer null for every field rather than saying the shape was not what
+ * this tool reads. */
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/**
+ * Why a read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. `alerts.ts`,
+ * `block.ts`, `network.ts` and `shares.ts` each hold this same reading under
+ * their own names. The result is never empty, because a failure with no text
+ * still has to read as a failure.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/** A read that did not complete, named by the stack it was against. */
+interface VmFailure {
+  source: VmSource;
+  error: string;
+}
+
+/** A read that produced rows, or the failure that stopped it. */
+interface Attempt<T> {
+  value: T | null;
+  failure: VmFailure | null;
+}
+
+/**
+ * One stack's read, with a failure caught and named rather than thrown.
+ *
+ * The read is passed as a thunk so that the call is made inside the `try`, which
+ * keeps this correct for a read that throws before it returns a promise at all.
+ *
+ * NEITHER READ IS ALLOWED TO FAIL THE TOOL, which is the difference from
+ * `block.ts`, where the subsystems read is primary and a denied read is raised.
+ * Here there is no primary: a system may legitimately have only one of the two
+ * stacks, so a stack that could not be read is reported as a failure beside
+ * whatever the other stack answered rather than losing that answer too.
+ */
+async function attempt<T>(source: VmSource, read: () => Promise<T>): Promise<Attempt<T>> {
+  try {
+    return { value: await read(), failure: null };
+  } catch (reason) {
+    return { value: null, failure: { source, error: errorText(reason) } };
+  }
+}
+
+/** MiB to bytes, the one unit conversion this file makes. */
+const BYTES_PER_MIB = 1024 * 1024;
+
+/** One virtual machine, in the shape this tool reports it, whichever stack it
+ * was read from. */
+interface VmRow {
+  source: VmSource;
+  id: string | number | null;
+  name: string | null;
+  state: string | null;
+  domain_state: string | null;
+  vcpus: number | null;
+  cpu_set: string | null;
+  memory_bytes: number | null;
+  min_memory_bytes: number | null;
+  autostart: boolean | null;
+}
+
+/**
+ * The total number of virtual CPUs a libvirt-backed VM has been given.
+ *
+ * TrueNAS stores the allocation as three numbers and the VM sees their product:
+ * `vcpus` virtual sockets, each of `cores` cores, each of `threads` threads.
+ * Reporting `vcpus` alone would understate a VM configured 1 × 2 × 2 by a
+ * factor of four, and that field's name makes the understatement look like the
+ * answer, so the product is what is reported.
+ *
+ * All three have to be readable numbers. A missing component is not treated as
+ * one: a defaulted-to-1 guess is indistinguishable in the result from a value
+ * the system actually reported, and a null says plainly that the count could
+ * not be stated.
+ */
+function totalVcpus(sockets: unknown, cores: unknown, threads: unknown): number | null {
+  const values = [numberOrNull(sockets), numberOrNull(cores), numberOrNull(threads)];
+  if (values.some((value) => value === null)) return null;
+  return (values as number[]).reduce((product, value) => product * value, 1);
+}
+
+/**
+ * A libvirt-backed VM as `vm.query` reports it.
+ *
+ * `memory` and `min_memory` are MiB on this stack and bytes on the other, which
+ * is the one place the two disagree about what a number means. Both are
+ * reported here in bytes so that a caller comparing two VMs is comparing the
+ * same quantity. THE MiB READING IS TrueNAS'S DOCUMENTED UNIT FOR THIS FIELD
+ * AND IS NOT CARRIED BY THE PINNED CLIENT'S TYPES, which describe it as a bare
+ * `number`; it is unconfirmed against a live middleware.
+ *
+ * `min_memory` is the floor of a memory range: where it is set the VM is
+ * guaranteed that much and may be given up to `memory`, so reporting the
+ * maximum alone would overstate what the VM is actually holding.
+ */
+function fromVmStack(entry: object): VmRow {
+  const row = entry as Record<string, unknown>;
+  const status = recordOrNull(row['status']);
+  const memory = numberOrNull(row['memory']);
+  const minMemory = numberOrNull(row['min_memory']);
+  return {
+    source: 'vm',
+    id: numberOrNull(row['id']),
+    name: textOrNull(row['name']),
+    // The middleware's own word for the state. `domain_state` beside it is
+    // libvirt's, and the two are reported separately rather than merged
+    // because they are different vocabularies and a caller cannot tell which
+    // one arrived once they share a field.
+    state: textOrNull(status?.['state']),
+    domain_state: textOrNull(status?.['domain_state']),
+    vcpus: totalVcpus(row['vcpus'], row['cores'], row['threads']),
+    // A CPU set is a `virt.instance` notion; this stack pins with `cpuset`,
+    // which is a different field and is not reported. Null keeps the column
+    // meaning one thing across both stacks.
+    cpu_set: null,
+    memory_bytes: memory === null ? null : memory * BYTES_PER_MIB,
+    min_memory_bytes: minMemory === null ? null : minMemory * BYTES_PER_MIB,
+    autostart: booleanOrNull(row['autostart']),
+  };
+}
+
+/**
+ * An incus-backed VM as `virt.instance.query` reports it.
+ *
+ * `cpu` is a single string covering two different facts: a plain count
+ * (`"4"`), or a set of host CPUs the instance is pinned to (`"0-3"`, `"1,3"`).
+ * Only the first is a vCPU count, so only the first fills `vcpus`; a set is
+ * reported verbatim as `cpu_set` and leaves `vcpus` null rather than having its
+ * members counted here, because that count is an inference about how the host
+ * expands the range and not something the system said.
+ *
+ * `memory` is already bytes on this stack and is passed through. There is no
+ * memory floor in this record, so `min_memory_bytes` is null — which is the
+ * absence of a range rather than an unreadable one, and the description says so.
+ */
+function fromVirtStack(entry: object): VmRow {
+  const row = entry as Record<string, unknown>;
+  const cpu = textOrNull(row['cpu']);
+  const plainCount = cpu !== null && /^\d+$/.test(cpu) ? Number(cpu) : null;
+  return {
+    source: 'virt_instance',
+    id: textOrNull(row['id']),
+    name: textOrNull(row['name']),
+    state: textOrNull(row['status']),
+    // libvirt's domain state has no counterpart on this stack; `status` above
+    // already distinguishes ERROR from STOPPED on its own.
+    domain_state: null,
+    vcpus: plainCount,
+    cpu_set: plainCount === null ? cpu : null,
+    memory_bytes: numberOrNull(row['memory']),
+    min_memory_bytes: null,
+    autostart: booleanOrNull(row['autostart']),
+  };
+}
+
+export const vmsList: ReadOnlyTool = {
+  name: 'vms_list',
+  description:
+    'Virtual machines configured on a TrueNAS system, with the state each is ' +
+    'in and the CPU and memory it has been given. TrueNAS runs VMs under two ' +
+    'stacks and both are read: `source` is `vm` for the older libvirt-backed ' +
+    'VMs and `virt_instance` for the newer incus-backed instances. A system ' +
+    'normally uses one or the other, and `vm` entries are listed before ' +
+    '`virt_instance` ones. `id` is the identifier that stack uses — a number ' +
+    'on `vm`, a string on `virt_instance` — and is null where the system ' +
+    'reported none; it is unique only within its own `source`, so two entries ' +
+    'may share a `name` or an `id` while being different machines. `state` is ' +
+    "the state word the system itself used: on `virt_instance` one of " +
+    '`RUNNING`, `STOPPED`, `STARTING`, `STOPPING`, `FROZEN`, `FREEZING`, ' +
+    '`THAWED`, `ABORTING`, `ERROR` or `UNKNOWN`, so A STOPPED VM AND A FAILED ' +
+    'ONE ARE DIFFERENT WORDS THERE. On `vm` the vocabulary is the ' +
+    "middleware's own and is narrower — a VM that is not running commonly " +
+    'reads `STOPPED` whether it was shut down or died — and `domain_state` is ' +
+    "beside it carrying libvirt's own state for the same machine, where " +
+    '`CRASHED` or `SHUTOFF` is what separates the two cases. `domain_state` is ' +
+    'null on `virt_instance`, which has no such second state, and null on `vm` ' +
+    'where the system reported none. NEITHER STATE IS TRANSLATED OR COMPARED ' +
+    'ACROSS THE TWO STACKS: the words come from different systems and this ' +
+    'tool reports them as they arrived. `vcpus` is the total number of virtual ' +
+    'CPUs allocated. On `vm` that is the product of the virtual sockets, cores ' +
+    'and threads TrueNAS stores separately, which is what the guest sees, and ' +
+    'is null where the system did not report all three. On `virt_instance` it ' +
+    'is the CPU allocation where that is a plain count, and NULL WHERE THE ' +
+    'INSTANCE IS PINNED TO A SET OF HOST CPUS INSTEAD — `cpu_set` then carries ' +
+    'that set verbatim, as the system spelled it (`0-3`, `1,3`), and the ' +
+    'number of CPUs it comes to is not counted here. `cpu_set` is null on `vm` ' +
+    'and null wherever `vcpus` is a count. `memory_bytes` is the memory the VM ' +
+    'is allocated, IN BYTES ON BOTH STACKS: the `vm` stack stores this figure ' +
+    'in MiB and it is converted here, so the two are directly comparable. ' +
+    '`min_memory_bytes` is the floor of a memory range where one is set — the ' +
+    'VM is guaranteed that much and may be given up to `memory_bytes` — and is ' +
+    'null on `virt_instance`, which has no such floor, and null on a `vm` ' +
+    'entry with no range set, where `memory_bytes` is simply what the VM has. ' +
+    'Every one of these fields is null where the system reported no value this ' +
+    'tool could read, which is never the same as a VM configured with none. ' +
+    '`autostart` is whether the VM starts with the system. AN EMPTY `vms` ' +
+    'LIST WITH AN EMPTY `failures` LIST IS A SYSTEM WITH NO VIRTUAL MACHINES ' +
+    'CONFIGURED IN EITHER STACK. `failures` names each stack that could not be ' +
+    'read at all, as `source` and the `error` the system gave, and WHILE IT IS ' +
+    'NOT EMPTY THE LIST IS INCOMPLETE — a system whose VMs all live in the ' +
+    'stack that failed reports no VMs and a failure, which is not a system ' +
+    'without any. A stack that is simply absent from a given TrueNAS release ' +
+    'appears here as a failure for that reason. This tool reports only virtual ' +
+    'machines: incus containers are excluded, applications are `apps_list`, ' +
+    'and the log output of one VM is `vm_logs`. It does not report a VM\'s ' +
+    'disks, network interfaces, display or passthrough devices, and it does ' +
+    'not create, start, stop or change one. NO field beyond those named here ' +
+    'is returned, whatever a later TrueNAS release adds to either record.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other, and each is caught: see `attempt` for why neither may fail the
+    // tool.
+    const [vms, instances] = await Promise.all([
+      attempt('vm', () => firstValueFrom(system.client.api.query('vm.query'))),
+      attempt('virt_instance', () =>
+        firstValueFrom(
+          // The filter is inlined so the call's own parameter types apply:
+          // written to a `const` first it widens and no longer satisfies the
+          // filter tuple, as in `storage.ts`.
+          system.client.api.query('virt.instance.query', [['type', '=', 'VM']]),
+        ),
+      ),
+    ]);
+
+    const failures: VmFailure[] = [];
+    if (vms.failure !== null) failures.push(vms.failure);
+    if (instances.failure !== null) failures.push(instances.failure);
+
+    return {
+      vms: [
+        ...(vms.value ?? []).map(fromVmStack),
+        // The `type` filter above is asked of the middleware; this re-checks
+        // it on what came back. A query parameter a release does not
+        // recognise is dropped rather than refused, and the result of that is
+        // containers in a list of virtual machines — indistinguishable from a
+        // filter that matched everything.
+        ...(instances.value ?? []).filter((instance) => instance.type === 'VM').map(fromVirtStack),
+      ],
+      failures,
+    };
+  },
+};


### PR DESCRIPTION
Adds `vms_list`, a read-only tool reporting the virtual machines a system has, the state each is in, and the CPU and memory it has been given.

Fixes #35

## Which sources were used, and why both

The ticket's design note says `vm.query` is confirmed and asks whether `virt.instance.query` and `container.query` also apply, preferring one call. What I found:

- **`vm.query`** and **`virt.instance.query`** are both in the pinned client's call directory for the API surface the tools are typed against (`ApiSurface` → the client's `DefaultApiDirectory`, the oldest supported version). Both are reachable today.
- **`container.query` is not.** It is a v26-only method — the client's own doc comment names it as the example of one — so it is not on this surface and is not called.

Both reachable methods are read, because TrueNAS carries the older libvirt-backed VMs under `vm.*` and the newer incus-backed instances under `virt.*`, and which one a given system's VMs live in is a per-system fact this cannot know in advance. Reading one alone would answer "no virtual machines" on a system whose VMs are all in the other — the incomplete-picture failure the ticket exists to prevent. Every row therefore carries `source`, which is `vm` or `virt_instance`, exactly as the ticket asks for where both are needed.

`virt.instance.query` also returns containers. They are excluded — this is a VM tool, and an incus container is closer to what `apps_list` already reports. The `type` filter is asked of the middleware **and** re-checked on the response, because an unrecognised filter is dropped rather than refused and the result of that is containers in a list of virtual machines.

## What the two stacks disagree about

The mapping reconciles three genuine differences rather than passing them through:

- **Memory units.** `memory` is MiB on `vm` and bytes on `virt_instance`. Both are reported as `memory_bytes`, so a caller comparing two VMs is comparing the same quantity — without this, a 4 GiB libvirt VM reports a smaller number than an 8 GiB incus one by a factor of a million rather than two. **(unconfirmed)** The MiB reading for the `vm` stack is TrueNAS's documented unit for that field; the pinned client types it as a bare `number` and carries no unit, so this is not confirmed against a live middleware. It is the one unit conversion in the file and is isolated in a single constant.
- **vCPU count.** `vm` stores the allocation as virtual sockets × cores × threads and the guest sees the product, so the product is what `vcpus` reports — `vcpus` alone would understate a VM configured 1 × 2 × 2 by a factor of four. All three must be readable; a missing component is not defaulted to 1, because a guess is indistinguishable in the result from a value the system reported. `virt_instance` has one `cpu` string that is either a plain count or a set of pinned host CPUs, and only the first fills `vcpus`; a set goes verbatim into `cpu_set` and leaves `vcpus` null rather than having its members counted here.
- **State vocabulary.** `virt_instance` has an explicit `ERROR` distinct from `STOPPED`. `vm` does not — a VM that died commonly reads `STOPPED` there — so `domain_state` is reported beside it carrying libvirt's own state, where `CRASHED` and `SHUTOFF` are what separate the two cases. The two vocabularies are never merged or translated: a caller cannot tell which one arrived once they share a field.

## The return shape, and the one place it departs from the ticket

The ticket's third acceptance criterion asks that a system with no VMs return `[]` rather than throwing, including where the virtualization service is not running. **The tool returns `{ vms, failures }` rather than a bare array**, and `vms` is `[]` in exactly that case.

The reason is the second half of that criterion. Neither read is allowed to fail the tool — a system may legitimately have only one of the two stacks — so a stack that could not be read is named in `failures` beside whatever the other stack answered. A bare array cannot carry that, and without it "no VMs" and "the stack holding all the VMs could not be read" are the same answer. That distinction is the one this repository has been repeatedly careful about, and `iscsi_list` and `nvmeof_list` in `block.ts` already return an object with a `failures` list for the same reason. Stated here because it is a departure from the criterion as written, and reversing it is a small change if the shape is wanted instead.

So: empty `vms` with empty `failures` is a system with no VMs in either stack. Empty `vms` with a failure is not.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` were all run locally and all pass. Coverage on `src/tools/vms.ts` is 100% of statements, branches, functions and lines; the global floors (branches 96 / statements 97) are met with room.

The local review ran the same shared reviewer this PR's required check runs, in a separate process, over three rounds. It raised one MEDIUM in each of the first two, both fixed:

- The description pointed a caller at `vm_logs` for a VM's log output. That tool is a separate ticket and is not in the catalog, so the pointer named a tool the model would then try to call. The exclusion is now stated as something this tool does not report rather than as a place to go for it.
- Both mappers took the row as `object` and cast it to `Record<string, unknown>`, so no field name in the file was compile-checked and a regenerated client renaming a field would have produced silent nulls with green tests. The row types are now derived from `ApiSurface` and every field is read by typed access, through the same runtime guards.

The third round returned nothing at or above MEDIUM.

## What I did not change, and why

Two LOWs from that clean round are left for a reviewer or a later ticket, since fixing a LOW makes a new diff that is itself unreviewed:

- **Neither query passes `select`**, so a `virt.instance` row's whole `raw` config, `environment` map and `vnc_password` cross the wire before the mapping drops them, where `tasks.ts` selects. Correct, and worth doing — the output is unaffected either way, since the allowlist is what decides what a caller sees, and there is a test asserting no unnamed field survives. It is a transfer-size improvement rather than a disclosure one.
- **No test pins that `cpu_set` stays null on the `vm` stack** and is never filled from that stack's own `cpuset`. Also correct: no fixture reaching that mapper sets `cpuset`, so the behaviour is asserted only by the exact-keys test and the round-trip test. A one-line fixture change would pin it.
