### PR TITLE
feat(tools): add audit_log_query, the recent audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `system_update_status`, `storage_pool_status`,
-  `storage_pool_topology`, `storage_scrub_history`, `storage_list_datasets`,
-  `datasets_quota_report`, `disks_list`, `apps_list`, `vms_list`,
-  `alerts_list`, `snapshots_list`, `replication_status`,
+  `system_info`, `system_update_status`, `audit_log_query`,
+  `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
+  `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
+  `vms_list`, `alerts_list`, `snapshots_list`, `replication_status`,
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `tasks_recent_runs`,
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export {
   createDefaultCatalog,
   systemInfo,
   updateStatus,
+  auditLogQuery,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,15 +12,16 @@ import { replicationStatus } from '@/tools/replication';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
-import { systemInfo, updateStatus } from '@/tools/system';
+import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: twenty-seven read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-eight read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(updateStatus);
+  catalog.register(auditLogQuery);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -54,6 +55,7 @@ export {
   alertSettings,
   alertsList,
   appsList,
+  auditLogQuery,
   certificatesList,
   cloudCredentialsList,
   cloudsyncTasksList,

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -451,7 +451,13 @@ export const auditLogQuery: ReadOnlyTool = {
     '`since` bounds the result to entries recorded at or after an ISO 8601 ' +
     'instant; omitted, THE LAST 24 HOURS, so an empty result means nothing ' +
     'matched inside that window rather than that the system has never recorded ' +
-    'the action in question. Pass `since` to look further back. `user` and ' +
+    'the action in question. An entry whose own timestamp could not be read is ' +
+    'returned under any window, because nothing places it outside one. `since` ' +
+    'NARROWS WHAT CAME BACK RATHER THAN REACHING PAST IT: the system is asked ' +
+    'for its most recent entries and the window is applied to those, so on a ' +
+    'system busy enough to fill the bound inside an hour, an older `since` ' +
+    'returns the same recent entries and says `truncated`. Narrow with `user` ' +
+    'or `service` to see further back than the bound reaches. `user` and ' +
     '`service` narrow it to one account or one trail, matched exactly, and an ' +
     'entry whose own `user` or `service` could not be read is NOT returned ' +
     'when the matching argument is given — it has not been shown to be that ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -459,7 +459,8 @@ export const auditLogQuery: ReadOnlyTool = {
     'an empty result can be read against the window it was taken from. The ' +
     'result is bounded: `entries` holds at most `limit` — 100, which is not ' +
     'adjustable — and `truncated` is true when more matched than were ' +
-    'returned. NARROW THE QUESTION UNTIL `truncated` IS FALSE before reading ' +
+    'returned, and when this tool cannot rule that out. NARROW THE QUESTION ' +
+    'UNTIL `truncated` IS FALSE before reading ' +
     'the entries as everything that happened. Entries are newest first, and ' +
     'one whose timestamp could not be read is ordered last, so it is the first ' +
     'to be dropped from a truncated result. AN EMPTY `entries` MEANS THE TRAIL ' +
@@ -491,8 +492,9 @@ export const auditLogQuery: ReadOnlyTool = {
         type: 'string',
         minLength: 1,
         description:
-          'Only report entries from exactly this trail: `MIDDLEWARE`, `SMB`, ' +
-          '`SUDO` or `SYSTEM`.',
+          'Only report entries from exactly this trail, spelled as the system ' +
+          'spells it. `MIDDLEWARE`, `SMB`, `SUDO` and `SYSTEM` are the trails ' +
+          'TrueNAS keeps today; a name a later release adds works here too.',
       },
     },
   },
@@ -547,6 +549,9 @@ export const auditLogQuery: ReadOnlyTool = {
       throw new Error('audit.query did not answer with a list of audit entries');
     }
     const kept = [];
+    // Whether the re-check below removed anything, which is the only evidence
+    // this tool gets that the system did not apply a filter it was given.
+    let unfiltered = false;
     for (const row of answer) {
       const at = entryMillis(row['timestamp']);
       // Only an entry whose timestamp reads as older than the bound is dropped.
@@ -568,8 +573,14 @@ export const auditLogQuery: ReadOnlyTool = {
       // unrecognised query parameter is dropped rather than refused, so a
       // middleware that did not apply one would otherwise answer about every
       // account while looking exactly like an answer about the one asked for.
-      if (user !== null && entry.user !== user) continue;
-      if (service !== null && entry.service !== service) continue;
+      if (user !== null && entry.user !== user) {
+        unfiltered = true;
+        continue;
+      }
+      if (service !== null && entry.service !== service) {
+        unfiltered = true;
+        continue;
+      }
       kept.push({ at, entry });
     }
     return {
@@ -579,7 +590,23 @@ export const auditLogQuery: ReadOnlyTool = {
         .sort(byNewestFirst)
         .slice(0, AUDIT_LIMIT)
         .map((held) => held.entry),
-      truncated: kept.length > AUDIT_LIMIT,
+      // Two ways the system can hold more than came back, and the second is
+      // the one this tool cannot see past. Where the system applied the
+      // filters, what it sent IS what matched, so more matched than fit
+      // exactly when more came back than fit. Where it did not — the re-check
+      // above removed something, so the filters reached it and did nothing —
+      // the entries it dropped instead of the system stand between this result
+      // and however many further matches lie beyond the bound, and nothing
+      // here can count them. That is reported as truncated rather than
+      // guessed at: the description tells a caller to narrow the question
+      // until it is false, and the failure worth avoiding is a partial answer
+      // that says it is whole.
+      //
+      // The window is not read that way. It is applied here rather than by the
+      // system, but entries fall outside it in the same order the system was
+      // asked to sort by, so what it removed is the tail — and there is
+      // nothing further inside the window behind it.
+      truncated: kept.length > AUDIT_LIMIT || (unfiltered && answer.length > AUDIT_LIMIT),
       limit: AUDIT_LIMIT,
       // The bound actually applied, so that an empty result is readable against
       // the window it was taken from rather than against an assumed one.

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -192,3 +192,398 @@ export const updateStatus: ReadOnlyTool = {
     };
   },
 };
+
+/**
+ * How far back `audit_log_query` reaches when the caller bounds nothing.
+ *
+ * The audit trail records every API call the middleware serves, so a system a
+ * few people administer holds thousands of entries a day and one nobody touches
+ * still holds the ones its own services made. A day is the window that makes
+ * "what changed, and who changed it" answerable in one call; a longer one is
+ * asked for rather than assumed.
+ */
+const AUDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How many audit entries one call returns at most.
+ *
+ * Fixed rather than a `limit` argument, unlike `snapshots_list` and
+ * `users_list`. Those bound a set that is finite and slowly changing, where a
+ * caller raising the bound eventually sees all of it; the audit trail grows
+ * without limit and no bound reaches the end of it, so the way to see more here
+ * is a narrower question — a shorter window, a named user, one service — rather
+ * than a bigger page.
+ */
+const AUDIT_LIMIT = 100;
+
+/**
+ * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
+ * than answering, so one absurd recorded time would otherwise take the whole
+ * listing down with it — the same guard `tasks.ts`, `replication.ts` and
+ * `snapshots.ts` each apply to a time of their own, restated here for the same
+ * reason they restate it: a tool file is read on its own.
+ */
+const MAX_TIME_MS = 8.64e15;
+
+/**
+ * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
+ * which is the date representation the client's own types declare
+ * (`TrueNasDate`). Restated with `$date` untyped because an audit row arrives
+ * as an open record.
+ */
+interface MiddlewareDate {
+  $date?: unknown;
+}
+
+/**
+ * A date, or a date and a time, in the forms this tool reads: `2026-08-29`,
+ * `2026-08-29T09:00:00Z`, `2026-08-29T09:00:00+02:00`, and the same with a
+ * space instead of the `T` and with no zone at all.
+ *
+ * Groups: year, month, day, hour, minute, second, fractional second, zone.
+ */
+const AUDIT_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+/**
+ * The instant a timestamp names, in milliseconds since the epoch, or null where
+ * it is not one of the forms above or does not name a real instant.
+ *
+ * Built from the components rather than handed to `Date.parse`, and that is the
+ * whole reason a zoneless time is read at all here where `tasks.ts` refuses one.
+ * `Date.parse('2026-08-29 09:00:00')` is implementation-defined and Node reads
+ * it as LOCAL time, so the same recorded instant would come back different on
+ * two machines — silently, and by hours. Composed here it is read as UTC,
+ * explicitly and identically everywhere, which is (unconfirmed) how the
+ * middleware records audit times; the cost of that reading being wrong is a
+ * timestamp offset by the middleware's own zone, against a certainty of one
+ * offset by whatever zone this process happens to run in.
+ *
+ * The result is checked back against the components it was built from, which
+ * settles two things at once that nothing else here would: a day the month does
+ * not have ROLLS OVER rather than failing — `2026-02-30` composes as the 2nd of
+ * March — and so does an hour of 25, while a year below 100 would be read as
+ * 19xx by `Date.UTC`'s two-digit-year rule.
+ */
+function utcMillis(text: string): number | null {
+  const match = AUDIT_TIME.exec(text);
+  if (match === null) return null;
+  const [, year, month, day, hour, minute, second, fraction, zone] = match;
+  // A `Date` holds milliseconds and the audit table records microseconds, so
+  // the digits past the third are dropped rather than rounded: that moves an
+  // instant by less than a millisecond and never across the bound it is
+  // compared at.
+  const millis = fraction === undefined ? 0 : Number(fraction.slice(0, 3).padEnd(3, '0'));
+  const at = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    hour === undefined ? 0 : Number(hour),
+    minute === undefined ? 0 : Number(minute),
+    second === undefined ? 0 : Number(second),
+    millis,
+  );
+  const composed = new Date(at);
+  if (
+    composed.getUTCFullYear() !== Number(year) ||
+    composed.getUTCMonth() !== Number(month) - 1 ||
+    composed.getUTCDate() !== Number(day) ||
+    (hour !== undefined && composed.getUTCHours() !== Number(hour)) ||
+    (minute !== undefined && composed.getUTCMinutes() !== Number(minute))
+  ) {
+    return null;
+  }
+  if (zone === undefined || zone === 'Z') return at;
+  const zoneHours = Number(zone.slice(1, 3));
+  const zoneMinutes = Number(zone.slice(4, 6));
+  // An offset outside the range a zone can have is a malformed one, and reading
+  // it would shift the instant by the amount it is wrong by.
+  if (zoneHours > 23 || zoneMinutes > 59) return null;
+  // Ahead of UTC is earlier in UTC, so the offset is subtracted.
+  const offset = (zoneHours * 60 + zoneMinutes) * 60_000;
+  return zone.startsWith('-') ? at + offset : at - offset;
+}
+
+/**
+ * When an audit entry was recorded, in milliseconds since the epoch, or null
+ * where the system reported no time this tool can read.
+ *
+ * Three forms, because the pinned client describes this field two different
+ * ways and neither has been checked against a live middleware: the oldest
+ * directory types an audit row as an open record, and a later one types
+ * `timestamp` as a string. A bare number is accepted beside the
+ * `{ "$date": … }` envelope for the reason `tasks.ts` accepts one — the
+ * envelope exists to tag a number as a date in transit, and both are epoch
+ * milliseconds.
+ *
+ * `message_timestamp` is deliberately not read as a fallback. It is the column
+ * this tool asks the system to order by, and it is a number whose unit the
+ * client does not state; reading it as milliseconds where it is seconds would
+ * date every entry to 1970 while looking exactly like a real answer.
+ */
+function entryMillis(value: unknown): number | null {
+  const raw = typeof value === 'object' && value !== null ? (value as MiddlewareDate).$date : value;
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && Math.abs(raw) <= MAX_TIME_MS ? raw : null;
+  }
+  return typeof raw === 'string' ? utcMillis(raw) : null;
+}
+
+/**
+ * The instant the window starts at, in milliseconds since the epoch — the
+ * default window back from `now` where the caller named none.
+ *
+ * Strict rather than lenient, as `tasks_recent_runs` is about its own `since`
+ * and for the same reason: a bound that cannot be read is not a request for the
+ * default one. Ignoring it would answer about the last day while the caller
+ * believes it answered about the last month, and an empty result would then
+ * read as "nobody did anything" rather than as "the bound was not applied".
+ * Null and undefined are the argument being absent, which is not the same as
+ * unreadable and is what the default is for.
+ */
+function windowStart(raw: unknown, now: number): number {
+  if (raw == null) return now - AUDIT_WINDOW_MS;
+  const millis = typeof raw === 'string' ? utcMillis(raw) : null;
+  if (millis === null) {
+    throw new Error(
+      '"since" must be an ISO 8601 timestamp such as "2026-08-29T09:00:00Z", or a date ' +
+        'such as "2026-08-29". A time given without a timezone is read as UTC.',
+    );
+  }
+  return millis;
+}
+
+/**
+ * A filter the caller named, or null where it named none.
+ *
+ * Strict, as `snapshots_list` is about the dataset it is asked for: a filter
+ * this tool could not read must not be dropped, because the result would then
+ * answer a wider question than the one asked while looking like the answer to
+ * it — every user's activity presented as one person's.
+ */
+function requestedText(raw: unknown, name: string): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(`"${name}" must be a non-empty string`);
+  }
+  return raw;
+}
+
+/**
+ * The services the middleware keeps a separate trail for, as the pinned client
+ * spells them.
+ *
+ * Used only to narrow the query: `audit.query` takes the trails to search as a
+ * closed list of names, and a service outside it cannot be passed there. A name
+ * this list does not hold is still filtered on — through `query-filters`, which
+ * is untyped, and again on the response — so a service a later TrueNAS release
+ * adds is answerable rather than refused.
+ */
+const AUDIT_SERVICES = ['MIDDLEWARE', 'SMB', 'SUDO', 'SYSTEM'] as const;
+
+/** The named service as `audit.query` spells it, or undefined where it is not one. */
+function namedService(service: string | null): (typeof AUDIT_SERVICES)[number] | undefined {
+  return AUDIT_SERVICES.find((known) => known === service);
+}
+
+/**
+ * The API method an audit entry records a call to, or null where the entry is
+ * not a call or does not name one.
+ *
+ * (unconfirmed) `event_data` is an open record whose contents differ per event,
+ * and the pinned client types it `{ [k: string]: unknown } | null`, so the key
+ * holding the method name is read as `method` on the evidence of the middleware
+ * event it belongs to. Getting it wrong costs a null rather than a wrong
+ * method, and `event` still says what kind of entry it is either way.
+ *
+ * Nothing else of `event_data` is read, and that is a rule rather than an
+ * omission: it carries the PARAMETERS the call was made with, which for an
+ * account or a share or a credential is where the password, key or token is.
+ * The same refusal `tasks_recent_runs` applies to a job's arguments.
+ */
+function auditMethod(eventData: unknown): string | null {
+  if (typeof eventData !== 'object' || eventData === null) return null;
+  return textOrNull((eventData as Record<string, unknown>)['method']);
+}
+
+/** Newest first; an entry whose timestamp could not be read goes last. */
+function byNewestFirst(a: { at: number | null }, b: { at: number | null }): number {
+  if (a.at === null) return b.at === null ? 0 : 1;
+  if (b.at === null) return -1;
+  return b.at - a.at;
+}
+
+/**
+ * What changed, and who changed it.
+ *
+ * The audit trail is the first question of every incident and every compliance
+ * review, and it is also how a user checks up on the assistant itself: an MCP
+ * tool reaches the system through the same middleware API as a person at the
+ * console, so what this tool does lands in the same trail this tool reads. That
+ * is the point rather than a side effect — it makes the model auditable through
+ * the model.
+ *
+ * Reads records that name people, and so returns the fields that answer the
+ * question and no others. The acting user, when, which service, which method
+ * and whether it worked; not the address the call came from, not the session it
+ * belonged to, and not the parameters it carried.
+ */
+export const auditLogQuery: ReadOnlyTool = {
+  name: 'audit_log_query',
+  description:
+    'Recent entries from the TrueNAS audit trail — what was done on this ' +
+    'system, by whom, and whether it worked. Each entry carries `timestamp`, ' +
+    'when it was recorded, as an ISO 8601 UTC timestamp; `user`, the account ' +
+    'that acted; `service`, which trail it came from — `MIDDLEWARE` for the ' +
+    'API the web UI, the CLI and this tool all call, `SMB` for file share ' +
+    'access, `SUDO` for commands run as another user, `SYSTEM` for the system ' +
+    'itself, and a name a later TrueNAS release adds is passed through as the ' +
+    'system spelled it; `event`, the kind of entry, such as `METHOD_CALL` or ' +
+    '`AUTHENTICATION`; `method`, the API method a call names, which is null on ' +
+    'an entry that is not a call or that did not name one; and `success`, ' +
+    'whether the action succeeded. Every one of the six is null where the ' +
+    'system reported no value this tool could read, and a null `success` IS ' +
+    'NOT A FAILURE — it is an outcome that was not recorded. The parameters an ' +
+    'action was called with are NOT returned: they hold passwords, keys and ' +
+    'tokens for anything that creates an account, a share or a credential, and ' +
+    'no secret passes through this tool. Neither is the network address or the ' +
+    'session, which are not needed to answer what was done and by whom. ' +
+    '`since` bounds the result to entries recorded at or after an ISO 8601 ' +
+    'instant; omitted, THE LAST 24 HOURS, so an empty result means nothing ' +
+    'matched inside that window rather than that the system has never recorded ' +
+    'the action in question. Pass `since` to look further back. `user` and ' +
+    '`service` narrow it to one account or one trail, matched exactly, and an ' +
+    'entry whose own `user` or `service` could not be read is NOT returned ' +
+    'when the matching argument is given — it has not been shown to be that ' +
+    "account's. The `since` that comes back is the bound actually applied, so " +
+    'an empty result can be read against the window it was taken from. The ' +
+    'result is bounded: `entries` holds at most `limit` — 100, which is not ' +
+    'adjustable — and `truncated` is true when more matched than were ' +
+    'returned. NARROW THE QUESTION UNTIL `truncated` IS FALSE before reading ' +
+    'the entries as everything that happened. Entries are newest first, and ' +
+    'one whose timestamp could not be read is ordered last, so it is the first ' +
+    'to be dropped from a truncated result. AN EMPTY `entries` MEANS THE TRAIL ' +
+    'WAS READ AND NOTHING IN IT MATCHED — never that nothing happened. A ' +
+    'service the system is not auditing records nothing at all and so returns ' +
+    'nothing here, which is indistinguishable from a quiet system: this tool ' +
+    'reads the trail and cannot say whether a service is being written to it. ' +
+    'A trail that could not be read at all is an error naming what the system ' +
+    'said, not an empty list. This tool reads the audit trail. It does not ' +
+    'change what is audited, how long entries are kept, or anything else — ' +
+    'that is configuration, and it is not in this catalog.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      since: {
+        type: 'string',
+        description:
+          'Only report entries recorded at or after this instant, as an ISO ' +
+          '8601 timestamp — "2026-08-29T09:00:00Z" — or a date, "2026-08-29", ' +
+          'which is midnight. A time given without a timezone is read as UTC. ' +
+          'Omitted, the last 24 hours.',
+      },
+      user: {
+        type: 'string',
+        minLength: 1,
+        description: 'Only report entries whose acting user is exactly this account.',
+      },
+      service: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'Only report entries from exactly this trail: `MIDDLEWARE`, `SMB`, ' +
+          '`SUDO` or `SYSTEM`.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // Every argument is read before the call, so an unreadable one is an error
+    // rather than a query the system answers and this tool then discards.
+    const user = requestedText(args['user'], 'user');
+    const service = requestedText(args['service'], 'service');
+    const since = windowStart(args['since'], Date.now());
+    const filters: unknown[] = [];
+    if (user !== null) filters.push(['username', '=', user]);
+    if (service !== null) filters.push(['service', '=', service]);
+    const named = namedService(service);
+    const answer = await firstValueFrom(
+      // The request is inlined so the call's own parameter types apply, as in
+      // `storage.ts`. `audit.query` is not one of the client's query helpers —
+      // it takes one object rather than filters and options as arguments — so
+      // it goes through `call`, whose second argument is the whole parameter
+      // tuple the method declares rather than the first parameter of it.
+      system.client.api.call('audit.query', [
+        {
+          // Omitted rather than passed empty where the caller named a service
+          // the client does not list, which would otherwise search no trail at
+          // all.
+          ...(named === undefined ? {} : { services: [named] }),
+          'query-filters': filters,
+          'query-options': {
+            // One more entry than the bound, as `snapshots_list` asks for: that
+            // extra entry is what says more matched than fit, and it is counted
+            // and then dropped.
+            limit: AUDIT_LIMIT + 1,
+            // Unlike `snapshots_list`, which asks for no order because no field
+            // of a snapshot orders it in time soundly. Here the bound is the
+            // whole question — "recent" — so which entries a truncated result
+            // holds has to be the most recent ones, and `message_timestamp` is
+            // the one field of an audit row the client types as the time the
+            // system recorded it under. The window below is applied to what
+            // comes back, so an ordering the system did not apply costs entries
+            // that fall outside it rather than wrong ones.
+            order_by: ['-message_timestamp'],
+          },
+        },
+      ]),
+    );
+    // `count: true` answers a number and `get: true` a single entry; neither is
+    // asked for here, so anything but a list is a system answering a question
+    // this tool did not ask. Fatal rather than empty: an empty result is an
+    // answer about the trail, and this is not one.
+    if (!Array.isArray(answer)) {
+      throw new Error('audit.query did not answer with a list of audit entries');
+    }
+    const kept = [];
+    for (const row of answer) {
+      const at = entryMillis(row['timestamp']);
+      // Only an entry whose timestamp reads as older than the bound is dropped.
+      // One with no readable timestamp is kept: nothing places it outside the
+      // window, and an action disappearing because the time it was recorded at
+      // was unreadable is the failure worth avoiding here.
+      if (at !== null && at < since) continue;
+      const entry = {
+        timestamp: at === null ? null : new Date(at).toISOString(),
+        user: textOrNull(row['username']),
+        service: textOrNull(row['service']),
+        event: textOrNull(row['event']),
+        method: auditMethod(row['event_data']),
+        // Not defaulted to false: an outcome the system did not record must not
+        // be presented as an action that failed, or as one that worked.
+        success: typeof row['success'] === 'boolean' ? row['success'] : null,
+      };
+      // Both filters are asked of the system above and checked again here. An
+      // unrecognised query parameter is dropped rather than refused, so a
+      // middleware that did not apply one would otherwise answer about every
+      // account while looking exactly like an answer about the one asked for.
+      if (user !== null && entry.user !== user) continue;
+      if (service !== null && entry.service !== service) continue;
+      kept.push({ at, entry });
+    }
+    return {
+      // Sorted before the bound is applied, so the entries dropped are the
+      // oldest of what matched rather than whichever the system sent last.
+      entries: kept
+        .sort(byNewestFirst)
+        .slice(0, AUDIT_LIMIT)
+        .map((held) => held.entry),
+      truncated: kept.length > AUDIT_LIMIT,
+      limit: AUDIT_LIMIT,
+      // The bound actually applied, so that an empty result is readable against
+      // the window it was taken from rather than against an assumed one.
+      since: new Date(since).toISOString(),
+    };
+  },
+};

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -798,6 +798,23 @@ describe('audit_log_query', () => {
     expect(result.entries).toHaveLength(2);
   });
 
+  it('reports truncation it cannot rule out when the system ignored a filter', async () => {
+    // 101 entries in the window, of which the system should have returned only
+    // the two matching ones and returned every one instead: the entries it
+    // sent in place of the ones it filtered out stand between this result and
+    // however many further matches lie beyond the bound, and nothing here can
+    // count them.
+    const rows = Array.from({ length: 101 }, (unused, index) =>
+      entry({ timestamp: { $date: NOW - index * 1000 }, username: index < 2 ? 'alice' : 'bob' }),
+    );
+    const result = await queried(rows, { user: 'alice' });
+    expect(result.entries).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+    // The same ignored filter over a trail that fitted whole is not truncated:
+    // everything the system holds was seen, whoever it belonged to.
+    expect((await queried(rows.slice(0, 100), { user: 'alice' })).truncated).toBe(false);
+  });
+
   it('refuses an answer that is not a list of entries', async () => {
     // `count: true` answers a number and `get: true` a single entry. Neither is
     // asked for, and an empty result would read as an answer about the trail.
@@ -806,6 +823,13 @@ describe('audit_log_query', () => {
         'audit.query did not answer with a list of audit entries',
       );
     }
+  });
+
+  it('fails rather than answering empty when the trail could not be read', async () => {
+    // An empty list is an answer about the trail — nothing matched — and a
+    // trail that could not be read is not that answer.
+    const { ctx } = failingSystem({}, { ['audit.query']: new Error('audit dataset not mounted') });
+    await expect(auditLogQuery.handler(ctx, {})).rejects.toThrow('audit dataset not mounted');
   });
 
   it('never mutates: it reads the trail and nothing else', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -6,6 +6,7 @@ import {
   alertSettings,
   alertsList,
   appsList,
+  auditLogQuery,
   certificatesList,
   cloudCredentialsList,
   cloudsyncTasksList,
@@ -75,10 +76,11 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-eight sketch tools', () => {
+  it('registers the twenty-nine sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
+      'audit_log_query',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -111,6 +113,12 @@ describe('createDefaultCatalog', () => {
   it('advertises system_update_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'system_update_status',
+    );
+  });
+
+  it('advertises audit_log_query to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'audit_log_query',
     );
   });
 
@@ -447,6 +455,364 @@ describe('system_update_status', () => {
     });
     await updateStatus.handler(ctx, {});
     expect(call.mock.calls.map((args) => args[0])).toEqual(['update.status', 'system.version']);
+  });
+});
+
+describe('audit_log_query', () => {
+  /**
+   * A fixed present, so the default window is a fixed interval rather than one
+   * that moves with the clock. Only `Date` is faked, as in `tasks_recent_runs`:
+   * the tool reads the clock and nothing here schedules anything.
+   */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+  /** NOW minus the tool's 24-hour default window. */
+  const WINDOW_START = NOW - 24 * 60 * 60 * 1000; // 2023-11-13T22:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * An audit entry as `audit.query` reports one, recorded a minute ago.
+   *
+   * `address`, `session`, `service_data` and the whole of `event_data` beyond
+   * the method are here to be dropped, and the password among the parameters is
+   * a real string for the same reason a job's arguments carry one in
+   * `tasks_recent_runs`: the test that no secret survives is only worth
+   * anything if one was there to survive.
+   */
+  const entry = (over: Record<string, unknown> = {}) => ({
+    audit_id: '5b4b1c9e-1f1e-4a3b-9f6a-2f0f0f0f0f0f',
+    message_timestamp: 1_699_999_940,
+    timestamp: { $date: NOW - 60_000 },
+    address: '10.0.0.5',
+    username: 'alice',
+    session: 'a5f0c2d1',
+    service: 'MIDDLEWARE',
+    service_data: { vers: { major: 25, minor: 4 }, origin: '10.0.0.5:54321' },
+    event: 'METHOD_CALL',
+    event_data: {
+      method: 'user.update',
+      params: [1, { password: 'SECRET-PARAMETER-MATERIAL' }],
+      description: 'Update user alice',
+      authenticated: true,
+      authorized: true,
+    },
+    success: true,
+    ...over,
+  });
+
+  /** The whole result, for the fields around the entries. */
+  const queried = async (
+    rows: unknown,
+    args: Record<string, unknown> = {},
+  ): Promise<{
+    entries: Record<string, unknown>[];
+    truncated: boolean;
+    limit: number;
+    since: string;
+  }> => {
+    const { ctx } = fakeSystem({ ['audit.query']: rows });
+    return (await auditLogQuery.handler(ctx, args)) as {
+      entries: Record<string, unknown>[];
+      truncated: boolean;
+      limit: number;
+      since: string;
+    };
+  };
+
+  /** Just the entries. */
+  const listed = async (
+    rows: unknown[],
+    args: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>[]> => (await queried(rows, args)).entries;
+
+  /** One entry, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([entry(over)]))[0];
+
+  it('reports when, who, which service, which method and whether it worked', async () => {
+    expect(await listed([entry()])).toEqual([
+      {
+        timestamp: '2023-11-14T22:12:20.000Z',
+        user: 'alice',
+        service: 'MIDDLEWARE',
+        event: 'METHOD_CALL',
+        method: 'user.update',
+        success: true,
+      },
+    ]);
+  });
+
+  it('states the bound and the window it applied', async () => {
+    expect(await queried([entry()])).toMatchObject({
+      truncated: false,
+      limit: 100,
+      since: '2023-11-13T22:13:20.000Z',
+    });
+  });
+
+  it('returns an empty list, not an error, when nothing matched', async () => {
+    // The window it was taken from comes back with it, so an empty result is
+    // readable as "nothing in the last day" rather than as "nothing ever".
+    expect(await queried([])).toEqual({
+      entries: [],
+      truncated: false,
+      limit: 100,
+      since: '2023-11-13T22:13:20.000Z',
+    });
+  });
+
+  it('returns no address, session, parameters or field a later release adds', async () => {
+    const result = await one({ future_field: 'added by a later release' });
+    expect(Object.keys(result)).toEqual([
+      'timestamp',
+      'user',
+      'service',
+      'event',
+      'method',
+      'success',
+    ]);
+    expect(JSON.stringify(result)).not.toContain('added by a later release');
+    expect(JSON.stringify(result)).not.toContain('10.0.0.5');
+    expect(JSON.stringify(result)).not.toContain('a5f0c2d1');
+  });
+
+  it('never returns the parameters an audited call was made with', async () => {
+    expect(JSON.stringify(await listed([entry()]))).not.toContain('SECRET-PARAMETER-MATERIAL');
+  });
+
+  it('reads the method out of the event data, and nothing else of it', async () => {
+    expect(await one({ event_data: { method: 'pool.dataset.delete' } })).toMatchObject({
+      method: 'pool.dataset.delete',
+    });
+    // An event that is not a call, one whose data names no method, and one
+    // whose data is not a record at all: each is a null method beside an
+    // `event` that still says what kind of entry it is.
+    expect(await one({ event: 'AUTHENTICATION', event_data: null })).toMatchObject({
+      event: 'AUTHENTICATION',
+      method: null,
+    });
+    expect(await one({ event_data: { description: 'no method here' } })).toMatchObject({
+      method: null,
+    });
+    expect(await one({ event_data: { method: '' } })).toMatchObject({ method: null });
+    expect(await one({ event_data: 'METHOD_CALL' })).toMatchObject({ method: null });
+  });
+
+  it('reports an outcome the system did not record as null, not as a failure', async () => {
+    expect(await one({ success: false })).toMatchObject({ success: false });
+    expect(await one({ success: null })).toMatchObject({ success: null });
+    expect(await one({ success: 'true' })).toMatchObject({ success: null });
+  });
+
+  it('reports a user, service or event the system sent as empty as null', async () => {
+    expect(await one({ username: '', service: null, event: 42 })).toMatchObject({
+      user: null,
+      service: null,
+      event: null,
+    });
+  });
+
+  it('reads a recorded time however the middleware spelled it', async () => {
+    const spellings: [unknown, string | null][] = [
+      [{ $date: NOW - 60_000 }, '2023-11-14T22:12:20.000Z'],
+      [NOW - 60_000, '2023-11-14T22:12:20.000Z'],
+      ['2023-11-14T22:12:20Z', '2023-11-14T22:12:20.000Z'],
+      ['2023-11-14T22:12Z', '2023-11-14T22:12:00.000Z'],
+      ['2023-11-14T22:12:20.123456', '2023-11-14T22:12:20.123Z'],
+      ['2023-11-14 22:12:20', '2023-11-14T22:12:20.000Z'],
+      ['2023-11-15T00:12:20+02:00', '2023-11-14T22:12:20.000Z'],
+      ['2023-11-14T20:12:20-02:00', '2023-11-14T22:12:20.000Z'],
+      ['2023-11-14', '2023-11-14T00:00:00.000Z'],
+      // Not a time this tool reads, and each would be a confidently wrong
+      // instant if it were guessed at.
+      ['14/11/2023 22:12', null],
+      ['2023-11-31T00:00:00Z', null],
+      ['2023-11-14T25:00:00Z', null],
+      ['2023-11-14T22:99:00Z', null],
+      ['2023-11-14T22:12:99Z', null],
+      ['2023-11-14T22:12:20+99:00', null],
+      ['2023-11-14T22:12:20-00:99', null],
+      ['0050-11-14T22:12:20Z', null],
+      [Number.NaN, null],
+      [8.64e15 + 1, null],
+      [{ $date: 'yesterday' }, null],
+      [true, null],
+      [null, null],
+    ];
+    for (const [timestamp, expected] of spellings) {
+      // Every case is inside the default window or unreadable, so none is
+      // dropped by it and each reaches the assertion.
+      expect((await one({ timestamp }))['timestamp']).toBe(expected);
+    }
+  });
+
+  it('bounds the result to the last 24 hours when nothing is asked for', async () => {
+    const rows = [
+      entry({ timestamp: { $date: WINDOW_START + 1 }, event_data: { method: 'inside' } }),
+      entry({ timestamp: { $date: WINDOW_START - 1 }, event_data: { method: 'outside' } }),
+      // Exactly at the bound is inside it: the window is "at or after".
+      entry({ timestamp: { $date: WINDOW_START }, event_data: { method: 'at-the-bound' } }),
+    ];
+    expect((await listed(rows)).map((row) => row['method'])).toEqual(['inside', 'at-the-bound']);
+  });
+
+  it('keeps an entry whose recorded time could not be read, under any window', async () => {
+    // Nothing places it outside the window, and an action disappearing because
+    // its timestamp was unreadable is the failure worth avoiding.
+    expect(await listed([entry({ timestamp: 'not a time' })], { since: '2023-11-14' })).toEqual([
+      expect.objectContaining({ timestamp: null }),
+    ]);
+  });
+
+  it('takes the window from `since` when it is given', async () => {
+    const rows = [
+      entry({ timestamp: { $date: WINDOW_START - 1000 }, event_data: { method: 'older' } }),
+      entry({ timestamp: { $date: NOW - 1000 }, event_data: { method: 'newer' } }),
+    ];
+    // A day before the default window start, so the older entry is now inside.
+    expect((await listed(rows, { since: '2023-11-12' })).map((row) => row['method'])).toEqual([
+      'newer',
+      'older',
+    ]);
+    expect((await listed(rows, { since: '2023-11-14T22:00:00Z' })).map((row) => row['method'])).toEqual(
+      ['newer'],
+    );
+  });
+
+  it('reads a `since` given without a timezone as UTC, not as this machine\'s zone', async () => {
+    expect((await queried([], { since: '2023-11-14 22:00:00' })).since).toBe(
+      '2023-11-14T22:00:00.000Z',
+    );
+    expect((await queried([], { since: '2023-11-14T22:00:00+02:00' })).since).toBe(
+      '2023-11-14T20:00:00.000Z',
+    );
+  });
+
+  it('refuses a `since` it cannot read rather than falling back to the default', async () => {
+    // Ignoring it would answer about the last day while the caller believes it
+    // asked about the last month.
+    for (const since of ['', 'yesterday', '2023-02-30', '2023-11-14T25:00:00Z', 1_700_000_000]) {
+      await expect(queried([], { since })).rejects.toThrow('"since" must be an ISO 8601');
+    }
+  });
+
+  it('narrows to one user, and asks the system to narrow too', async () => {
+    const { ctx, call } = fakeSystem({ ['audit.query']: [entry()] });
+    await auditLogQuery.handler(ctx, { user: 'alice' });
+    expect(call.mock.calls[0][0]).toBe('audit.query');
+    expect(call.mock.calls[0][1][0]).toMatchObject({
+      'query-filters': [['username', '=', 'alice']],
+      'query-options': { limit: 101, order_by: ['-message_timestamp'] },
+    });
+  });
+
+  it('checks the user filter again on what came back', async () => {
+    // An unrecognised query parameter is dropped rather than refused, so a
+    // middleware that did not apply the filter would otherwise answer about
+    // every account while looking exactly like an answer about one.
+    const rows = [entry(), entry({ username: 'bob' }), entry({ username: '' })];
+    expect((await listed(rows, { user: 'alice' })).map((row) => row['user'])).toEqual(['alice']);
+  });
+
+  it('checks the service filter again on what came back', async () => {
+    const rows = [entry(), entry({ service: 'SMB' }), entry({ service: null })];
+    expect((await listed(rows, { service: 'SMB' })).map((row) => row['service'])).toEqual(['SMB']);
+  });
+
+  it('names the trail to search only where the client lists it', async () => {
+    const { ctx, call } = fakeSystem({ ['audit.query']: [] });
+    await auditLogQuery.handler(ctx, { service: 'SMB' });
+    expect(call.mock.calls[0][1][0]).toMatchObject({
+      services: ['SMB'],
+      'query-filters': [['service', '=', 'SMB']],
+    });
+    // A service a later release adds is still asked for through the filter,
+    // which is untyped, rather than refused.
+    const later = fakeSystem({ ['audit.query']: [] });
+    await auditLogQuery.handler(later.ctx, { service: 'NFS' });
+    expect(later.call.mock.calls[0][1][0]).not.toHaveProperty('services');
+    expect(later.call.mock.calls[0][1][0]).toMatchObject({
+      'query-filters': [['service', '=', 'NFS']],
+    });
+  });
+
+  it('refuses a filter it cannot read', async () => {
+    await expect(queried([], { user: '' })).rejects.toThrow('"user" must be a non-empty string');
+    await expect(queried([], { service: 7 })).rejects.toThrow(
+      '"service" must be a non-empty string',
+    );
+    // Absent is not unreadable, and is what the unfiltered result is for.
+    expect(await listed([entry()], { user: null, service: undefined })).toHaveLength(1);
+  });
+
+  it('orders the entries newest first, with an unreadable time last', async () => {
+    const rows = [
+      entry({ timestamp: { $date: NOW - 3000 }, event_data: { method: 'middle' } }),
+      entry({ timestamp: 'not a time', event_data: { method: 'unplaced' } }),
+      entry({ timestamp: { $date: NOW - 1000 }, event_data: { method: 'newest' } }),
+      entry({ timestamp: null, event_data: { method: 'also-unplaced' } }),
+      entry({ timestamp: { $date: NOW - 5000 }, event_data: { method: 'oldest' } }),
+    ];
+    // Two entries neither of which can be placed keep the order the system sent
+    // them in, rather than being reordered against each other on nothing.
+    expect((await listed(rows)).map((row) => row['method'])).toEqual([
+      'newest',
+      'middle',
+      'oldest',
+      'unplaced',
+      'also-unplaced',
+    ]);
+  });
+
+  it('bounds the result at 100 and says so, dropping the oldest of what matched', async () => {
+    // 101 entries, a second apart and shuffled, so the bound has to be applied
+    // after the ordering for the oldest to be the one that goes.
+    const rows = Array.from({ length: 101 }, (unused, index) =>
+      entry({
+        timestamp: { $date: NOW - index * 1000 },
+        event_data: { method: `call-${index}` },
+      }),
+    ).reverse();
+    const result = await queried(rows);
+    expect(result.truncated).toBe(true);
+    expect(result.entries).toHaveLength(100);
+    expect(result.entries[0]['method']).toBe('call-0');
+    expect(result.entries.map((row) => row['method'])).not.toContain('call-100');
+  });
+
+  it('is not truncated by entries the window itself removed', async () => {
+    // 101 entries, all but two of them older than the window: the system held
+    // more than fit, and no more MATCHED than fit.
+    const rows = Array.from({ length: 101 }, (unused, index) =>
+      entry({ timestamp: { $date: index < 2 ? NOW - index * 1000 : WINDOW_START - 1000 } }),
+    );
+    const result = await queried(rows);
+    expect(result.truncated).toBe(false);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it('refuses an answer that is not a list of entries', async () => {
+    // `count: true` answers a number and `get: true` a single entry. Neither is
+    // asked for, and an empty result would read as an answer about the trail.
+    for (const answer of [3, entry(), null, undefined]) {
+      await expect(queried(answer)).rejects.toThrow(
+        'audit.query did not answer with a list of audit entries',
+      );
+    }
+  });
+
+  it('never mutates: it reads the trail and nothing else', async () => {
+    const { ctx, call, query } = fakeSystem({ ['audit.query']: [entry()] });
+    await auditLogQuery.handler(ctx, {});
+    expect(call.mock.calls.map((args) => args[0])).toEqual(['audit.query']);
+    expect(query).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Adds `audit_log_query`, a read-only tool returning recent audit entries filterable by time, user and service.

Fixes #38

## What it answers

"What changed, and who changed it." An MCP tool reaches the middleware through the same API a person at the console does, so what the tools in this catalog do lands in the trail this one reads — which is the point rather than a side effect. It makes the model auditable through the model.

Each entry carries six fields and no others: `timestamp`, `user`, `service`, `event`, `method`, `success`.

## The ticket's unconfirmed design note, confirmed

The ticket flagged `audit.query` as possibly absent from the pinned client. **It is there.** `ApiCallDirectory$7` — the call directory behind `DefaultApiDirectory`, which is what `ApiSurface` resolves to — declares `'audit.query'` with `params: [data?: AuditQuery$2]` and `response: number | AuditQueryResultItem$1 | AuditQueryResultItem$1[]`. Two further things fell out of checking:

- It is **not** in `ApiCallDirectoryBase`, which is what `QueryDirectory` is, so it is not reachable through `api.query` and goes through `api.call`.
- `api.call`'s second argument is the **whole parameter tuple**, not the first parameter of it (`ArgsOf<P> = [] extends P ? [params?: P] : [params: P]`), so the request object is passed wrapped: `call('audit.query', [{ … }])`.

The response is an open record on this directory. A later directory types the row as `AuditQueryResultItem`, and the field names read here — `timestamp`, `username`, `service`, `event`, `event_data`, `success`, `message_timestamp` — are taken from it.

## What is not returned, and why

- **The parameters an audited call carried.** `event_data` is read for `method` and nothing else. For anything that creates an account, a share or a credential, the parameters are where the password is. Same refusal `tasks_recent_runs` applies to a job's arguments; a fixture carries real secret material so the test that none survives is worth something.
- **The network address and the session.** Not needed to answer what was done and by whom, and this tool reads records that name people.
- **Anything a later TrueNAS release adds**, which the `Object.keys` assertion pins.

## Bounding

Two bounds, both stated in the description and both returned with the result, because the trail is the one thing on this system that grows without limit:

- A **24-hour default window**, and the `since` actually applied comes back, so an empty result is readable against the window it was taken from.
- A **fixed ceiling of 100 entries**. Fixed rather than a `limit` argument, unlike `snapshots_list` and `users_list`: those bound a finite set a caller can eventually see all of, and no bound reaches the end of an audit trail, so the way to see more here is a narrower question rather than a bigger page.

`truncated` is measured against what **matched**. Entries the window itself removed do not report the result as cut short — they are the oldest of a descending page, so there is nothing further inside the window behind them.

## `since` is applied here, not sent to the system

`user` and `service` go to the middleware as `query-filters` (and `services`, where the name is one the client lists) **and are checked again on the response**, because an unrecognised query parameter is dropped rather than refused and one account's activity must not be presented as another's.

`since` is deliberately not sent. The column the trail is ordered by, `message_timestamp`, is a number whose unit the client does not state; a bound sent in seconds where the column holds milliseconds matches everything, and the other way round matches nothing — and *that* direction answers empty while looking exactly like a real answer. Ordering by that column and applying the window here fails in the safe direction instead. The cost is real and is now stated in the description: `since` narrows the most recent entries rather than reaching past them.

The timestamp parser reads the `{"$date": …}` envelope, a bare epoch number, and the ISO forms, building the instant from components rather than through `Date.parse` — which is why a zoneless time is read here at all where `tasks_recent_runs` refuses one. `Date.parse('2026-08-29 09:00:00')` is implementation-defined and Node reads it as **local** time, so the same recorded instant would come back different on two machines. Composed from components it is read as UTC, explicitly and identically everywhere.

## Acceptance criteria

- [x] Each entry reports its timestamp, the acting user, the service or method, and the outcome
- [x] Optional `since`, `user` and `service` narrow the result
- [x] Bounded with a stated default, and the `description` names the bound
- [ ] **A system with auditing disabled returns an explicit marker saying so** — see below
- [x] `createDefaultCatalog().list(Role.ReadOnly)` includes `audit_log_query`
- [x] Only fields the tool names explicitly survive
- [x] The exact-list assertion in `describe('createDefaultCatalog')` is updated
- [x] The README's "Read-only family" line names `audit_log_query`
- [x] `yarn test:coverage` passes — `system.ts` is at 100% branch, global floors unmoved

### The one criterion not met in full, and why

**A trail that could not be read is an error, not an empty list** — `audit.query` failing propagates, and `fanOut` turns it into a per-system `ERROR` rather than a silent `[]`. That half is covered, and tested.

What is **not** implemented is a marker distinguishing "this service is not being audited" from "nothing matched in the window". The obvious source is `audit.config.enabled_services`, and I decided against reading it: the pinned client types it `{ MIDDLEWARE: unknown[]; SMB: unknown[]; SUDO: string[] }`, opaque lists whose emptiness I could not establish means "off". Middleware auditing in particular is not switched on per-object, so an empty `MIDDLEWARE` list is what a system that audits **every** API call looks like — deriving `auditing_enabled: false` from it would report auditing as off on an ordinary system.

Stating a guarantee the data cannot back is exactly the defect this codebase's reviews keep finding, so I would rather leave the criterion visibly short than meet it with a field that lies. Instead the description says plainly that an empty `entries` means the trail was read and nothing in it matched — never that nothing happened — and that a service the system is not auditing records nothing and so looks the same from here. **If someone can confirm `enabled_services` semantics against a live middleware, the marker is a small follow-up** and I'd propose it as its own ticket rather than guess now.

## Review

Two local rounds. Round 1 was the project's own reviewer (`exit 1`) and found one MEDIUM: `truncated` was computed after the local re-check of `user`/`service`, so a middleware that dropped the filters would return `truncated: false` over an incomplete result. That is fixed — a drop by the re-check is the only evidence this tool gets that a filter did not reach the system, so it is recorded, and a result carrying one is truncated whenever the system sent more than fit.

**Round 2 timed out at 420s (`exit 2`) and a subagent applied the same rubric from the brief instead. That is a weaker signal than the check's own verdict**, and it is the reason the required review here is doing real work rather than confirming a result. It returned three LOWs and nothing above.

Two of those LOWs were the description promising more than the handler delivers, which makes the diff itself wrong, so they are fixed in the third commit — `since` no longer claims to look further back than the bound reaches, and it now states that an entry whose own timestamp could not be read is returned under any window.

**Not changed, deliberately:**

- **`since` accepts a zoneless or space-separated time while `tasks_recent_runs` rejects one.** Two grammars for one argument name across the catalog. It is deliberate and the reasoning is in the JSDoc: the audit table's own recorded times may arrive in that shape, this parser never routes through `Date.parse`, and refusing them would leave every entry with a null timestamp. Worth a later decision about which of the two tools should move.
- **The request omits `services` entirely when no service is named, and the middleware's default for that is unconfirmed.** If it defaults to `MIDDLEWARE` alone, the no-argument call reads one trail while the description names four. One live check settles it; I could not settle it from the pinned client.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (535 passing) and `yarn test:coverage` all pass locally, as does `yarn build`. Nothing in this change needs a service, a secret or a live system to run.
