### PR TITLE
feat(tools): add reporting_utilisation, CPU, memory and network over a range

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `tasks_recent_runs`,
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,
-  `certificates_list`, `cloud_credentials_list`, `alert_settings`.
+  `certificates_list`, `cloud_credentials_list`, `alert_settings`,
+  `reporting_utilisation`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,5 +88,6 @@ export {
   networkConfig,
   certificatesList,
   cloudCredentialsList,
+  reportingUtilisation,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
+import { reportingUtilisation } from '@/tools/reporting';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
@@ -16,7 +17,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: twenty-eight read-only tools plus one mutating tool. */
+/** The sketch's catalog: twenty-nine read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -47,6 +48,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(certificatesList);
   catalog.register(cloudCredentialsList);
   catalog.register(alertSettings);
+  catalog.register(reportingUtilisation);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -71,6 +73,7 @@ export {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingUtilisation,
   scrubHistory,
   shareAccess,
   sharesList,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -76,9 +76,12 @@ const NO_DATA = 'the system collected no data for this metric in this range';
 const NO_INTERFACES = 'the system named no interface to graph';
 
 /**
- * What a metric whose graph came back without the dimension it is derived from
- * is marked with. Not the same as {@link NO_DATA}: the system answered with a
- * series, and it is not one this reduction can be computed from.
+ * What a metric whose graph's LEGEND did not name the dimension it is derived
+ * from is marked with. Not the same as {@link NO_DATA}: the system answered
+ * with a series, and it is not one this reduction can be computed from.
+ *
+ * Decided from the legend rather than from the samples, which is what keeps the
+ * two apart — see {@link graphMetric}.
  */
 const NO_DIMENSION = 'the system reported no series this metric can be derived from';
 
@@ -346,11 +349,27 @@ interface Point {
 }
 
 /**
- * How a metric is computed from one sample's dimensions. Null where this sample
- * does not yield one — a dimension the graph did not carry, or a total of zero
- * to divide by.
+ * How a metric is computed from a graph.
+ *
+ * The dimension names travel WITH the computation rather than being inferred
+ * from it, because they are what tells a graph that carries no such series
+ * apart from a graph that carries it and collected nothing — a distinction the
+ * samples alone cannot make, for the reason {@link graphMetric} gives.
  */
-type Derivation = (dimensions: Dimensions) => number | null;
+interface Derivation {
+  /**
+   * The legend names, lowercased, without which the metric cannot be derived
+   * from this graph at all. A name here missing from the legend is
+   * {@link NO_DIMENSION}; every other reason a sample yields nothing is a
+   * property of that sample rather than of the graph.
+   */
+  requires: string[];
+  /**
+   * The value at one sample, or null where this sample does not yield one — a
+   * dimension the row reported as null, or a total of zero to divide by.
+   */
+  from: (dimensions: Dimensions) => number | null;
+}
 
 /** What a graph yielded for one metric. */
 interface Samples {
@@ -367,16 +386,23 @@ interface Samples {
  * bucket: the system is asked for the range and is not obliged to answer with
  * exactly it, and a sample from before the start belongs in no bucket of it.
  *
- * The count of rows in the range is kept beside them because it is what
- * separates the two ways a metric ends up with nothing — a system that recorded
- * no sample, and a graph whose samples carry no dimension this metric is derived
- * from. Both are an empty list of points and they are different facts.
+ * The count of rows in the range is kept beside them because it is what says
+ * whether the system recorded anything here at all, which an empty list of
+ * points on its own does not.
+ *
+ * The column index is passed in rather than read from the legend here, because
+ * {@link graphMetric} needs the same index to decide which marker an empty
+ * result is.
  */
-function points(graph: GraphAttempt, range: Range, derive: Derivation): Samples {
-  const index = columns(graph.legend);
+function points(
+  rows: unknown[],
+  index: Map<string, number>,
+  range: Range,
+  derive: Derivation,
+): Samples {
   const found: Point[] = [];
   let inRange = 0;
-  for (const row of graph.rows) {
+  for (const row of rows) {
     if (!Array.isArray(row)) continue;
     const at = rowMillis(row[0]);
     if (at === null || at < range.start || at > range.end) continue;
@@ -389,7 +415,7 @@ function points(graph: GraphAttempt, range: Range, derive: Derivation): Samples 
       // what stops a gap in collection reading as an idle system.
       if (typeof value === 'number' && Number.isFinite(value)) dimensions.set(name, value);
     }
-    const value = derive(dimensions);
+    const value = derive.from(dimensions);
     if (value !== null) found.push({ at, value });
   }
   return { found, inRange };
@@ -521,10 +547,13 @@ const NETWORK_UNIT = 'kilobits_per_second';
  * anything outside that is a graph this reading does not hold of, and a
  * utilisation of -3% would be read as a real measurement.
  */
-const cpuPercent: Derivation = (dimensions) => {
-  const idle = dimensions.get('idle');
-  if (idle === undefined) return null;
-  return Math.min(100, Math.max(0, 100 - idle));
+const cpuPercent: Derivation = {
+  requires: ['idle'],
+  from: (dimensions) => {
+    const idle = dimensions.get('idle');
+    if (idle === undefined) return null;
+    return Math.min(100, Math.max(0, 100 - idle));
+  },
 };
 
 /**
@@ -556,13 +585,16 @@ const MEMORY_PARTS = ['free', 'used', 'cached', 'buffers'];
  * partitioning the same memory. Null where either is missing, and null where the
  * parts sum to nothing to take a share of.
  */
-const memoryUsedPercent: Derivation = (dimensions) => {
-  const used = dimensions.get('used');
-  if (used === undefined || dimensions.get('free') === undefined) return null;
-  let total = 0;
-  for (const part of MEMORY_PARTS) total += dimensions.get(part) ?? 0;
-  if (total <= 0) return null;
-  return Math.min(100, Math.max(0, (used / total) * 100));
+const memoryUsedPercent: Derivation = {
+  requires: ['used', 'free'],
+  from: (dimensions) => {
+    const used = dimensions.get('used');
+    if (used === undefined || dimensions.get('free') === undefined) return null;
+    let total = 0;
+    for (const part of MEMORY_PARTS) total += dimensions.get(part) ?? 0;
+    if (total <= 0) return null;
+    return Math.min(100, Math.max(0, (used / total) * 100));
+  },
 };
 
 /**
@@ -575,9 +607,12 @@ const memoryUsedPercent: Derivation = (dimensions) => {
  * carries nothing this result needs.
  */
 function throughput(dimension: string): Derivation {
-  return (dimensions) => {
-    const value = dimensions.get(dimension);
-    return value === undefined ? null : Math.abs(value);
+  return {
+    requires: [dimension],
+    from: (dimensions) => {
+      const value = dimensions.get(dimension);
+      return value === undefined ? null : Math.abs(value);
+    },
   };
 }
 
@@ -744,6 +779,19 @@ export const reportingUtilisation: ReadOnlyTool = {
  * different facts about the system: the read failed, the graph carried no
  * series this metric is derived from, and the graph was read and held no sample
  * in the range. Only the last is "the system was not recording".
+ *
+ * Which of the last two an empty result is is decided from the LEGEND, and it
+ * has to be: a row whose dimensions are all null — netdata's own marker for a
+ * second it collected nothing in — is indistinguishable from a row missing the
+ * dimension once {@link points} has dropped the non-numeric values. Counting
+ * rows would therefore report a collection GAP inside retention, which is
+ * exactly the "was it busy at 3am?" case this tool is built for, as a graph
+ * that carries no such series at all.
+ *
+ * A graph holding no row in the range at all is {@link NO_DATA} whatever its
+ * legend named, which is the weaker of the two claims and the only one the
+ * system's answer supports: nothing was collected here, and a legend alone says
+ * nothing about whether the series would have been derivable had it been.
  */
 function graphMetric(
   metric: MetricName,
@@ -754,10 +802,11 @@ function graphMetric(
   derive: Derivation,
 ): MetricReport {
   if (graph.error !== null) return unavailable(metric, iface, unit, graph.error);
-  const samples = points(graph, range, derive);
-  if (samples.inRange === 0) return unavailable(metric, iface, unit, NO_DATA);
-  // Rows inside the range that yielded no value are a dimension this metric is
-  // derived from that the graph did not carry — the samples were there.
-  if (samples.found.length === 0) return unavailable(metric, iface, unit, NO_DIMENSION);
-  return summarise(metric, iface, unit, samples.found, range);
+  const carried = columns(graph.legend);
+  const samples = points(graph.rows, carried, range, derive);
+  if (samples.found.length > 0) return summarise(metric, iface, unit, samples.found, range);
+  if (samples.inRange > 0 && derive.requires.some((name) => !carried.has(name))) {
+    return unavailable(metric, iface, unit, NO_DIMENSION);
+  }
+  return unavailable(metric, iface, unit, NO_DATA);
 }

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1,0 +1,744 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+
+/**
+ * Reporting family: how busy a system was over a time range, rather than how
+ * busy it is now.
+ *
+ * `system_info` answers the instant. Every "is it busy?" and "was it busy at
+ * 3am?" question needs a series, and the series is where the cost is: the
+ * middleware records a sample every few seconds, so an hour is hundreds of
+ * points per metric and a week is tens of thousands. A raw series is therefore
+ * never returned. What comes back is, per metric, four numbers over the whole
+ * range and a fixed twelve buckets across it — bounded by construction, so the
+ * result of a one-week question is the same size as the result of a one-hour
+ * one.
+ *
+ * The metrics are DERIVED rather than passed through. `reporting.netdata_get_data`
+ * answers with the graph's own dimensions — the CPU graph has one series per
+ * scheduler state, the memory graph one per kind of page — and handing those to
+ * a caller would be both unbounded and unanswerable. So each graph is reduced to
+ * the one number the catalog asks for, the reduction is stated in the tool's
+ * description, and a graph the reduction cannot be computed from is an explicit
+ * marker rather than a wrong number.
+ *
+ * (unconfirmed) against a live middleware, and each is noted where it is relied
+ * on: which dimensions each graph carries, that a data row is
+ * `[timestamp, ...values]` aligned to `legend`, that the query bounds are unix
+ * seconds, and the unit the interface graph records. Each is read defensively —
+ * a wrong reading costs a stated `unavailable` rather than a plausible wrong
+ * value — except the interface unit, which is named in the result and would be
+ * wrong rather than absent; see `NETWORK_UNIT`.
+ */
+
+/**
+ * How long a range covers when the caller bounds neither end.
+ *
+ * An hour is the window in which "is it busy?" is a question about now. A
+ * longer one is asked for rather than assumed: the buckets are a fixed count,
+ * so widening the range coarsens every bucket in it, and a caller who wanted
+ * the last hour would get twelve two-hour averages instead.
+ */
+const DEFAULT_RANGE_MS = 60 * 60 * 1000;
+
+/**
+ * How many buckets the range is divided into, whatever its length.
+ *
+ * Fixed rather than derived from the range, which is the whole point: the
+ * result of a question about a month costs the same tokens as one about an
+ * hour. Twelve is enough to see a shape — a spike, a ramp, a plateau — and
+ * small enough that a metric costs roughly a line.
+ */
+const BUCKETS = 12;
+
+/**
+ * How many interfaces the network metrics cover.
+ *
+ * The graph is per-interface and a system's interface listing is unbounded —
+ * every port, VLAN, bridge and aggregation is a row — so without a cap a system
+ * with forty of them would answer with eighty metrics. Interfaces are taken in
+ * name order so the choice is deterministic rather than whichever the system
+ * listed first, and `truncated_interfaces` says when the cap removed any.
+ */
+const MAX_INTERFACES = 6;
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/** What a metric the system collected nothing for in the range is marked with. */
+const NO_DATA = 'the system collected no data for this metric in this range';
+
+/**
+ * What a metric whose graph came back without the dimension it is derived from
+ * is marked with. Not the same as {@link NO_DATA}: the system answered with a
+ * series, and it is not one this reduction can be computed from.
+ */
+const NO_DIMENSION = 'the system reported no series this metric can be derived from';
+
+/**
+ * A string a row reported, or null where it reported anything else.
+ *
+ * An empty string is read as no value rather than as text of no characters: an
+ * interface of no characters names nothing that could be graphed. `network.ts`,
+ * `system.ts` and `shares.ts` each hold this same reading under their own names,
+ * and it is restated here for the reason those files give: a tool file is read
+ * on its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * Why a read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Restated from
+ * `network.ts` and `system.ts` for the reason they restate it from each other.
+ * The result is never empty, because a failure with no text still has to read
+ * as a failure.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/**
+ * A date, or a date and a time, in the forms this tool reads: `2026-08-29`,
+ * `2026-08-29T09:00:00Z`, `2026-08-29T09:00:00+02:00`, and the same with a
+ * space instead of the `T` and with no zone at all.
+ *
+ * Groups: year, month, day, hour, minute, second, fractional second, zone.
+ */
+const RANGE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+/**
+ * The instant a timestamp names, in milliseconds since the epoch, or null where
+ * it is not one of the forms above or does not name a real instant.
+ *
+ * The same grammar and the same reading as `audit_log_query`'s `since`, restated
+ * here deliberately rather than shared: the two tools are read on their own, and
+ * a caller who has learned one timestamp grammar for this catalog should not
+ * meet a second. Built from the components rather than handed to `Date.parse`,
+ * because `Date.parse('2026-08-29 09:00:00')` is implementation-defined and Node
+ * reads it as LOCAL time — the same range would then cover different instants on
+ * two machines, silently and by hours. Composed here it is read as UTC,
+ * explicitly and identically everywhere.
+ *
+ * The result is checked back against the components it was built from, which
+ * settles what nothing else here would: a day the month does not have ROLLS OVER
+ * rather than failing — `2026-02-30` composes as the 2nd of March — and so does
+ * an hour of 25.
+ */
+function utcMillis(text: string): number | null {
+  const match = RANGE_TIME.exec(text);
+  if (match === null) return null;
+  const [, year, month, day, hour, minute, second, fraction, zone] = match;
+  // A `Date` holds milliseconds and a timestamp may carry microseconds, so the
+  // digits past the third are dropped rather than rounded: that moves an instant
+  // by less than a millisecond and never across a bucket boundary of any range
+  // this tool can be asked for.
+  const millis = fraction === undefined ? 0 : Number(fraction.slice(0, 3).padEnd(3, '0'));
+  const at = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    hour === undefined ? 0 : Number(hour),
+    minute === undefined ? 0 : Number(minute),
+    second === undefined ? 0 : Number(second),
+    millis,
+  );
+  const composed = new Date(at);
+  if (
+    composed.getUTCFullYear() !== Number(year) ||
+    composed.getUTCMonth() !== Number(month) - 1 ||
+    composed.getUTCDate() !== Number(day) ||
+    (hour !== undefined && composed.getUTCHours() !== Number(hour)) ||
+    (minute !== undefined && composed.getUTCMinutes() !== Number(minute))
+  ) {
+    return null;
+  }
+  if (zone === undefined || zone === 'Z') return at;
+  const zoneHours = Number(zone.slice(1, 3));
+  const zoneMinutes = Number(zone.slice(4, 6));
+  // An offset outside the range a zone can have is a malformed one, and reading
+  // it would shift the instant by the amount it is wrong by.
+  if (zoneHours > 23 || zoneMinutes > 59) return null;
+  // Ahead of UTC is earlier in UTC, so the offset is subtracted.
+  const offset = (zoneHours * 60 + zoneMinutes) * 60_000;
+  return zone.startsWith('-') ? at + offset : at - offset;
+}
+
+/**
+ * One end of the range the caller named, in milliseconds since the epoch, or
+ * null where the caller named none.
+ *
+ * Strict rather than lenient, as `audit_log_query` is about its own `since`: a
+ * bound that cannot be read is not a request for the default one. Ignoring it
+ * would answer about the last hour while the caller believes it answered about
+ * last Tuesday, and the numbers would look exactly as real either way. Null and
+ * undefined are the argument being absent, which is not the same as unreadable
+ * and is what the default is for.
+ */
+function rangeBound(raw: unknown, name: string): number | null {
+  if (raw == null) return null;
+  const millis = typeof raw === 'string' ? utcMillis(raw) : null;
+  if (millis === null) {
+    throw new Error(
+      `"${name}" must be an ISO 8601 timestamp such as "2026-08-29T09:00:00Z", or a date ` +
+        'such as "2026-08-29". A time given without a timezone is read as UTC.',
+    );
+  }
+  return millis;
+}
+
+/** The range a call covers, in milliseconds since the epoch. */
+interface Range {
+  start: number;
+  end: number;
+}
+
+/**
+ * The range to report over: what the caller named, defaulted at either end.
+ *
+ * The default start hangs off the END rather than off `now`, so a caller who
+ * names only an end gets the hour before it rather than an hour that may lie
+ * entirely outside the range they asked about.
+ */
+function resolveRange(args: Record<string, unknown>, now: number): Range {
+  const end = rangeBound(args['end'], 'end') ?? now;
+  const start = rangeBound(args['start'], 'start') ?? end - DEFAULT_RANGE_MS;
+  if (start >= end) {
+    throw new Error('"start" must be before "end"');
+  }
+  return { start, end };
+}
+
+/**
+ * The graphs this tool reads, spelled as the middleware's reporting graph names.
+ * `interface` is per-interface and carries an identifier; the other two are
+ * system-wide and carry none.
+ */
+type GraphName = 'cpu' | 'memory' | 'interface';
+
+/** What one graph read produced, with a failure named rather than thrown. */
+interface GraphAttempt {
+  /**
+   * The legend as the system sent it, entry for entry. Not filtered to the
+   * strings in it: an entry's POSITION is what maps it to a column, so dropping
+   * one would shift every series after it onto its neighbour's numbers.
+   */
+  legend: unknown[];
+  rows: unknown[];
+  error: string | null;
+}
+
+/**
+ * One reporting graph over the range, with a failure caught and named.
+ *
+ * Read per graph rather than all graphs in one call, which the method would
+ * accept. Each graph is then independent: a system that keeps no interface
+ * graph, or that rejects one identifier, still answers for CPU and memory
+ * instead of taking the whole result down. The cost is a call per graph, and
+ * they are all issued together.
+ *
+ * (unconfirmed) the query bounds are unix SECONDS, which is what netdata records
+ * in and what the response's own `start` and `end` are read as below.
+ */
+async function readGraph(
+  system: SystemHandle,
+  name: GraphName,
+  identifier: string | null,
+  range: Range,
+): Promise<GraphAttempt> {
+  try {
+    const answer = await firstValueFrom(
+      // The request is inlined so the call's own parameter types apply, as in
+      // `storage.ts`: written to a `const` first, the graph name widens to
+      // `string` and no longer satisfies the graph-name union.
+      system.client.api.call('reporting.netdata_get_data', [
+        [identifier === null ? { name } : { name, identifier }],
+        { start: Math.floor(range.start / 1000), end: Math.ceil(range.end / 1000) },
+      ]),
+    );
+    // One graph was asked for, so one is expected back. Anything else — no
+    // list, an empty one, an entry that is not a record — is a system that did
+    // not answer the question, and it reads as no data rather than as an error:
+    // the other graphs in the same result are unaffected by it.
+    const graph = Array.isArray(answer) ? (answer[0] as unknown) : undefined;
+    if (typeof graph !== 'object' || graph === null) return { legend: [], rows: [], error: null };
+    const held = graph as Record<string, unknown>;
+    const legend = held['legend'];
+    const rows = held['data'];
+    return {
+      legend: Array.isArray(legend) ? legend : [],
+      rows: Array.isArray(rows) ? rows : [],
+      error: null,
+    };
+  } catch (reason) {
+    return { legend: [], rows: [], error: errorText(reason) };
+  }
+}
+
+/**
+ * The instant a data row is stamped with, in milliseconds since the epoch, or
+ * null where the row's first column is not a time this tool can read.
+ *
+ * (unconfirmed) the stamp is unix seconds, as netdata records them. A value too
+ * large to be a plausible second — 1e11 seconds is the year 5138 — is read as
+ * milliseconds instead, so a middleware that sends milliseconds places its
+ * samples correctly rather than putting every one of them in 1970 and reporting
+ * an empty range.
+ */
+function rowMillis(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.abs(value) > 1e11 ? value : value * 1000;
+}
+
+/**
+ * Which column of a data row each legend entry describes.
+ *
+ * (unconfirmed) a row is `[timestamp, ...values]`. The legend either names that
+ * timestamp column as its own first entry or describes only the values after it,
+ * and which of the two a release sends is exactly the kind of detail that turns
+ * every series into its neighbour if it is assumed. So it is READ: a legend that
+ * opens with `time` is aligned column-for-column, and one that does not is
+ * shifted by the timestamp the row carries anyway.
+ */
+function columns(legend: unknown[]): Map<string, number> {
+  const first = legend[0];
+  const offset = typeof first === 'string' && first.toLowerCase() === 'time' ? 0 : 1;
+  const index = new Map<string, number>();
+  legend.forEach((name, position) => {
+    // Position is preserved through an entry that is not a name at all, for the
+    // reason `GraphAttempt` gives for not filtering the legend.
+    if (typeof name !== 'string') return;
+    const key = name.toLowerCase();
+    // The timestamp column is not a series, and a duplicate name keeps its
+    // first column: a second column of the same name is a graph this tool
+    // cannot tell apart, and taking the later one would silently prefer it.
+    if (key === 'time' || index.has(key)) return;
+    index.set(key, position + offset);
+  });
+  return index;
+}
+
+/** The dimensions of one sample, keyed by the lowercased legend name. */
+type Dimensions = Map<string, number>;
+
+/** One sample of a derived metric: when it was taken, and its value there. */
+interface Point {
+  at: number;
+  value: number;
+}
+
+/**
+ * How a metric is computed from one sample's dimensions. Null where this sample
+ * does not yield one — a dimension the graph did not carry, or a total of zero
+ * to divide by.
+ */
+type Derivation = (dimensions: Dimensions) => number | null;
+
+/** What a graph yielded for one metric. */
+interface Samples {
+  /** The samples the metric could be derived from. */
+  found: Point[];
+  /** How many rows the graph held inside the range at all, derivable or not. */
+  inRange: number;
+}
+
+/**
+ * The samples of a graph that fall inside the range, reduced to one metric.
+ *
+ * Samples outside the range are dropped rather than clamped into the nearest
+ * bucket: the system is asked for the range and is not obliged to answer with
+ * exactly it, and a sample from before the start belongs in no bucket of it.
+ *
+ * The count of rows in the range is kept beside them because it is what
+ * separates the two ways a metric ends up with nothing — a system that recorded
+ * no sample, and a graph whose samples carry no dimension this metric is derived
+ * from. Both are an empty list of points and they are different facts.
+ */
+function points(graph: GraphAttempt, range: Range, derive: Derivation): Samples {
+  const index = columns(graph.legend);
+  const found: Point[] = [];
+  let inRange = 0;
+  for (const row of graph.rows) {
+    if (!Array.isArray(row)) continue;
+    const at = rowMillis(row[0]);
+    if (at === null || at < range.start || at > range.end) continue;
+    inRange += 1;
+    const dimensions: Dimensions = new Map();
+    for (const [name, column] of index) {
+      const value = row[column] as unknown;
+      // A dimension the system reported as null — netdata's own marker for a
+      // second it collected nothing in — is absent rather than zero, which is
+      // what stops a gap in collection reading as an idle system.
+      if (typeof value === 'number' && Number.isFinite(value)) dimensions.set(name, value);
+    }
+    const value = derive(dimensions);
+    if (value !== null) found.push({ at, value });
+  }
+  return { found, inRange };
+}
+
+/** To one decimal place, which is the precision every metric here is reported at. */
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/** The metrics this tool reports. */
+type MetricName = 'cpu_percent' | 'memory_used_percent' | 'network_received' | 'network_sent';
+
+/** One metric over the range, or the stated reason there is none. */
+interface MetricReport {
+  metric: MetricName;
+  interface: string | null;
+  unit: string;
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  latest: number | null;
+  buckets: (number | null)[];
+  unavailable: string | null;
+}
+
+/** A metric with nothing to report, and why. */
+function unavailable(
+  metric: MetricName,
+  iface: string | null,
+  unit: string,
+  reason: string,
+): MetricReport {
+  return {
+    metric,
+    interface: iface,
+    unit,
+    min: null,
+    max: null,
+    mean: null,
+    latest: null,
+    // Empty rather than twelve nulls: `unavailable` is what says there is
+    // nothing here, and a list of nulls would invite reading it as twelve
+    // buckets that each happened to be empty.
+    buckets: [],
+    unavailable: reason,
+  };
+}
+
+/**
+ * The four numbers and the twelve buckets, from the samples that yielded a
+ * value.
+ *
+ * `latest` is the value at the NEWEST sample rather than the last one the system
+ * sent, because nothing here guarantees the order it sent them in. A bucket with
+ * no sample in it is null rather than zero, for the reason a missing dimension
+ * is absent above: an interval the system collected nothing in is not an
+ * interval in which nothing happened.
+ *
+ * Only ever called with at least one sample — {@link graphMetric} is what
+ * decides that an empty list is a marker rather than a summary, and which of the
+ * markers it is.
+ */
+function summarise(
+  metric: MetricName,
+  iface: string | null,
+  unit: string,
+  found: Point[],
+  range: Range,
+): MetricReport {
+  const width = (range.end - range.start) / BUCKETS;
+  const sums = new Array<number>(BUCKETS).fill(0);
+  const counts = new Array<number>(BUCKETS).fill(0);
+  let min = found[0].value;
+  let max = found[0].value;
+  let total = 0;
+  let latest = found[0];
+  for (const point of found) {
+    if (point.value < min) min = point.value;
+    if (point.value > max) max = point.value;
+    total += point.value;
+    if (point.at > latest.at) latest = point;
+    // Clamped at the last bucket so that a sample exactly at the end of the
+    // range lands in it rather than one past the end.
+    const bucket = Math.min(BUCKETS - 1, Math.floor((point.at - range.start) / width));
+    sums[bucket] += point.value;
+    counts[bucket] += 1;
+  }
+  return {
+    metric,
+    interface: iface,
+    unit,
+    min: round1(min),
+    max: round1(max),
+    mean: round1(total / found.length),
+    latest: round1(latest.value),
+    buckets: sums.map((sum, bucket) => (counts[bucket] === 0 ? null : round1(sum / counts[bucket]))),
+    unavailable: null,
+  };
+}
+
+/** The unit CPU and memory are reported in. */
+const PERCENT = 'percent';
+
+/**
+ * The unit the network metrics are reported in.
+ *
+ * (unconfirmed) against a live middleware, and the one assumption in this file
+ * that would be WRONG rather than absent if it is: the interface graph's values
+ * are passed through, so a release recording bytes per second would be reported
+ * as kilobits per second. It is stated rather than omitted because a throughput
+ * with no unit is a number a caller cannot compare with anything — and the
+ * reading is netdata's own, which records the interface chart in kilobits per
+ * second.
+ */
+const NETWORK_UNIT = 'kilobits_per_second';
+
+/**
+ * The share of CPU time that was not idle, as a percentage.
+ *
+ * Derived rather than read: the graph carries one dimension per scheduler state
+ * — user, system, nice, iowait, steal and the rest — and "utilisation" is the
+ * complement of the one that means the CPU had nothing to do. Taken as
+ * `100 - idle` rather than as the sum of the others because the set of the
+ * others differs by release and by kernel, and a release that adds a state would
+ * quietly under-report a sum while leaving the complement exact.
+ *
+ * Clamped into 0..100: the dimensions are percentages that add to a hundred, so
+ * anything outside that is a graph this reading does not hold of, and a
+ * utilisation of -3% would be read as a real measurement.
+ */
+const cpuPercent: Derivation = (dimensions) => {
+  const idle = dimensions.get('idle');
+  if (idle === undefined) return null;
+  return Math.min(100, Math.max(0, 100 - idle));
+};
+
+/**
+ * The dimensions of the memory graph that partition physical memory.
+ *
+ * (unconfirmed) the graph carries these four and they sum to the memory
+ * installed, which is what makes a percentage of their total meaningful. Named
+ * as a closed list rather than summing every dimension the graph carries: a
+ * release adding a derived dimension — an `available` that overlaps `free` and
+ * `cached` — would inflate the total and shrink every percentage, silently and
+ * plausibly.
+ */
+const MEMORY_PARTS = ['free', 'used', 'cached', 'buffers'];
+
+/**
+ * Memory in use, as a percentage of the memory the graph accounts for.
+ *
+ * A percentage rather than a byte count deliberately: the graph's unit is not
+ * stated anywhere this tool can read, and a ratio of two values in the same
+ * unit is right whatever that unit turns out to be. Null where the graph
+ * carried no `used` dimension, or where the parts it did carry sum to nothing
+ * to take a share of.
+ */
+const memoryUsedPercent: Derivation = (dimensions) => {
+  const used = dimensions.get('used');
+  if (used === undefined) return null;
+  let total = 0;
+  for (const part of MEMORY_PARTS) total += dimensions.get(part) ?? 0;
+  if (total <= 0) return null;
+  return Math.min(100, Math.max(0, (used / total) * 100));
+};
+
+/**
+ * The magnitude of one direction of interface traffic.
+ *
+ * The magnitude rather than the value, because netdata's interface chart mirrors
+ * one direction below the axis to draw it: a sent rate arrives negative on a
+ * link that is sending, and passing it through would report a busy link as one
+ * with less than no traffic. Direction is what the metric name says, so the sign
+ * carries nothing this result needs.
+ */
+function throughput(dimension: string): Derivation {
+  return (dimensions) => {
+    const value = dimensions.get(dimension);
+    return value === undefined ? null : Math.abs(value);
+  };
+}
+
+/** The interfaces to report, and whether the cap left any out. */
+interface Interfaces {
+  names: string[];
+  truncated: boolean;
+  error: string | null;
+}
+
+/**
+ * The interfaces to graph: every one the system lists, in name order, up to the
+ * cap.
+ *
+ * Bridges, VLANs and aggregations are listed alongside physical ports and are
+ * kept, because traffic over a bridge is traffic. That does mean an aggregation
+ * and its members can both appear, and their throughputs then overlap — the
+ * description says so rather than this guessing which of them the caller meant.
+ *
+ * A listing that could not be read is named rather than thrown: CPU and memory
+ * are still an answer, and the network metrics say why they are not one.
+ */
+async function interfaceNames(system: SystemHandle): Promise<Interfaces> {
+  try {
+    const rows = await firstValueFrom(system.client.api.query('interface.query'));
+    const named = rows.flatMap((row) => {
+      const name = textOrNull(row['name']);
+      return name === null ? [] : [name];
+    });
+    // Sorted before the cap, so which interfaces a capped result covers is a
+    // property of the system rather than of the order it happened to list them.
+    named.sort();
+    return {
+      names: named.slice(0, MAX_INTERFACES),
+      truncated: named.length > MAX_INTERFACES,
+      error: null,
+    };
+  } catch (reason) {
+    return { names: [], truncated: false, error: errorText(reason) };
+  }
+}
+
+export const reportingUtilisation: ReadOnlyTool = {
+  name: 'reporting_utilisation',
+  description:
+    'CPU, memory and network utilisation of a TrueNAS system OVER A TIME ' +
+    'RANGE, from the metrics the system records for itself. `system_info` ' +
+    'reports the instant; this reports the interval, and is what answers ' +
+    '"was it busy at 3am?". `metrics` holds one entry per measurement, each ' +
+    'with: `metric`, which of the four it is; `interface`, the interface a ' +
+    'network metric was measured on and NULL ON CPU AND MEMORY; `unit`, what ' +
+    'the numbers are in; `min`, `max` and `mean` over the whole range; ' +
+    '`latest`, the value at the most recent sample IN THE RANGE, which is not ' +
+    'the value now unless the range ends now; and `buckets`. `cpu_percent` is ' +
+    'the percentage of CPU time that was NOT IDLE, across all cores together, ' +
+    'so 100 is every core fully busy and it does not say which core or which ' +
+    'workload. `memory_used_percent` is memory in use as a percentage of the ' +
+    'memory the system accounts for; CACHED AND BUFFERED MEMORY COUNT AS FREE ' +
+    'in that reading, because they are reclaimable, so a healthy system running ' +
+    'a large cache reports low. `network_received` and `network_sent` are ' +
+    'throughput in each direction on ONE INTERFACE, reported as a magnitude, ' +
+    'and they cover at most six interfaces IN NAME ORDER — ' +
+    '`truncated_interfaces` is true when the system has more than that and some ' +
+    'were left out. Bridges, VLANs and link aggregations are reported ' +
+    'alongside the physical ports beneath them, so ADDING THE INTERFACES ' +
+    'TOGETHER DOUBLE-COUNTS traffic that crossed both; compare interfaces ' +
+    'rather than summing them. `buckets` is always exactly twelve entries: the ' +
+    'range is divided into twelve equal intervals and each entry is the MEAN of ' +
+    'the samples inside its interval, oldest first, so the width of one is a ' +
+    'twelfth of the range and is given as `bucket_seconds`. A bucket the system ' +
+    'collected nothing in is NULL, WHICH IS NOT ZERO — no measurement was ' +
+    'taken, and the metric may have been at any value. Raw samples are never ' +
+    'returned: an hour is hundreds of them per metric, so the summary and the ' +
+    'twelve buckets are the whole answer and the result is the same size ' +
+    'whatever range is asked for. `unavailable` is null on a metric that was ' +
+    'measured, and otherwise names why there is nothing to report — the system ' +
+    'collected no data in the range, its graph carried no series this metric ' +
+    'could be derived from, or the read itself failed with the reason the ' +
+    'system gave. WHERE IT IS NON-NULL, `min`, `max`, `mean` and `latest` ARE ' +
+    'ALL NULL AND `buckets` IS EMPTY, and that is never a system that was idle: ' +
+    'nothing was measured. Metrics fail independently, so a result can report ' +
+    'CPU and memory while every network metric is unavailable. `start` and ' +
+    '`end` are the range actually reported on, as ISO 8601 UTC timestamps, so ' +
+    'an unavailable metric is readable against the window it was asked for. ' +
+    'Give `start` and `end` to bound the range; OMITTED, THE LAST HOUR ending ' +
+    'now, and a `start` with no `end` runs to now while an `end` with no ' +
+    '`start` covers the hour before it. This tool reads recorded metrics. It ' +
+    'does not report per-process, per-app or per-VM usage, per-disk throughput, ' +
+    'or per-share traffic, and it changes nothing about what the system records.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      start: {
+        type: 'string',
+        description:
+          'The beginning of the range, as an ISO 8601 timestamp — ' +
+          '"2026-08-29T09:00:00Z" — or a date, "2026-08-29", which is ' +
+          'midnight. A time given without a timezone is read as UTC. Omitted, ' +
+          'one hour before the end of the range.',
+      },
+      end: {
+        type: 'string',
+        description:
+          'The end of the range, in the same forms as `start`. Omitted, now.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // The range is resolved before anything is read, so an unreadable bound is
+    // an error rather than a query the system answers over the wrong interval.
+    const range = resolveRange(args, Date.now());
+    // The interface listing is what decides which graphs are read, so it is the
+    // one read that cannot be issued alongside the others.
+    const interfaces = await interfaceNames(system);
+    const [cpu, memory, ...network] = await Promise.all([
+      readGraph(system, 'cpu', null, range),
+      readGraph(system, 'memory', null, range),
+      ...interfaces.names.map((name) => readGraph(system, 'interface', name, range)),
+    ]);
+
+    const metrics: MetricReport[] = [
+      graphMetric('cpu_percent', null, PERCENT, cpu, range, cpuPercent),
+      graphMetric('memory_used_percent', null, PERCENT, memory, range, memoryUsedPercent),
+    ];
+    if (interfaces.error !== null) {
+      // Both network metrics are still reported, carrying the reason no
+      // interface could be graphed. An absent metric would read as a system
+      // with no network at all.
+      metrics.push(
+        unavailable('network_received', null, NETWORK_UNIT, interfaces.error),
+        unavailable('network_sent', null, NETWORK_UNIT, interfaces.error),
+      );
+    }
+    interfaces.names.forEach((name, position) => {
+      const graph = network[position];
+      metrics.push(
+        graphMetric('network_received', name, NETWORK_UNIT, graph, range, throughput('received')),
+        graphMetric('network_sent', name, NETWORK_UNIT, graph, range, throughput('sent')),
+      );
+    });
+
+    return {
+      start: new Date(range.start).toISOString(),
+      end: new Date(range.end).toISOString(),
+      bucket_seconds: round1((range.end - range.start) / BUCKETS / 1000),
+      metrics,
+      truncated_interfaces: interfaces.truncated,
+    };
+  },
+};
+
+/**
+ * One metric from one graph: the summary where the graph yielded samples, and
+ * the stated reason where it did not.
+ *
+ * The three ways there is nothing to report are kept apart, because they are
+ * different facts about the system: the read failed, the graph carried no
+ * series this metric is derived from, and the graph was read and held no sample
+ * in the range. Only the last is "the system was not recording".
+ */
+function graphMetric(
+  metric: MetricName,
+  iface: string | null,
+  unit: string,
+  graph: GraphAttempt,
+  range: Range,
+  derive: Derivation,
+): MetricReport {
+  if (graph.error !== null) return unavailable(metric, iface, unit, graph.error);
+  const samples = points(graph, range, derive);
+  if (samples.inRange === 0) return unavailable(metric, iface, unit, NO_DATA);
+  // Rows inside the range that yielded no value are a dimension this metric is
+  // derived from that the graph did not carry — the samples were there.
+  if (samples.found.length === 0) return unavailable(metric, iface, unit, NO_DIMENSION);
+  return summarise(metric, iface, unit, samples.found, range);
+}

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -70,6 +70,12 @@ const NO_REASON = 'the system reported no reason';
 const NO_DATA = 'the system collected no data for this metric in this range';
 
 /**
+ * What the network metrics are marked with where the interface listing was read
+ * and named nothing to graph.
+ */
+const NO_INTERFACES = 'the system named no interface to graph';
+
+/**
  * What a metric whose graph came back without the dimension it is derived from
  * is marked with. Not the same as {@link NO_DATA}: the system answered with a
  * series, and it is not one this reduction can be computed from.
@@ -538,13 +544,21 @@ const MEMORY_PARTS = ['free', 'used', 'cached', 'buffers'];
  *
  * A percentage rather than a byte count deliberately: the graph's unit is not
  * stated anywhere this tool can read, and a ratio of two values in the same
- * unit is right whatever that unit turns out to be. Null where the graph
- * carried no `used` dimension, or where the parts it did carry sum to nothing
- * to take a share of.
+ * unit is right whatever that unit turns out to be.
+ *
+ * BOTH `used` and `free` are required, and the second is what stops the answer
+ * being a tautology. `used` is itself one of the parts summed into the total, so
+ * a graph carrying `used` and nothing else divides a number by itself and
+ * reports 100% — a system at three percent of its memory presented as one out of
+ * it, which is worse than no answer. `free` is the dimension that makes the
+ * total account for memory nothing is using; `cached` and `buffers` refine it
+ * and are optional, because a release that folds them into `free` is still
+ * partitioning the same memory. Null where either is missing, and null where the
+ * parts sum to nothing to take a share of.
  */
 const memoryUsedPercent: Derivation = (dimensions) => {
   const used = dimensions.get('used');
-  if (used === undefined) return null;
+  if (used === undefined || dimensions.get('free') === undefined) return null;
   let total = 0;
   for (const part of MEMORY_PARTS) total += dimensions.get(part) ?? 0;
   if (total <= 0) return null;
@@ -630,7 +644,8 @@ export const reportingUtilisation: ReadOnlyTool = {
     'were left out. Bridges, VLANs and link aggregations are reported ' +
     'alongside the physical ports beneath them, so ADDING THE INTERFACES ' +
     'TOGETHER DOUBLE-COUNTS traffic that crossed both; compare interfaces ' +
-    'rather than summing them. `buckets` is always exactly twelve entries: the ' +
+    'rather than summing them. `buckets` is twelve entries on every metric that ' +
+    'was measured: the ' +
     'range is divided into twelve equal intervals and each entry is the MEAN of ' +
     'the samples inside its interval, oldest first, so the width of one is a ' +
     'twelfth of the range and is given as `bucket_seconds`. A bucket the system ' +
@@ -641,8 +656,10 @@ export const reportingUtilisation: ReadOnlyTool = {
     'whatever range is asked for. `unavailable` is null on a metric that was ' +
     'measured, and otherwise names why there is nothing to report — the system ' +
     'collected no data in the range, its graph carried no series this metric ' +
-    'could be derived from, or the read itself failed with the reason the ' +
-    'system gave. WHERE IT IS NON-NULL, `min`, `max`, `mean` and `latest` ARE ' +
+    'could be derived from, the read itself failed with the reason the ' +
+    'system gave, or — on the network metrics, which then carry a null ' +
+    '`interface` — the system named no interface to graph at all. WHERE IT IS ' +
+    'NON-NULL, `min`, `max`, `mean` and `latest` ARE ' +
     'ALL NULL AND `buckets` IS EMPTY, and that is never a system that was idle: ' +
     'nothing was measured. Metrics fail independently, so a result can report ' +
     'CPU and memory while every network metric is unavailable. `start` and ' +
@@ -690,13 +707,15 @@ export const reportingUtilisation: ReadOnlyTool = {
       graphMetric('cpu_percent', null, PERCENT, cpu, range, cpuPercent),
       graphMetric('memory_used_percent', null, PERCENT, memory, range, memoryUsedPercent),
     ];
-    if (interfaces.error !== null) {
+    if (interfaces.names.length === 0) {
       // Both network metrics are still reported, carrying the reason no
-      // interface could be graphed. An absent metric would read as a system
-      // with no network at all.
+      // interface could be graphed — the listing failed, or it was read and
+      // named none. Absent metrics would read as a system with no network at
+      // all, which is the one thing a result must not imply here.
+      const reason = interfaces.error ?? NO_INTERFACES;
       metrics.push(
-        unavailable('network_received', null, NETWORK_UNIT, interfaces.error),
-        unavailable('network_sent', null, NETWORK_UNIT, interfaces.error),
+        unavailable('network_received', null, NETWORK_UNIT, reason),
+        unavailable('network_sent', null, NETWORK_UNIT, reason),
       );
     }
     interfaces.names.forEach((name, position) => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8088,6 +8088,18 @@ describe('reporting_utilisation', () => {
     expect(report.truncated_interfaces).toBe(false);
   });
 
+  it('still reports both network metrics when the system named no interface', async () => {
+    const fake = reportingSystem({ cpu: cpuGraph, memory: memoryGraph }, { interfaces: [] });
+    const report = await reported(fake);
+    // Dropping them would be indistinguishable from a system with no network.
+    expect(metric(report, 'network_received')).toMatchObject({
+      interface: null,
+      buckets: [],
+      unavailable: 'the system named no interface to graph',
+    });
+    expect(metric(report, 'network_sent').unavailable).toBe('the system named no interface to graph');
+  });
+
   it('covers six interfaces in name order and says when it left some out', async () => {
     const fake = reportingSystem(
       { cpu: cpuGraph, memory: memoryGraph },
@@ -8179,11 +8191,14 @@ describe('reporting_utilisation', () => {
   });
 
   it('reports no memory percentage where nothing accounts for the total', async () => {
-    const missing = ['time', 'free', 'cached'];
-    const zero = ['time', 'free', 'used'];
     const cases: [unknown[], unknown[]][] = [
-      [missing, [[at(60_000), 100, 20]]],
-      [zero, [[at(60_000), 0, 0]]],
+      // No `used` to report.
+      [['time', 'free', 'cached'], [[at(60_000), 100, 20]]],
+      // `used` alone is its own total, and dividing it by itself would report
+      // every system as fully out of memory.
+      [['time', 'used'], [[at(60_000), 500]]],
+      // Nothing to take a share of.
+      [['time', 'free', 'used'], [[at(60_000), 0, 0]]],
     ];
     for (const [legend, data] of cases) {
       const fake = reportingSystem({ memory: graph(legend, data) });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -23,6 +23,7 @@ import {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingUtilisation,
   scrubHistory,
   shareAccess,
   sharesList,
@@ -76,7 +77,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the twenty-nine sketch tools', () => {
+  it('registers the thirty sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -106,8 +107,15 @@ describe('createDefaultCatalog', () => {
       'certificates_list',
       'cloud_credentials_list',
       'alert_settings',
+      'reporting_utilisation',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises reporting_utilisation to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'reporting_utilisation',
+    );
   });
 
   it('advertises system_update_status to a read-only credential', () => {
@@ -7785,5 +7793,482 @@ describe('vms_list', () => {
     await vmsList.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('vm.query');
     expect(query).toHaveBeenCalledWith('virt.instance.query', [['type', '=', 'VM']]);
+  });
+});
+
+describe('reporting_utilisation', () => {
+  /**
+   * A fixed present, so the default range is a fixed interval rather than one
+   * that moves with the clock. Only `Date` is faked, as in `audit_log_query`:
+   * the tool reads the clock and nothing here schedules anything.
+   */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+  /** NOW minus the tool's one-hour default range. */
+  const RANGE_START = NOW - 60 * 60 * 1000; // 2023-11-14T21:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** A sample time inside the default range, in the unix seconds a row carries. */
+  const at = (offset: number): number => (RANGE_START + offset) / 1000;
+
+  /** A graph as `reporting.netdata_get_data` answers with one. */
+  const graph = (legend: unknown[], data: unknown[]): unknown => [
+    { name: 'graph', identifier: null, data, aggregations: {}, start: 0, end: 0, legend },
+  ];
+
+  /** Three CPU samples: 10%, 20% and 30% busy, the last exactly at the range end. */
+  const cpuGraph = graph(
+    ['time', 'user', 'system', 'idle'],
+    [
+      [at(60_000), 5, 5, 90],
+      [at(360_000), 10, 10, 80],
+      [at(3_600_000), 20, 10, 70],
+    ],
+  );
+
+  /** Two memory samples, 50% and 60% of a thousand accounted-for units. */
+  const memoryGraph = graph(
+    ['time', 'free', 'used', 'cached', 'buffers'],
+    [
+      [at(60_000), 250, 500, 200, 50],
+      [at(3_600_000), 200, 600, 150, 50],
+    ],
+  );
+
+  /** Two interface samples, with the sent direction mirrored below the axis. */
+  const netGraph = graph(
+    ['time', 'received', 'sent'],
+    [
+      [at(60_000), 100, -40],
+      [at(3_600_000), 300, -80],
+    ],
+  );
+
+  interface Fake {
+    ctx: ToolContext;
+    call: ReturnType<typeof vi.fn>;
+    query: ReturnType<typeof vi.fn>;
+  }
+
+  /**
+   * A SystemHandle answering per GRAPH rather than per method, which neither
+   * `fakeSystem` nor `failingSystem` can do: every graph this tool reads comes
+   * back from the same `reporting.netdata_get_data` call, distinguished only by
+   * the name and identifier asked for. Graphs are keyed `cpu`, `memory` and
+   * `interface:<name>`, and a key present in `failures` rejects instead.
+   */
+  const reportingSystem = (
+    graphs: Record<string, unknown>,
+    options: { interfaces?: unknown; failures?: Record<string, unknown> } = {},
+  ): Fake => {
+    const failures = options.failures ?? {};
+    const call = vi.fn((method: string, params?: unknown) => {
+      const asked = (params as [{ name: string; identifier?: string }[]])[0][0];
+      const key = asked.identifier === undefined ? asked.name : `${asked.name}:${asked.identifier}`;
+      return key in failures ? throwError(() => failures[key]) : of(graphs[key]);
+    });
+    const query = vi.fn(() =>
+      'interface.query' in failures
+        ? throwError(() => failures['interface.query'])
+        : of(options.interfaces ?? [{ name: 'eno1' }]),
+    );
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    return { ctx: { system }, call, query };
+  };
+
+  /** A system with all three graphs and one interface. */
+  const healthy = (): Fake =>
+    reportingSystem({ cpu: cpuGraph, memory: memoryGraph, ['interface:eno1']: netGraph });
+
+  interface Metric {
+    metric: string;
+    interface: string | null;
+    unit: string;
+    min: number | null;
+    max: number | null;
+    mean: number | null;
+    latest: number | null;
+    buckets: (number | null)[];
+    unavailable: string | null;
+  }
+
+  interface Report {
+    start: string;
+    end: string;
+    bucket_seconds: number;
+    metrics: Metric[];
+    truncated_interfaces: boolean;
+  }
+
+  const reported = async (fake: Fake, args: Record<string, unknown> = {}): Promise<Report> =>
+    (await reportingUtilisation.handler(fake.ctx, args)) as Report;
+
+  /** One metric of a result, by name and by the interface it was measured on. */
+  const metric = (report: Report, name: string, iface: string | null = null): Metric =>
+    report.metrics.filter((entry) => entry.metric === name && entry.interface === iface)[0];
+
+  /** The whole default-range result of a system carrying just this one CPU graph. */
+  const cpuOnly = async (legend: unknown[], data: unknown[]): Promise<Metric> =>
+    metric(await reported(reportingSystem({ cpu: graph(legend, data) })), 'cpu_percent');
+
+  it('summarises CPU over the range and buckets it twelve ways', async () => {
+    expect(metric(await reported(healthy()), 'cpu_percent')).toEqual({
+      metric: 'cpu_percent',
+      interface: null,
+      unit: 'percent',
+      min: 10,
+      max: 30,
+      mean: 20,
+      latest: 30,
+      // The third sample sits exactly at the end of the range and lands in the
+      // last bucket rather than one past it.
+      buckets: [10, 20, null, null, null, null, null, null, null, null, null, 30],
+      unavailable: null,
+    });
+  });
+
+  it('reports memory in use as a percentage of the memory the graph accounts for', async () => {
+    expect(metric(await reported(healthy()), 'memory_used_percent')).toMatchObject({
+      unit: 'percent',
+      min: 50,
+      max: 60,
+      mean: 55,
+      latest: 60,
+      unavailable: null,
+    });
+  });
+
+  it('reports each direction of interface traffic as a magnitude', async () => {
+    const report = await reported(healthy());
+    expect(metric(report, 'network_received', 'eno1')).toMatchObject({
+      unit: 'kilobits_per_second',
+      min: 100,
+      max: 300,
+      mean: 200,
+      latest: 300,
+    });
+    // Sent arrives negative, mirrored below the axis; a busy link must not
+    // report as one carrying less than nothing.
+    expect(metric(report, 'network_sent', 'eno1')).toMatchObject({
+      min: 40,
+      max: 80,
+      mean: 60,
+      latest: 80,
+    });
+  });
+
+  it('states the range it reported on and how wide a bucket is', async () => {
+    expect(await reported(healthy())).toMatchObject({
+      start: '2023-11-14T21:13:20.000Z',
+      end: '2023-11-14T22:13:20.000Z',
+      bucket_seconds: 300,
+      truncated_interfaces: false,
+    });
+  });
+
+  it('returns only the fields it names', async () => {
+    const report = await reported(healthy());
+    expect(Object.keys(report)).toEqual([
+      'start',
+      'end',
+      'bucket_seconds',
+      'metrics',
+      'truncated_interfaces',
+    ]);
+    expect(Object.keys(metric(report, 'cpu_percent'))).toEqual([
+      'metric',
+      'interface',
+      'unit',
+      'min',
+      'max',
+      'mean',
+      'latest',
+      'buckets',
+      'unavailable',
+    ]);
+  });
+
+  it('asks the system for the range in unix seconds, per graph', async () => {
+    const fake = healthy();
+    await reported(fake);
+    const bounds = { start: RANGE_START / 1000, end: NOW / 1000 };
+    expect(fake.call).toHaveBeenCalledWith('reporting.netdata_get_data', [[{ name: 'cpu' }], bounds]);
+    expect(fake.call).toHaveBeenCalledWith('reporting.netdata_get_data', [
+      [{ name: 'memory' }],
+      bounds,
+    ]);
+    expect(fake.call).toHaveBeenCalledWith('reporting.netdata_get_data', [
+      [{ name: 'interface', identifier: 'eno1' }],
+      bounds,
+    ]);
+  });
+
+  it('returns twelve buckets however long the range is', async () => {
+    const report = await reported(healthy(), { start: '2023-10-14', end: '2023-11-15' });
+    expect(report.metrics.every((entry) => entry.buckets.length <= 12)).toBe(true);
+    expect(metric(report, 'cpu_percent').buckets).toHaveLength(12);
+    expect(report.bucket_seconds).toBe(230400);
+  });
+
+  it('marks a range the system collected nothing in, rather than returning an empty series', async () => {
+    // The samples all sit after this range, so the graph answered and held
+    // nothing inside it.
+    const report = await reported(healthy(), { start: '2023-10-14', end: '2023-11-14' });
+    expect(metric(report, 'cpu_percent')).toMatchObject({
+      min: null,
+      max: null,
+      mean: null,
+      latest: null,
+      buckets: [],
+      unavailable: 'the system collected no data for this metric in this range',
+    });
+  });
+
+  it('marks a graph carrying no series the metric can be derived from', async () => {
+    // Rows were returned, and none of them names the idle time CPU utilisation
+    // is the complement of — which is a different fact from collecting nothing.
+    expect(await cpuOnly(['time', 'user', 'system'], [[at(60_000), 5, 5]])).toMatchObject({
+      buckets: [],
+      unavailable: 'the system reported no series this metric can be derived from',
+    });
+  });
+
+  it('names a failed graph read on that metric alone', async () => {
+    const fake = reportingSystem(
+      { memory: memoryGraph, ['interface:eno1']: netGraph },
+      { failures: { cpu: new Error('netdata is not running') } },
+    );
+    const report = await reported(fake);
+    expect(metric(report, 'cpu_percent')).toMatchObject({
+      min: null,
+      buckets: [],
+      unavailable: 'netdata is not running',
+    });
+    expect(metric(report, 'memory_used_percent').unavailable).toBeNull();
+    expect(metric(report, 'network_received', 'eno1').unavailable).toBeNull();
+  });
+
+  it('names the failure however the system reported it', async () => {
+    const reasons: [unknown, string][] = [
+      [new Error('netdata is not running'), 'netdata is not running'],
+      [new Error(''), 'the system reported no reason'],
+      [{ reason: 'no such graph' }, 'no such graph'],
+      [{ message: 'transport closed' }, 'transport closed'],
+      ['reporting is disabled', 'reporting is disabled'],
+      [{}, 'the system reported no reason'],
+      [null, 'the system reported no reason'],
+    ];
+    for (const [thrown, expected] of reasons) {
+      const fake = reportingSystem({}, { failures: { cpu: thrown } });
+      expect(metric(await reported(fake), 'cpu_percent').unavailable).toBe(expected);
+    }
+  });
+
+  it('still reports both network metrics when the interface listing could not be read', async () => {
+    const fake = reportingSystem(
+      { cpu: cpuGraph, memory: memoryGraph },
+      { failures: { ['interface.query']: new Error('interfaces unavailable') } },
+    );
+    const report = await reported(fake);
+    // Absent metrics would read as a system with no network at all.
+    expect(metric(report, 'network_received')).toMatchObject({
+      interface: null,
+      buckets: [],
+      unavailable: 'interfaces unavailable',
+    });
+    expect(metric(report, 'network_sent').unavailable).toBe('interfaces unavailable');
+    expect(metric(report, 'cpu_percent').unavailable).toBeNull();
+    expect(report.truncated_interfaces).toBe(false);
+  });
+
+  it('covers six interfaces in name order and says when it left some out', async () => {
+    const fake = reportingSystem(
+      { cpu: cpuGraph, memory: memoryGraph },
+      { interfaces: ['eth7', 'eth3', 'eth1', 'eth5', 'eth2', 'eth6', 'eth4'].map((name) => ({ name })) },
+    );
+    const report = await reported(fake);
+    expect(report.truncated_interfaces).toBe(true);
+    expect(
+      report.metrics.filter((entry) => entry.metric === 'network_received').map((e) => e.interface),
+    ).toEqual(['eth1', 'eth2', 'eth3', 'eth4', 'eth5', 'eth6']);
+  });
+
+  it('graphs only the interfaces the system actually named', async () => {
+    const fake = reportingSystem(
+      { cpu: cpuGraph, memory: memoryGraph, ['interface:eno1']: netGraph },
+      { interfaces: [{ name: 'eno1' }, { name: '' }, { name: 42 }, {}] },
+    );
+    const report = await reported(fake);
+    expect(
+      report.metrics.filter((entry) => entry.metric === 'network_sent').map((e) => e.interface),
+    ).toEqual(['eno1']);
+  });
+
+  it('marks one direction unavailable while the other reports', async () => {
+    const fake = reportingSystem({
+      ['interface:eno1']: graph(['time', 'received'], [[at(60_000), 100]]),
+    });
+    const report = await reported(fake);
+    expect(metric(report, 'network_received', 'eno1').mean).toBe(100);
+    expect(metric(report, 'network_sent', 'eno1').unavailable).toBe(
+      'the system reported no series this metric can be derived from',
+    );
+  });
+
+  it('reads a legend that does not name the timestamp column', async () => {
+    expect(await cpuOnly(['user', 'system', 'idle'], [[at(60_000), 5, 5, 90]])).toMatchObject({
+      mean: 10,
+    });
+  });
+
+  it('keeps the first column of a duplicated legend name', async () => {
+    // Taking the later column would read this graph as 90% busy.
+    expect(await cpuOnly(['time', 'idle', 'idle'], [[at(60_000), 90, 10]])).toMatchObject({
+      mean: 10,
+    });
+  });
+
+  it('keeps every column in place through a legend entry that is not a name', async () => {
+    expect(await cpuOnly(['time', 42, 'idle'], [[at(60_000), 5, 90]])).toMatchObject({ mean: 10 });
+  });
+
+  it('reads a row timestamp sent as milliseconds', async () => {
+    expect(
+      await cpuOnly(['time', 'idle'], [[RANGE_START + 60_000, 90]]),
+    ).toMatchObject({ mean: 10, buckets: [10, ...new Array<null>(11).fill(null)] });
+  });
+
+  it('drops a row it cannot read a time or a value from', async () => {
+    expect(
+      await cpuOnly(
+        ['time', 'idle'],
+        ['not a row', [null, 90], [at(60_000), 'unreadable'], [at(360_000), 90]],
+      ),
+    ).toMatchObject({ min: 10, max: 10, mean: 10, latest: 10 });
+  });
+
+  it('takes the latest value from the newest sample, not the last one sent', async () => {
+    expect(
+      await cpuOnly(
+        ['time', 'idle'],
+        [
+          [at(3_600_000), 70],
+          [at(60_000), 90],
+        ],
+      ),
+    ).toMatchObject({ latest: 30 });
+  });
+
+  it('clamps CPU utilisation into nought to a hundred', async () => {
+    expect(
+      await cpuOnly(
+        ['time', 'idle'],
+        [
+          [at(60_000), 110],
+          [at(360_000), -20],
+        ],
+      ),
+    ).toMatchObject({ min: 0, max: 100 });
+  });
+
+  it('reports no memory percentage where nothing accounts for the total', async () => {
+    const missing = ['time', 'free', 'cached'];
+    const zero = ['time', 'free', 'used'];
+    const cases: [unknown[], unknown[]][] = [
+      [missing, [[at(60_000), 100, 20]]],
+      [zero, [[at(60_000), 0, 0]]],
+    ];
+    for (const [legend, data] of cases) {
+      const fake = reportingSystem({ memory: graph(legend, data) });
+      expect(metric(await reported(fake), 'memory_used_percent').unavailable).toBe(
+        'the system reported no series this metric can be derived from',
+      );
+    }
+  });
+
+  it('clamps a memory percentage the parts do not support', async () => {
+    const fake = reportingSystem({ memory: graph(['time', 'free', 'used'], [[at(60_000), 100, -50]]) });
+    expect(metric(await reported(fake), 'memory_used_percent').mean).toBe(0);
+  });
+
+  it('reads a graph the system answered in a shape this tool cannot use as no data', async () => {
+    const shapes: unknown[] = [
+      'not a list',
+      [],
+      [null],
+      [{ legend: 'not a list', data: 'not a list' }],
+      graph([], [[at(60_000), 90]]),
+    ];
+    for (const answer of shapes) {
+      const fake = reportingSystem({ cpu: answer });
+      expect(metric(await reported(fake), 'cpu_percent').min).toBeNull();
+    }
+  });
+
+  it('reads every timestamp form the catalog accepts, as UTC', async () => {
+    const starts = [
+      '2023-11-14T21:13:20Z',
+      '2023-11-14 21:13:20',
+      '2023-11-14T23:13:20+02:00',
+      '2023-11-14T19:13:20-02:00',
+    ];
+    for (const start of starts) {
+      expect((await reported(healthy(), { start })).start).toBe('2023-11-14T21:13:20.000Z');
+    }
+    expect((await reported(healthy(), { start: '2023-11-14T21:13:20.123456Z' })).start).toBe(
+      '2023-11-14T21:13:20.123Z',
+    );
+    expect((await reported(healthy(), { start: '2023-11-14' })).start).toBe(
+      '2023-11-14T00:00:00.000Z',
+    );
+  });
+
+  it('defaults each end of the range from the other', async () => {
+    // An end alone covers the hour before it, rather than an hour that may lie
+    // outside the range asked about at all.
+    expect(await reported(healthy(), { end: '2023-11-14T12:00:00Z' })).toMatchObject({
+      start: '2023-11-14T11:00:00.000Z',
+      end: '2023-11-14T12:00:00.000Z',
+    });
+    // A start alone runs to now.
+    expect(await reported(healthy(), { start: '2023-11-14T12:00:00Z', end: null })).toMatchObject({
+      start: '2023-11-14T12:00:00.000Z',
+      end: '2023-11-14T22:13:20.000Z',
+    });
+  });
+
+  it('refuses a bound it cannot read rather than silently using the default', async () => {
+    const unreadable = [
+      { start: 'last tuesday' },
+      { end: 1_700_000_000 },
+      { start: '2023-02-30' },
+      { start: '2023-13-01' },
+      { start: '0000-01-01' },
+      { start: '2023-11-14T25:00:00Z' },
+      { start: '2023-11-14T09:99:00Z' },
+      { start: '2023-11-14T09:00:00+25:00' },
+      { start: '2023-11-14T09:00:00+02:99' },
+    ];
+    for (const args of unreadable) {
+      await expect(reportingUtilisation.handler(healthy().ctx, args)).rejects.toThrow(
+        /must be an ISO 8601 timestamp/,
+      );
+    }
+  });
+
+  it('refuses a range that does not run forwards', async () => {
+    await expect(
+      reportingUtilisation.handler(healthy().ctx, {
+        start: '2023-11-14T12:00:00Z',
+        end: '2023-11-14T11:00:00Z',
+      }),
+    ).rejects.toThrow('"start" must be before "end"');
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8040,6 +8040,26 @@ describe('reporting_utilisation', () => {
     });
   });
 
+  it('marks a gap in collection as no data, not as a graph carrying no such series', async () => {
+    // Netdata stamps a second it collected nothing in with a row of nulls, so
+    // these rows are inside the range and the legend does name `idle`. Deciding
+    // this from the rows rather than from the legend would answer "this system
+    // reports no series CPU utilisation can be derived from" — that it does not
+    // record CPU at all — for what is a gap at 3am.
+    expect(
+      await cpuOnly(
+        ['time', 'user', 'system', 'idle'],
+        [
+          [at(60_000), null, null, null],
+          [at(360_000), null, null, null],
+        ],
+      ),
+    ).toMatchObject({
+      buckets: [],
+      unavailable: 'the system collected no data for this metric in this range',
+    });
+  });
+
   it('names a failed graph read on that metric alone', async () => {
     const fake = reportingSystem(
       { memory: memoryGraph, ['interface:eno1']: netGraph },
@@ -8191,20 +8211,22 @@ describe('reporting_utilisation', () => {
   });
 
   it('reports no memory percentage where nothing accounts for the total', async () => {
-    const cases: [unknown[], unknown[]][] = [
-      // No `used` to report.
-      [['time', 'free', 'cached'], [[at(60_000), 100, 20]]],
+    const noSeries = 'the system reported no series this metric can be derived from';
+    const noData = 'the system collected no data for this metric in this range';
+    const cases: [unknown[], unknown[], string][] = [
+      // No `used` to report: the graph carries no series this is derived from.
+      [['time', 'free', 'cached'], [[at(60_000), 100, 20]], noSeries],
       // `used` alone is its own total, and dividing it by itself would report
       // every system as fully out of memory.
-      [['time', 'used'], [[at(60_000), 500]]],
-      // Nothing to take a share of.
-      [['time', 'free', 'used'], [[at(60_000), 0, 0]]],
+      [['time', 'used'], [[at(60_000), 500]], noSeries],
+      // The graph carries both series and this sample has nothing to take a
+      // share of — a property of the sample rather than of the graph, so it
+      // reads as a range that yielded no measurement.
+      [['time', 'free', 'used'], [[at(60_000), 0, 0]], noData],
     ];
-    for (const [legend, data] of cases) {
+    for (const [legend, data, expected] of cases) {
       const fake = reportingSystem({ memory: graph(legend, data) });
-      expect(metric(await reported(fake), 'memory_used_percent').unavailable).toBe(
-        'the system reported no series this metric can be derived from',
-      );
+      expect(metric(await reported(fake), 'memory_used_percent').unavailable).toBe(expected);
     }
   });
 
@@ -8213,7 +8235,7 @@ describe('reporting_utilisation', () => {
     expect(metric(await reported(fake), 'memory_used_percent').mean).toBe(0);
   });
 
-  it('reads a graph the system answered in a shape this tool cannot use as no data', async () => {
+  it('reports nothing, with a stated reason, for a graph in a shape it cannot use', async () => {
     const shapes: unknown[] = [
       'not a list',
       [],
@@ -8223,7 +8245,12 @@ describe('reporting_utilisation', () => {
     ];
     for (const answer of shapes) {
       const fake = reportingSystem({ cpu: answer });
-      expect(metric(await reported(fake), 'cpu_percent').min).toBeNull();
+      const reading = metric(await reported(fake), 'cpu_percent');
+      expect(reading.min).toBeNull();
+      // Which marker it is depends on whether any row survived — the last shape
+      // holds one, under a legend naming nothing. What every shape must do is
+      // say why there is nothing, rather than report a measurement.
+      expect(reading.unavailable).not.toBeNull();
     }
   });
 


### PR DESCRIPTION
Closes #39

`reporting_utilisation` reads the metrics the middleware records for itself and
answers CPU, memory and network utilisation over a time range. `system_info`
answers the instant; this answers the interval, and is what "was it busy at
3am?" needs.

## The shape, which this ticket binds for the rest of the reporting family

A raw series is never returned. The middleware samples every few seconds, so an
hour is hundreds of points per metric and a week is tens of thousands — bigger
than an LLM can reason over and paid for by the token. Each metric comes back as
`min`, `max`, `mean` and `latest` over the whole range, plus **twelve** equal
buckets across it, each the mean of the samples inside it. Twelve regardless of
range length, so a one-week question costs exactly what a one-hour question
costs, and `bucket_seconds` states how wide one is.

Four metrics: `cpu_percent`, `memory_used_percent`, and `network_received` /
`network_sent` per interface. They are **derived**, not passed through — the CPU
graph carries one dimension per scheduler state and the memory graph one per
kind of page, and handing those over would be both unbounded and unanswerable.
Each derivation is stated in the tool description.

Every way a metric can have nothing to report is an explicit marker in
`unavailable` naming which — the read failed, the graph carried no series the
metric is derived from, the system collected nothing in the range, or (network
only) the system named no interface. Metrics fail independently, so a graph a
system does not keep does not take the rest of the result down. Where
`unavailable` is non-null the four numbers are null and `buckets` is empty, and
that is never a system that was idle.

**Which of "no such series" and "collected nothing" an empty result is is
decided from the LEGEND**, not from how many rows came back. A derivation
carries the legend names it needs (`Derivation.requires`) beside the
computation, and only a required name absent from the legend is "no such
series". That is the whole point of the distinction: netdata stamps a second it
collected nothing in with a row of nulls, so counting rows would report a
collection gap — the middleware down at 3am, which is precisely this tool's
question — as a system that does not record CPU at all. A graph holding no row
in the range at all stays "collected nothing" whatever its legend named, which
is the weaker of the two claims and the only one the answer supports.

The network metrics cover at most six interfaces in name order, with
`truncated_interfaces` saying when the cap left some out. Bridges, VLANs and
aggregations are reported alongside the ports beneath them, so summing
interfaces double-counts; the description says so rather than guessing which the
caller meant.

## What was unconfirmed in the ticket, and what I found

- **`reporting.netdata_get_data` is in the pinned client** — the ticket noted it
  was absent from the `TrueNasEndpoint` enum. It is present in
  `ApiCallDirectory$7`, which is `DefaultApiDirectory` and therefore the surface
  `ApiSurface` resolves to, typed
  `params: [graphs: GraphIdentifier[], query?: ReportingQuery]`. `yarn typecheck`
  passes against it with no cast. The graph names come from the client's own
  `Name` constant, which lists `cpu`, `memory` and `interface` among others.
- **`aggregations` on the response is not read.** It is typed
  `{ min|mean|max: { [k: string]: unknown } }` — keyed by the graph's own
  dimensions, which are not the metrics reported here — so the four numbers are
  computed from the samples instead. That also makes `latest`, which the
  aggregations do not carry, come from the same place as the rest.

Still unconfirmed against a live middleware, each noted where it is relied on:

- Which dimensions each graph carries. Read defensively — a wrong reading costs
  a stated `unavailable` rather than a plausible wrong number.
- That a data row is `[timestamp, ...values]` aligned to `legend`. Whether the
  legend names the timestamp column as its own first entry is **read** rather
  than assumed, because getting it wrong would shift every series onto its
  neighbour's numbers.
- That query bounds and row timestamps are unix seconds. A row value too large
  to be a plausible second is read as milliseconds instead, so a middleware that
  sends those places its samples rather than dating all of them to 1970.
- **The one that would be wrong rather than absent:** the unit the interface
  graph records. Values are passed through and `unit` says
  `kilobits_per_second`, which is netdata's own unit for that chart. A release
  recording bytes per second would be mislabelled. It is stated rather than
  omitted because a throughput with no unit cannot be compared with anything.

## Review

Three local rounds so far, plus one round of the required check on the PR.

Rounds one and two ran through `local-review.py` against the shared reviewer —
the same rubric, threshold and parser as the required check, in a separate
process. Round one found and this fixes:

- **HIGH** — `memory_used_percent` divided `used` by a total that `used` is
  itself summed into, so a graph carrying `used` and no other partition
  dimension reported 100% on every sample: a system at three percent of its
  memory presented as one out of it. `free` is now required beside `used`;
  `cached` and `buffers` stay optional.
- **MEDIUM** — an interface listing that was read and named nothing dropped both
  network metrics with no marker, which is the "a system with no network"
  reading the listing-failure branch beside it exists to prevent.

Round two returned nothing at MEDIUM or above, and the PR was opened. The
required check then found one MEDIUM, which the latest commit fixes:

- **MEDIUM** — a collection gap covering the whole range was reported as
  `NO_DIMENSION` rather than `NO_DATA`. `points()` counted a row as in-range as
  soon as its timestamp was readable, whatever its values were, so a window
  inside retention but inside a gap produced rows that were in range and yielded
  nothing, and fell past `NO_DATA` into `NO_DIMENSION` — telling the caller the
  graph carries no such series at all. The two are now separated by the legend,
  as described under **The shape** above. The memory graph whose parts sum to
  zero moves with it: the graph does carry `used` and `free`, so it reads as a
  range that yielded no measurement rather than as one with no such series, and
  the test that pinned the old reason moves too. A gap under a legend that names
  the dimension is now a test.

**Round three is weaker than the two before it, and than the check.** The shared
reviewer timed out at its 420s cap without producing findings, so
`local-review.py` fell back to writing a brief and a subagent applied the same
rubric in a separate process instead. It returned four findings, all LOW —
nothing at MEDIUM or above. That is the same threshold, applied by a different
reader.

## LOW findings not acted on

Left deliberately, per the round rule — each is worth a later look and none
blocks:

- `utcMillis` / `RANGE_TIME` duplicate ~55 lines of the timestamp parsing in
  `system.ts` (raised by both the check and round three). Deliberate here: the
  two tools are read on their own and a caller who learned one timestamp grammar
  for this catalog should not meet a second. The finding is fair that a fix to
  one copy will not reach the other, and the reporting family is about to add
  four more tools that each want a range — the right time to extract a shared
  parser is when the second reporting tool lands, not inside this one's scope.
- A `netdata_get_data` response in a shape this tool cannot use degrades to an
  empty legend and no rows, and is reported as "collected no data", which
  asserts slightly more about the system's recording than was established. A
  fifth marker — the read succeeded and the answer could not be understood —
  would separate a middleware whose response shape changed from a system with an
  empty window. Same class as the MEDIUM above and a candidate for the same
  treatment, but it is a shape nothing is known to send.
- The `samples.inRange > 0` conjunct in `graphMetric` — which is what keeps a
  graph with no row in the range reading as "collected no data" whatever its
  legend named — is not pinned by a test: removing it leaves all 567 passing.
  The branch is covered, the behaviour is not distinguished. A case with a
  legend missing `idle` and no row inside the range would close it.
- Each interface graph is walked twice, once per direction, re-running the
  legend index and a fresh dimension map per row. Deriving both directions in
  one pass would halve it. The output is identical either way.
- `interface.query` is awaited before the CPU and memory graph reads are issued,
  costing one sequential round trip. It is the read that decides which graphs to
  ask for, so overlapping it would mean issuing the interface graphs afterwards
  anyway; the saving is smaller than it looks.
- Nothing caps how wide a range may be asked for. The result is bounded by
  construction; the read is not, so a very early `start` asks the middleware for
  a long series. Retention truncates it in practice, so this is latency and
  payload rather than a wrong answer.
- In `tools.spec.ts`, `metrics.every((entry) => entry.buckets.length <= 12)`
  holds vacuously for a result where every metric is unavailable; the
  `toHaveLength(12)` on the next line is what carries that test.
- No test covers one interface's graph failing while another still reports,
  though the per-graph isolation itself is tested on CPU.
- `reporting_utilisation` is British-spelled, unlike the rest of the catalog.
  It is the name the ticket specifies and the name the whole family is filed
  under, so changing it is not this PR's call.

One finding from the check was acted on rather than deferred: the
unusable-shape test was named for a marker it did not assert. Its name now
matches what it checks — that a reason is stated at all — because the fix above
changes which marker one of its shapes produces.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
locally — the four steps `ci.yml` gates on. 567 tests pass. `reporting.ts` is at
100% statement and branch coverage; the global floors (branches 96, statements
97) are unchanged and still met.
