### PR TITLE
feat(tools): add system_update_status, whether a TrueNAS update is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `storage_pool_status`, `storage_pool_topology`,
-  `storage_scrub_history`, `storage_list_datasets`, `datasets_quota_report`,
-  `disks_list`, `apps_list`, `vms_list`, `alerts_list`, `snapshots_list`,
-  `replication_status`, `snapshot_tasks_list`, `cloudsync_tasks_list`,
-  `tasks_recent_runs`, `shares_list`, `share_access`, `iscsi_list`,
-  `nvmeof_list`, `users_list`, `directory_services_status`,
-  `network_interfaces`, `network_config`, `certificates_list`,
-  `cloud_credentials_list`, `alert_settings`.
+  `system_info`, `system_update_status`, `storage_pool_status`,
+  `storage_pool_topology`, `storage_scrub_history`, `storage_list_datasets`,
+  `datasets_quota_report`, `disks_list`, `apps_list`, `vms_list`,
+  `alerts_list`, `snapshots_list`, `replication_status`,
+  `snapshot_tasks_list`, `cloudsync_tasks_list`, `tasks_recent_runs`,
+  `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
+  `directory_services_status`, `network_interfaces`, `network_config`,
+  `certificates_list`, `cloud_credentials_list`, `alert_settings`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export type { ConfirmationGate, ConfirmationServiceOptions } from '@/execution/c
 export {
   createDefaultCatalog,
   systemInfo,
+  updateStatus,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,14 +12,15 @@ import { replicationStatus } from '@/tools/replication';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
-import { systemInfo } from '@/tools/system';
+import { systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: twenty-six read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-seven read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
+  catalog.register(updateStatus);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -75,6 +76,7 @@ export {
   snapshotTasksList,
   systemInfo,
   tasksRecentRuns,
+  updateStatus,
   usersList,
   vmsList,
 };

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,6 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 
 /**
  * Grounds the LLM on what it is talking to — version, hostname, hardware —
@@ -25,6 +25,170 @@ export const systemInfo: ReadOnlyTool = {
       physical_cores: info.physical_cores,
       memory_bytes: info.physmem,
       timezone: info.timezone,
+    };
+  },
+};
+
+/**
+ * A string the system reported, or null where it reported anything else.
+ *
+ * An empty string is read as no value rather than as text of no characters: a
+ * version of no characters names nothing a caller could act on, and passing it
+ * through would put a field in the result that says nothing.
+ *
+ * `accounts.ts`, `shares.ts` and `block.ts` each hold the same reading under
+ * their own names, and this restates rather than shares it for the reason
+ * `shares.ts` gives for restating its own guards: a tool file is read on its
+ * own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/** What a system answering the check with no status at all is reported as. */
+const NO_STATUS = 'the system reported no update status';
+
+/**
+ * Why the version read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Anything else
+ * still becomes a stated absence rather than `"[object Object]"`, and the
+ * result is never empty: a failure with no text still has to read as a failure.
+ * The same reading as `accounts.ts` holds of a failed configuration read.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/** The running version, or the failure that stopped it being read. */
+interface VersionAttempt {
+  value: string | null;
+  error: string | null;
+}
+
+/**
+ * The version the system is running now, with a failure named rather than
+ * thrown.
+ *
+ * `update.status` reports the train and profile the system updates along and
+ * the version it could move to, but never the version it is on — its
+ * `current_version` names the train, the profile and whether the two agree, and
+ * nothing else. So the running version is a second read, and it is reported
+ * rather than fatal for the reason `accounts.ts` gives for its configuration
+ * read: the question the tool is asked — is an update available, and which — is
+ * answered by `update.status` on its own, and losing the version it is moving
+ * from must not lose the answer as well.
+ */
+async function readVersion(system: SystemHandle): Promise<VersionAttempt> {
+  try {
+    const version = await firstValueFrom(system.client.api.call('system.version'));
+    return { value: textOrNull(version), error: null };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/**
+ * The `update.status` payload, read through one seam so that its type is taken
+ * from the client by inference rather than restated here — the generated types
+ * suffix duplicate names, and a hand-written copy of one is a copy that can
+ * drift.
+ *
+ * `code` is the system's own verdict on whether the check itself worked —
+ * `NORMAL` or `ERROR` — and `status` carries the answer where it did.
+ */
+function readStatus(system: SystemHandle) {
+  return firstValueFrom(system.client.api.call('update.status'));
+}
+
+/** What {@link readStatus} answers with. */
+type UpdateReport = Awaited<ReturnType<typeof readStatus>>;
+
+/**
+ * Why the check could not answer, in words. Only ever called where it did not.
+ *
+ * The system's own error is preferred, then its error name — a reason a person
+ * can read before a symbol only a machine can — and a check that failed while
+ * saying nothing still has to read as one that failed. A system that reported
+ * `NORMAL` and then sent no status is a third case: nothing went wrong that it
+ * admits to, and there is still no answer in the payload.
+ */
+function checkFailure(report: UpdateReport): string {
+  const error = report.error;
+  if (error !== null) return textOrNull(error.reason) ?? textOrNull(error.errname) ?? NO_REASON;
+  return report.code === 'ERROR' ? NO_REASON : NO_STATUS;
+}
+
+/**
+ * Whether a TrueNAS update is available, and which.
+ *
+ * The distinction the tool exists to keep is between a system that is up to
+ * date and one that could not be asked. Both have no update to report, and
+ * across a fleet they are opposite answers: the first needs nothing, the second
+ * has not been checked at all and may have been unchecked for months. So
+ * `update_available` is a three-valued answer — false, true, or null for "not
+ * established" — rather than a boolean that quietly reads an unreachable update
+ * server as good news.
+ */
+export const updateStatus: ReadOnlyTool = {
+  name: 'system_update_status',
+  description:
+    'Whether a TrueNAS update is available for this system, and which. ' +
+    '`update_available` is true when the system has an update it could move ' +
+    'to, false when it is already up to date, and NULL WHEN THE CHECK COULD ' +
+    'NOT BE COMPLETED — a system that is air-gapped, that cannot reach the ' +
+    'update server, or that reported no status at all. Null is not "no update ' +
+    'available": nothing has been established about that system, and it may ' +
+    'have been unchecked for a long time. `check_error` is what the system ' +
+    'said about that failure and is null whenever `update_available` is true ' +
+    'or false. `new_version` is the version the system would move to, and is ' +
+    'null unless `update_available` is true. `train` is the update train the ' +
+    'system follows — the channel its updates come from. `new_version` and ' +
+    '`train` ARE BOTH NULL WHILE `update_available` IS NULL, because they come ' +
+    'from the status the check did not produce, not because the system has no ' +
+    'train. `current_version` is the version the system is running now and ' +
+    'comes from a SEPARATE read, so it is unaffected by a failed check and is ' +
+    'reported even where `update_available` is null. `version_error` names ' +
+    'what the system said when that read failed, and `current_version` is null ' +
+    'while it is non-null; `current_version` null with `version_error` null is ' +
+    'a system that answered the read with no version. This tool only checks. ' +
+    'It does not download, apply or schedule an update, and it does not reboot ' +
+    'anything. Applications are updated separately and are not reported here — ' +
+    'that is `apps_list`.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other. Only the status read may fail the tool, for the reason
+    // `readVersion` gives.
+    const [report, version] = await Promise.all([readStatus(system), readVersion(system)]);
+
+    // The check has an answer only where the system said the check itself
+    // worked AND sent a status to read. A payload that reports `ERROR` and a
+    // status together is not read as an answer: the system has said its own
+    // check did not complete, and a stale or partial status behind that is
+    // exactly what must not be reported as "up to date".
+    const status = report.code === 'NORMAL' ? report.status : null;
+    const candidate = status?.new_version ?? null;
+    return {
+      update_available: status === null ? null : candidate !== null,
+      current_version: version.value,
+      new_version: candidate === null ? null : textOrNull(candidate.version),
+      train: status === null ? null : textOrNull(status.current_version.train),
+      check_error: status === null ? checkFailure(report) : null,
+      version_error: version.error,
     };
   },
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -28,6 +28,7 @@ import {
   snapshotsList,
   snapshotTasksList,
   tasksRecentRuns,
+  updateStatus,
   usersList,
   vmsList,
 } from '@/tools/index';
@@ -74,9 +75,10 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-seven sketch tools', () => {
+  it('registers the twenty-eight sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
+      'system_update_status',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -104,6 +106,12 @@ describe('createDefaultCatalog', () => {
       'alert_settings',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises system_update_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'system_update_status',
+    );
   });
 
   it('advertises alert_settings to a read-only credential', () => {
@@ -224,6 +232,221 @@ describe('createDefaultCatalog', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'network_config',
     );
+  });
+});
+
+describe('system_update_status', () => {
+  /** `update.status` as the middleware sends it on a system with an update. */
+  const report = (over: Record<string, unknown> = {}) => ({
+    code: 'NORMAL',
+    status: {
+      current_version: {
+        train: 'TrueNAS-SCALE-Fangtooth',
+        profile: 'GENERAL',
+        matches_profile: true,
+      },
+      new_version: {
+        version: '25.04.1',
+        manifest: {},
+        release_notes: null,
+        release_notes_url: 'https://example.invalid/notes',
+      },
+    },
+    error: null,
+    update_download_progress: null,
+    ...over,
+  });
+
+  /** The status of a check that reached the update server and found nothing. */
+  const upToDate = () => report({ status: { ...report().status, new_version: null } });
+
+  const reported = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = failingSystem(
+      {
+        ['update.status']: report(),
+        ['system.version']: 'TrueNAS-SCALE-25.04.0',
+        ...rows,
+      },
+      failures,
+    );
+    return (await updateStatus.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('reports the candidate version, the train and the running version', async () => {
+    expect(await reported()).toEqual({
+      update_available: true,
+      current_version: 'TrueNAS-SCALE-25.04.0',
+      new_version: '25.04.1',
+      train: 'TrueNAS-SCALE-Fangtooth',
+      check_error: null,
+      version_error: null,
+    });
+  });
+
+  it('reports a system already up to date as an explicit no', async () => {
+    // Not an empty result: false is an answer, and it is the answer that has to
+    // stay distinct from the null below.
+    expect(await reported({ ['update.status']: upToDate() })).toEqual({
+      update_available: false,
+      current_version: 'TrueNAS-SCALE-25.04.0',
+      new_version: null,
+      train: 'TrueNAS-SCALE-Fangtooth',
+      check_error: null,
+      version_error: null,
+    });
+  });
+
+  it('distinguishes a check that could not run from a system with no update', async () => {
+    expect(
+      await reported({
+        ['update.status']: report({
+          code: 'ERROR',
+          status: null,
+          error: { errname: 'ENETUNREACH', reason: 'could not reach the update server' },
+        }),
+      }),
+    ).toEqual({
+      // Null rather than false: nothing has been established about this system.
+      update_available: null,
+      // The version read is separate and is unaffected by the failed check.
+      current_version: 'TrueNAS-SCALE-25.04.0',
+      new_version: null,
+      train: null,
+      check_error: 'could not reach the update server',
+      version_error: null,
+    });
+  });
+
+  it('does not read a status the system sent beside its own error', async () => {
+    // `code` is the system's verdict on its own check. A status behind an
+    // `ERROR` may be stale, and reporting it would answer "up to date" for a
+    // system that was never successfully asked.
+    expect(await reported({ ['update.status']: report({ code: 'ERROR' }) })).toMatchObject({
+      update_available: null,
+      new_version: null,
+      train: null,
+      check_error: 'the system reported no reason',
+    });
+  });
+
+  it('names the error name where the failure carried no reason', async () => {
+    expect(
+      await reported({
+        ['update.status']: report({
+          code: 'ERROR',
+          status: null,
+          error: { errname: 'ENOTCONN', reason: '' },
+        }),
+      }),
+    ).toMatchObject({ update_available: null, check_error: 'ENOTCONN' });
+  });
+
+  it('reports a check that failed while saying nothing as a failure', async () => {
+    expect(
+      await reported({
+        ['update.status']: report({
+          code: 'ERROR',
+          status: null,
+          error: { errname: '', reason: '' },
+        }),
+      }),
+    ).toMatchObject({ update_available: null, check_error: 'the system reported no reason' });
+  });
+
+  it('reports a system that answered normally with no status at all', async () => {
+    // Nothing went wrong that the system admits to, and there is still no
+    // answer in the payload — which is not "no update available".
+    expect(await reported({ ['update.status']: report({ status: null }) })).toMatchObject({
+      update_available: null,
+      check_error: 'the system reported no update status',
+    });
+  });
+
+  it('reports a train the system sent as empty as null', async () => {
+    expect(
+      await reported({
+        ['update.status']: report({
+          status: { ...report().status, current_version: { train: '' } },
+        }),
+      }),
+    ).toMatchObject({ update_available: true, train: null });
+  });
+
+  it('reports a candidate the system named with no version as null', async () => {
+    // Still an update available: the system said there is one, and only its
+    // name is missing.
+    expect(
+      await reported({
+        ['update.status']: report({
+          status: { ...report().status, new_version: { version: '' } },
+        }),
+      }),
+    ).toMatchObject({ update_available: true, new_version: null });
+  });
+
+  it('keeps the update answer when the running version could not be read', async () => {
+    expect(
+      await reported({}, { ['system.version']: new Error('connection reset') }),
+    ).toMatchObject({
+      update_available: true,
+      new_version: '25.04.1',
+      current_version: null,
+      version_error: 'connection reset',
+    });
+  });
+
+  it('names a version failure however the client rejected', async () => {
+    const reasons: [unknown, string][] = [
+      [{ reason: 'system.version failed' }, 'system.version failed'],
+      [{ message: 'connection reset' }, 'connection reset'],
+      ['ENOTCONN', 'ENOTCONN'],
+      [new Error(''), 'the system reported no reason'],
+      [{ code: 42 }, 'the system reported no reason'],
+      [null, 'the system reported no reason'],
+    ];
+    for (const [reason, expected] of reasons) {
+      expect((await reported({}, { ['system.version']: reason }))['version_error']).toBe(expected);
+    }
+  });
+
+  it('reports a version the system sent as empty as null, and not as a failure', async () => {
+    expect(await reported({ ['system.version']: '' })).toMatchObject({
+      current_version: null,
+      version_error: null,
+    });
+  });
+
+  it('returns no field a later release adds', async () => {
+    const result = await reported({
+      ['update.status']: report({
+        future_field: 'added by a later release',
+        status: {
+          ...report().status,
+          future_field: 'added by a later release',
+        },
+      }),
+    });
+    expect(Object.keys(result)).toEqual([
+      'update_available',
+      'current_version',
+      'new_version',
+      'train',
+      'check_error',
+      'version_error',
+    ]);
+    expect(JSON.stringify(result)).not.toContain('added by a later release');
+  });
+
+  it('never mutates: it checks for an update and does not apply one', async () => {
+    const { ctx, call } = failingSystem({
+      ['update.status']: report(),
+      ['system.version']: 'TrueNAS-SCALE-25.04.0',
+    });
+    await updateStatus.handler(ctx, {});
+    expect(call.mock.calls.map((args) => args[0])).toEqual(['update.status', 'system.version']);
   });
 });
 


### PR DESCRIPTION
Adds `system_update_status`, the read-only tool that answers whether a TrueNAS update is available for a system and which. Fixes #37.

## What it returns

| field | meaning |
|---|---|
| `update_available` | `true` an update exists, `false` already up to date, `null` the check could not be completed |
| `current_version` | the version the system is running now |
| `new_version` | the version it would move to |
| `train` | the update train the system follows |
| `check_error` | why the check could not answer; null whenever `update_available` is `true` or `false` |
| `version_error` | why the running version could not be read |

## Why three-valued

A system that is up to date and one that could not be asked — air-gapped, no route to the update server — both have no update to report, and across a fleet they are opposite answers: the first needs nothing, the second has not been checked at all and may not have been for months. So `update_available` is `null` rather than `false` when the check did not complete, and `check_error` says what the system said. A boolean here would read an unreachable update server as good news.

A status sent beside an `ERROR` code is not read as an answer either. `code` is the system's own verdict on its own check, and a stale or partial status behind a failed check is exactly what must not report as "up to date".

## Two reads

`update.status` carries the train, the profile and the candidate version, but never the version the system is on — its own `current_version` names the train, the profile and whether the two agree, and nothing else. The running version is therefore a second call to `system.version`, issued alongside rather than after.

That read is reported rather than fatal, following `directory_services_status` in `accounts.ts`: the question the tool is asked is answered by `update.status` on its own, so losing the version a system is moving *from* must not lose the answer. `current_version` is reported even when the check itself failed, and `version_error` names a read that failed.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run clean locally. 508 tests pass; coverage is 99.4% statements / 99.37% branches against floors of 97 / 96, and every branch of the new code is covered. The exact-list assertion in `describe('createDefaultCatalog')` and the README's read-only family line are both updated.

## Review

The shared reviewer ran here — the same reviewer, rubric and threshold as the required check — and its round returned nothing at or above MEDIUM. It raised three LOWs, left unfixed deliberately, because every fix is a new diff and a new round:

- **`checkFailure` guards `report.error` with `!== null` and then dereferences it, so a payload omitting the field entirely would throw.** Unreachable within the client's declared type (`error` is `UpdateStatusError | null`, not optional) but less defensive than the rest of the file. A `?? null` on the read would close it.
- **The description does not spell out that `new_version` can be null while `update_available` is true** — a system that reports an update whose version string is empty. The description says `new_version` "is null unless `update_available` is true", which does not claim the converse, so nothing in it is false; it is an omission rather than a contradiction. The behaviour is asserted by a test.
- **A rejection from `update.status` itself throws out of the handler and discards the `system.version` result that was read successfully**, and that path has no test. This is deliberate — the fan-out turns a thrown tool into a structured per-system failure, and a system whose update status could not be fetched at all has no answer to give — but the asymmetry with `version_error` is worth naming.

None blocks the build; all three are visible to the reviewer on this PR and any of them could be a follow-up ticket.
