### PR TITLE
feat(tools): add reporting_disk_io, per-disk throughput, IOPS and latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
-  `reporting_utilisation`.
+  `reporting_utilisation`, `reporting_disk_io`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,5 +89,6 @@ export {
   certificatesList,
   cloudCredentialsList,
   reportingUtilisation,
+  reportingDiskIo,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,7 +9,7 @@ import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
-import { reportingUtilisation } from '@/tools/reporting';
+import { reportingDiskIo, reportingUtilisation } from '@/tools/reporting';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
@@ -17,7 +17,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: twenty-nine read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -49,6 +49,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(cloudCredentialsList);
   catalog.register(alertSettings);
   catalog.register(reportingUtilisation);
+  catalog.register(reportingDiskIo);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -73,6 +74,7 @@ export {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingDiskIo,
   reportingUtilisation,
   scrubHistory,
   shareAccess,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -715,9 +715,12 @@ interface DiskMeasurement {
  * recorded operation counts and I/O wait times would plausibly call them, and
  * on every release this was written against the graph carries neither — which
  * is why the tool's description says those two are commonly unavailable rather
- * than promising them. A name guessed wrong costs a stated `unavailable`, never
- * a wrong number, which is the whole reason the dimension travels with the
- * derivation; see {@link Derivation}.
+ * than promising them. A name that no release carries costs a stated
+ * `unavailable` rather than a number, which is the whole reason the dimension
+ * travels with the derivation; see {@link Derivation}. What that does NOT cover
+ * is a name a release carries under other semantics — the value would then be
+ * reported under the unit asserted here — so the four guessed names are ones
+ * netdata uses for these quantities and nothing else.
  */
 const DISK_MEASUREMENTS: DiskMeasurement[] = [
   { metric: 'read_throughput', unit: DISK_THROUGHPUT_UNIT, derive: magnitude('reads') },
@@ -769,9 +772,10 @@ function graphedNames(rows: unknown[], cap: number): Omit<Graphed, 'error'> {
  */
 async function interfaceNames(system: SystemHandle): Promise<Graphed> {
   try {
-    // Inlined rather than shared with `diskNames` below: the client types
-    // `query` per method, and a method name reaching it through a variable
-    // widens to `string` and loses the row type with it.
+    // The call is inlined rather than shared with `diskNames` below, as the
+    // graph reads are inlined above: the client types `query` per method, so a
+    // method name reaching it through a variable widens to `string` and no
+    // longer selects an overload. Only the sort-and-cap step is shared.
     const rows = await firstValueFrom(system.client.api.query('interface.query'));
     return { ...graphedNames(rows, MAX_INTERFACES), error: null };
   } catch (reason) {

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -26,10 +26,16 @@ import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
  * (unconfirmed) against a live middleware, and each is noted where it is relied
  * on: which dimensions each graph carries, that a data row is
  * `[timestamp, ...values]` aligned to `legend`, that the query bounds are unix
- * seconds, and the unit the interface graph records. Each is read defensively —
- * a wrong reading costs a stated `unavailable` rather than a plausible wrong
- * value — except the interface unit, which is named in the result and would be
- * wrong rather than absent; see `NETWORK_UNIT`.
+ * seconds, and the units the interface and disk graphs record. Each is read
+ * defensively — a wrong reading costs a stated `unavailable` rather than a
+ * plausible wrong value — except those two units, which are named in the result
+ * and would be wrong rather than absent; see `NETWORK_UNIT` and
+ * `DISK_THROUGHPUT_UNIT`.
+ *
+ * The range, the bucketing, the markers and the summary are shared by every
+ * tool here, so a caller who has learned one of them has learned the family.
+ * What differs per tool is the label a metric carries — the interface it was
+ * measured on, or the disk — and which dimension each metric is derived from.
  */
 
 /**
@@ -63,6 +69,19 @@ const BUCKETS = 12;
  */
 const MAX_INTERFACES = 6;
 
+/**
+ * How many disks the disk metrics cover.
+ *
+ * The same cap as {@link MAX_INTERFACES}, and for the same reason: a disk
+ * shelf is unbounded, and six is a number a caller can read. It bites harder
+ * here — a shelf of twenty-four disks is ordinary where twenty-four interfaces
+ * are not, and this tool reports six metrics per disk rather than two — so
+ * `truncated_disks` matters more than its network counterpart, and the
+ * description says plainly that the answer covers the first six disks IN NAME
+ * ORDER rather than the six most interesting ones.
+ */
+const MAX_DISKS = 6;
+
 /** What a failure carrying no text of its own is reported as. */
 const NO_REASON = 'the system reported no reason';
 
@@ -74,6 +93,12 @@ const NO_DATA = 'the system collected no data for this metric in this range';
  * and named nothing to graph.
  */
 const NO_INTERFACES = 'the system named no interface to graph';
+
+/**
+ * What the disk metrics are marked with where the disk listing was read and
+ * named nothing to graph.
+ */
+const NO_DISKS = 'the system named no disk to graph';
 
 /**
  * What a metric whose graph's LEGEND did not name the dimension it is derived
@@ -235,7 +260,7 @@ function resolveRange(args: Record<string, unknown>, now: number): Range {
  * `interface` is per-interface and carries an identifier; the other two are
  * system-wide and carry none.
  */
-type GraphName = 'cpu' | 'memory' | 'interface';
+type GraphName = 'cpu' | 'memory' | 'interface' | 'disk';
 
 /** What one graph read produced, with a failure named rather than thrown. */
 interface GraphAttempt {
@@ -426,13 +451,46 @@ function round1(value: number): number {
   return Math.round(value * 10) / 10;
 }
 
-/** The metrics this tool reports. */
+/** The metrics `reporting_utilisation` reports. */
 type MetricName = 'cpu_percent' | 'memory_used_percent' | 'network_received' | 'network_sent';
 
-/** One metric over the range, or the stated reason there is none. */
-interface MetricReport {
+/** The metrics `reporting_disk_io` reports. */
+type DiskMetricName =
+  | 'read_throughput'
+  | 'write_throughput'
+  | 'read_iops'
+  | 'write_iops'
+  | 'read_latency'
+  | 'write_latency';
+
+/**
+ * What names one of `reporting_utilisation`'s metrics: which of the four it is,
+ * and the interface a network metric was measured on.
+ */
+interface UtilisationLabel {
   metric: MetricName;
   interface: string | null;
+}
+
+/**
+ * What names one of `reporting_disk_io`'s metrics: which of the six it is, and
+ * the disk it was measured on.
+ */
+interface DiskLabel {
+  metric: DiskMetricName;
+  disk: string | null;
+}
+
+/**
+ * What every metric carries beyond the label naming it — the summary, or the
+ * stated reason there is none.
+ *
+ * Split from the label because the two tools here name their metrics
+ * differently (an interface, or a disk) and summarise them identically. The
+ * label is SPREAD FIRST into the result, so a metric reads with its identity
+ * ahead of its numbers whichever tool produced it.
+ */
+interface MetricBody {
   unit: string;
   min: number | null;
   max: number | null;
@@ -442,16 +500,16 @@ interface MetricReport {
   unavailable: string | null;
 }
 
+/** One of `reporting_utilisation`'s metrics over the range. */
+type MetricReport = UtilisationLabel & MetricBody;
+
+/** One of `reporting_disk_io`'s metrics over the range. */
+type DiskMetricReport = DiskLabel & MetricBody;
+
 /** A metric with nothing to report, and why. */
-function unavailable(
-  metric: MetricName,
-  iface: string | null,
-  unit: string,
-  reason: string,
-): MetricReport {
+function unavailable<L extends object>(label: L, unit: string, reason: string): L & MetricBody {
   return {
-    metric,
-    interface: iface,
+    ...label,
     unit,
     min: null,
     max: null,
@@ -479,13 +537,12 @@ function unavailable(
  * decides that an empty list is a marker rather than a summary, and which of the
  * markers it is.
  */
-function summarise(
-  metric: MetricName,
-  iface: string | null,
+function summarise<L extends object>(
+  label: L,
   unit: string,
   found: Point[],
   range: Range,
-): MetricReport {
+): L & MetricBody {
   const width = (range.end - range.start) / BUCKETS;
   const sums = new Array<number>(BUCKETS).fill(0);
   const counts = new Array<number>(BUCKETS).fill(0);
@@ -505,8 +562,7 @@ function summarise(
     counts[bucket] += 1;
   }
   return {
-    metric,
-    interface: iface,
+    ...label,
     unit,
     min: round1(min),
     max: round1(max),
@@ -598,15 +654,16 @@ const memoryUsedPercent: Derivation = {
 };
 
 /**
- * The magnitude of one direction of interface traffic.
+ * The magnitude of one dimension, whatever it measures.
  *
- * The magnitude rather than the value, because netdata's interface chart mirrors
- * one direction below the axis to draw it: a sent rate arrives negative on a
- * link that is sending, and passing it through would report a busy link as one
- * with less than no traffic. Direction is what the metric name says, so the sign
- * carries nothing this result needs.
+ * The magnitude rather than the value, because netdata mirrors one direction of
+ * a two-way chart below the axis to draw it — on the interface chart and on the
+ * disk one alike: a sent rate arrives negative on a link that is sending, and a
+ * write rate negative on a disk that is writing. Passing that through would
+ * report a busy link, or a busy disk, as one doing less than nothing. Direction
+ * is what the metric NAME says, so the sign carries nothing the result needs.
  */
-function throughput(dimension: string): Derivation {
+function magnitude(dimension: string): Derivation {
   return {
     requires: [dimension],
     from: (dimensions) => {
@@ -616,11 +673,86 @@ function throughput(dimension: string): Derivation {
   };
 }
 
-/** The interfaces to report, and whether the cap left any out. */
-interface Interfaces {
+/**
+ * The unit the disk throughput metrics are reported in.
+ *
+ * (unconfirmed), and the same kind of assumption as {@link NETWORK_UNIT}: the
+ * disk graph's values are passed through, so a release recording bytes per
+ * second would be reported as kibibytes per second. Stated rather than omitted
+ * because a throughput with no unit cannot be compared with anything, and the
+ * reading is netdata's own, which records the disk chart in KiB/s.
+ */
+const DISK_THROUGHPUT_UNIT = 'kibibytes_per_second';
+
+/** The unit the disk IOPS metrics are reported in. */
+const IOPS_UNIT = 'operations_per_second';
+
+/** The unit the disk latency metrics are reported in. */
+const LATENCY_UNIT = 'milliseconds';
+
+/** One of the six measurements `reporting_disk_io` reports per disk. */
+interface DiskMeasurement {
+  metric: DiskMetricName;
+  unit: string;
+  derive: Derivation;
+}
+
+/**
+ * The six measurements, and the dimension of the disk graph each is derived
+ * from.
+ *
+ * All six come from the ONE `disk` graph, because there is no second one to
+ * read: the client types `reporting.netdata_get_data`'s graph name as a closed
+ * union — `cpu`, `cputemp`, `disk`, `disktemp`, `interface`, `load`, `memory`,
+ * `processes`, `uptime`, `arcsize` and the UPS graphs — and `disk` is the only
+ * member of it that is per-disk I/O. So whether this system can report IOPS and
+ * latency at all is a question about that graph's LEGEND, and it is asked as
+ * one: each metric names the dimension it needs, and a graph that does not
+ * carry it answers {@link NO_DIMENSION} rather than a number.
+ *
+ * (unconfirmed) every dimension name below. `reads` and `writes` are netdata's
+ * own for the disk chart's throughput. The other four are what a release that
+ * recorded operation counts and I/O wait times would plausibly call them, and
+ * on every release this was written against the graph carries neither — which
+ * is why the tool's description says those two are commonly unavailable rather
+ * than promising them. A name guessed wrong costs a stated `unavailable`, never
+ * a wrong number, which is the whole reason the dimension travels with the
+ * derivation; see {@link Derivation}.
+ */
+const DISK_MEASUREMENTS: DiskMeasurement[] = [
+  { metric: 'read_throughput', unit: DISK_THROUGHPUT_UNIT, derive: magnitude('reads') },
+  { metric: 'write_throughput', unit: DISK_THROUGHPUT_UNIT, derive: magnitude('writes') },
+  { metric: 'read_iops', unit: IOPS_UNIT, derive: magnitude('read_ops') },
+  { metric: 'write_iops', unit: IOPS_UNIT, derive: magnitude('write_ops') },
+  { metric: 'read_latency', unit: LATENCY_UNIT, derive: magnitude('read_await') },
+  { metric: 'write_latency', unit: LATENCY_UNIT, derive: magnitude('write_await') },
+];
+
+/** The things to graph, and whether the cap left any out. */
+interface Graphed {
   names: string[];
   truncated: boolean;
   error: string | null;
+}
+
+/**
+ * The `name` of every row that has one, in name order, up to the cap.
+ *
+ * Sorted BEFORE the cap, so which of them a capped result covers is a property
+ * of the system rather than of the order it happened to list them.
+ *
+ * A row that is not a record, or whose name is not a non-empty string, names
+ * nothing that could be graphed and is dropped: the identifier is what the
+ * graph is asked for by, so a row without one has no graph to read.
+ */
+function graphedNames(rows: unknown[], cap: number): Omit<Graphed, 'error'> {
+  const named = rows.flatMap((row) => {
+    if (typeof row !== 'object' || row === null) return [];
+    const name = textOrNull((row as Record<string, unknown>)['name']);
+    return name === null ? [] : [name];
+  });
+  named.sort();
+  return { names: named.slice(0, cap), truncated: named.length > cap };
 }
 
 /**
@@ -635,21 +767,35 @@ interface Interfaces {
  * A listing that could not be read is named rather than thrown: CPU and memory
  * are still an answer, and the network metrics say why they are not one.
  */
-async function interfaceNames(system: SystemHandle): Promise<Interfaces> {
+async function interfaceNames(system: SystemHandle): Promise<Graphed> {
   try {
+    // Inlined rather than shared with `diskNames` below: the client types
+    // `query` per method, and a method name reaching it through a variable
+    // widens to `string` and loses the row type with it.
     const rows = await firstValueFrom(system.client.api.query('interface.query'));
-    const named = rows.flatMap((row) => {
-      const name = textOrNull(row['name']);
-      return name === null ? [] : [name];
-    });
-    // Sorted before the cap, so which interfaces a capped result covers is a
-    // property of the system rather than of the order it happened to list them.
-    named.sort();
-    return {
-      names: named.slice(0, MAX_INTERFACES),
-      truncated: named.length > MAX_INTERFACES,
-      error: null,
-    };
+    return { ...graphedNames(rows, MAX_INTERFACES), error: null };
+  } catch (reason) {
+    return { names: [], truncated: false, error: errorText(reason) };
+  }
+}
+
+/**
+ * The disks to graph: every one the system lists, in name order, up to the cap.
+ *
+ * The device name rather than the serial, because the name is what the disk
+ * graph is identified by. Every disk the system knows is kept, whether or not
+ * it belongs to a pool: a disk being hammered while in no pool is exactly the
+ * kind of thing this tool is asked about, and `disks_list` is where pool
+ * membership is answered.
+ *
+ * A listing that could not be read is named rather than thrown, as the
+ * interface listing is: the metrics then say why there is nothing rather than
+ * the whole call failing.
+ */
+async function diskNames(system: SystemHandle): Promise<Graphed> {
+  try {
+    const rows = await firstValueFrom(system.client.api.query('disk.query'));
+    return { ...graphedNames(rows, MAX_DISKS), error: null };
   } catch (reason) {
     return { names: [], truncated: false, error: errorText(reason) };
   }
@@ -739,8 +885,14 @@ export const reportingUtilisation: ReadOnlyTool = {
     ]);
 
     const metrics: MetricReport[] = [
-      graphMetric('cpu_percent', null, PERCENT, cpu, range, cpuPercent),
-      graphMetric('memory_used_percent', null, PERCENT, memory, range, memoryUsedPercent),
+      graphMetric<UtilisationLabel>({ metric: 'cpu_percent', interface: null }, PERCENT, cpu, range, cpuPercent),
+      graphMetric<UtilisationLabel>(
+        { metric: 'memory_used_percent', interface: null },
+        PERCENT,
+        memory,
+        range,
+        memoryUsedPercent,
+      ),
     ];
     if (interfaces.names.length === 0) {
       // Both network metrics are still reported, carrying the reason no
@@ -749,15 +901,35 @@ export const reportingUtilisation: ReadOnlyTool = {
       // all, which is the one thing a result must not imply here.
       const reason = interfaces.error ?? NO_INTERFACES;
       metrics.push(
-        unavailable('network_received', null, NETWORK_UNIT, reason),
-        unavailable('network_sent', null, NETWORK_UNIT, reason),
+        unavailable<UtilisationLabel>(
+          { metric: 'network_received', interface: null },
+          NETWORK_UNIT,
+          reason,
+        ),
+        unavailable<UtilisationLabel>(
+          { metric: 'network_sent', interface: null },
+          NETWORK_UNIT,
+          reason,
+        ),
       );
     }
     interfaces.names.forEach((name, position) => {
       const graph = network[position];
       metrics.push(
-        graphMetric('network_received', name, NETWORK_UNIT, graph, range, throughput('received')),
-        graphMetric('network_sent', name, NETWORK_UNIT, graph, range, throughput('sent')),
+        graphMetric<UtilisationLabel>(
+          { metric: 'network_received', interface: name },
+          NETWORK_UNIT,
+          graph,
+          range,
+          magnitude('received'),
+        ),
+        graphMetric<UtilisationLabel>(
+          { metric: 'network_sent', interface: name },
+          NETWORK_UNIT,
+          graph,
+          range,
+          magnitude('sent'),
+        ),
       );
     });
 
@@ -767,6 +939,126 @@ export const reportingUtilisation: ReadOnlyTool = {
       bucket_seconds: round1((range.end - range.start) / BUCKETS / 1000),
       metrics,
       truncated_interfaces: interfaces.truncated,
+    };
+  },
+};
+
+export const reportingDiskIo: ReadOnlyTool = {
+  name: 'reporting_disk_io',
+  description:
+    'Per-disk throughput, IOPS and latency on a TrueNAS system OVER A TIME ' +
+    'RANGE, from the metrics the system records for itself. This is what ' +
+    'answers "which disk is slow" and "was that disk slow at 3am" — latency ' +
+    'is how a failing disk announces itself before SMART does, and it is what ' +
+    'explains a slow pool when every capacity and health figure looks fine. ' +
+    '`metrics` holds one entry per measurement per disk, each with: `metric`, ' +
+    'which of the six it is; `disk`, the device name it was measured on; ' +
+    '`unit`, what the numbers are in; `min`, `max` and `mean` over the whole ' +
+    'range; `latest`, the value at the most recent sample IN THE RANGE, which ' +
+    'is not the value now unless the range ends now; and `buckets`. ' +
+    '`read_throughput` and `write_throughput` are data moved per second in ' +
+    'each direction, reported as a magnitude. `read_iops` and `write_iops` are ' +
+    'operations per second, and `read_latency` and `write_latency` the average ' +
+    'wait per operation in milliseconds. THE IOPS AND LATENCY METRICS ARE ' +
+    'COMMONLY UNAVAILABLE: they come from the same per-disk graph as ' +
+    'throughput, and a system whose graph records throughput only reports them ' +
+    'with `unavailable` set rather than omitting them — that is a fact about ' +
+    'what the system records, NOT about the disk, and it is not worth ' +
+    'retrying. At most six disks are covered, IN NAME ORDER — not the six ' +
+    'busiest — and `truncated_disks` is true when the system has more than ' +
+    'that and some were left out, so on a large shelf this reports a slice ' +
+    'chosen alphabetically. Every disk the system knows is eligible whether or ' +
+    'not it is in a pool; `disks_list` is what says which pool a disk belongs ' +
+    'to, and this tool does not say. `buckets` is twelve entries on every ' +
+    'metric that was measured: the range is divided into twelve equal ' +
+    'intervals and each entry is the MEAN of the samples inside its interval, ' +
+    'oldest first, so the width of one is a twelfth of the range and is given ' +
+    'as `bucket_seconds`. A bucket the system collected nothing in is NULL, ' +
+    'WHICH IS NOT ZERO — no measurement was taken, and the disk may have been ' +
+    'at any rate. Raw samples are never returned: an hour is hundreds of them ' +
+    'per metric, so the summary and the twelve buckets are the whole answer ' +
+    'and the result is the same size whatever range is asked for. ' +
+    '`unavailable` is null on a metric that was measured, and otherwise names ' +
+    'why there is nothing to report — the system collected no data for that ' +
+    'disk in the range, its graph carried no series this metric could be ' +
+    'derived from, the read itself failed with the reason the system gave, or ' +
+    '— on entries that then carry a null `disk` — the system named no disk to ' +
+    'graph at all. WHERE IT IS NON-NULL, `min`, `max`, `mean` and `latest` ARE ' +
+    'ALL NULL AND `buckets` IS EMPTY, and that is never a disk that was idle: ' +
+    'nothing was measured. Metrics fail independently, so one disk can report ' +
+    'while another is unavailable, and a disk can report throughput while its ' +
+    'own IOPS and latency are not. `start` and `end` are the range actually ' +
+    'reported on, as ISO 8601 UTC timestamps, so an unavailable metric is ' +
+    'readable against the window it was asked for. Give `start` and `end` to ' +
+    'bound the range; OMITTED, THE LAST HOUR ending now, and a `start` with no ' +
+    '`end` runs to now while an `end` with no `start` covers the hour before ' +
+    'it. This tool reads recorded metrics. It does not report SMART attributes ' +
+    'or disk temperature, per-pool or per-dataset activity, or which workload ' +
+    'caused the I/O, and it changes nothing about what the system records.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      start: {
+        type: 'string',
+        description:
+          'The beginning of the range, as an ISO 8601 timestamp — ' +
+          '"2026-08-29T09:00:00Z" — or a date, "2026-08-29", which is ' +
+          'midnight. A time given without a timezone is read as UTC. Omitted, ' +
+          'one hour before the end of the range.',
+      },
+      end: {
+        type: 'string',
+        description: 'The end of the range, in the same forms as `start`. Omitted, now.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // The range is resolved before anything is read, so an unreadable bound is
+    // an error rather than a query the system answers over the wrong interval.
+    const range = resolveRange(args, Date.now());
+    // The disk listing is what decides which graphs are read, so it is the one
+    // read that cannot be issued alongside the others.
+    const disks = await diskNames(system);
+    const graphs = await Promise.all(
+      disks.names.map((name) => readGraph(system, 'disk', name, range)),
+    );
+
+    const metrics: DiskMetricReport[] = [];
+    if (disks.names.length === 0) {
+      // All six metrics are still reported, carrying the reason no disk could
+      // be graphed — the listing failed, or it was read and named none. Absent
+      // metrics would read as a system with no disks at all, which is the one
+      // thing a result must not imply here.
+      const reason = disks.error ?? NO_DISKS;
+      for (const measurement of DISK_MEASUREMENTS) {
+        metrics.push(
+          unavailable<DiskLabel>({ metric: measurement.metric, disk: null }, measurement.unit, reason),
+        );
+      }
+    }
+    disks.names.forEach((name, position) => {
+      const graph = graphs[position];
+      for (const measurement of DISK_MEASUREMENTS) {
+        metrics.push(
+          graphMetric<DiskLabel>(
+            { metric: measurement.metric, disk: name },
+            measurement.unit,
+            graph,
+            range,
+            measurement.derive,
+          ),
+        );
+      }
+    });
+
+    return {
+      start: new Date(range.start).toISOString(),
+      end: new Date(range.end).toISOString(),
+      bucket_seconds: round1((range.end - range.start) / BUCKETS / 1000),
+      metrics,
+      truncated_disks: disks.truncated,
     };
   },
 };
@@ -793,20 +1085,19 @@ export const reportingUtilisation: ReadOnlyTool = {
  * system's answer supports: nothing was collected here, and a legend alone says
  * nothing about whether the series would have been derivable had it been.
  */
-function graphMetric(
-  metric: MetricName,
-  iface: string | null,
+function graphMetric<L extends object>(
+  label: L,
   unit: string,
   graph: GraphAttempt,
   range: Range,
   derive: Derivation,
-): MetricReport {
-  if (graph.error !== null) return unavailable(metric, iface, unit, graph.error);
+): L & MetricBody {
+  if (graph.error !== null) return unavailable(label, unit, graph.error);
   const carried = columns(graph.legend);
   const samples = points(graph.rows, carried, range, derive);
-  if (samples.found.length > 0) return summarise(metric, iface, unit, samples.found, range);
+  if (samples.found.length > 0) return summarise(label, unit, samples.found, range);
   if (samples.inRange > 0 && derive.requires.some((name) => !carried.has(name))) {
-    return unavailable(metric, iface, unit, NO_DIMENSION);
+    return unavailable(label, unit, NO_DIMENSION);
   }
-  return unavailable(metric, iface, unit, NO_DATA);
+  return unavailable(label, unit, NO_DATA);
 }

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -23,6 +23,7 @@ import {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingDiskIo,
   reportingUtilisation,
   scrubHistory,
   shareAccess,
@@ -77,7 +78,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty sketch tools', () => {
+  it('registers the thirty-one sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -108,6 +109,7 @@ describe('createDefaultCatalog', () => {
       'cloud_credentials_list',
       'alert_settings',
       'reporting_utilisation',
+      'reporting_disk_io',
       'snapshots_create',
     ]);
   });
@@ -115,6 +117,12 @@ describe('createDefaultCatalog', () => {
   it('advertises reporting_utilisation to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'reporting_utilisation',
+    );
+  });
+
+  it('advertises reporting_disk_io to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'reporting_disk_io',
     );
   });
 
@@ -8308,6 +8316,313 @@ describe('reporting_utilisation', () => {
   it('refuses a range that does not run forwards', async () => {
     await expect(
       reportingUtilisation.handler(healthy().ctx, {
+        start: '2023-11-14T12:00:00Z',
+        end: '2023-11-14T11:00:00Z',
+      }),
+    ).rejects.toThrow('"start" must be before "end"');
+  });
+});
+
+describe('reporting_disk_io', () => {
+  /** The same fixed present as `reporting_utilisation`, for the same reason. */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+  /** NOW minus the tool's one-hour default range. */
+  const RANGE_START = NOW - 60 * 60 * 1000; // 2023-11-14T21:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** A sample time inside the default range, in the unix seconds a row carries. */
+  const at = (offset: number): number => (RANGE_START + offset) / 1000;
+
+  /** A graph as `reporting.netdata_get_data` answers with one. */
+  const graph = (legend: unknown[], data: unknown[]): unknown => [
+    { name: 'disk', identifier: 'sda', data, aggregations: {}, start: 0, end: 0, legend },
+  ];
+
+  /**
+   * Two samples of a disk moving data, with the write direction mirrored below
+   * the axis as netdata draws it.
+   */
+  const diskGraph = graph(
+    ['time', 'reads', 'writes'],
+    [
+      [at(60_000), 100, -40],
+      [at(3_600_000), 300, -80],
+    ],
+  );
+
+  interface Fake {
+    ctx: ToolContext;
+    call: ReturnType<typeof vi.fn>;
+    query: ReturnType<typeof vi.fn>;
+  }
+
+  /**
+   * A SystemHandle answering per DISK: every graph comes back from the same
+   * `reporting.netdata_get_data` call, distinguished only by the identifier
+   * asked for, so graphs are keyed by disk name and a key present in `failures`
+   * rejects instead.
+   */
+  const diskSystem = (
+    graphs: Record<string, unknown>,
+    options: { disks?: unknown; failures?: Record<string, unknown> } = {},
+  ): Fake => {
+    const failures = options.failures ?? {};
+    const call = vi.fn((method: string, params?: unknown) => {
+      const asked = (params as [{ name: string; identifier?: string }[]])[0][0];
+      const key = asked.identifier ?? asked.name;
+      return key in failures ? throwError(() => failures[key]) : of(graphs[key]);
+    });
+    const query = vi.fn(() =>
+      'disk.query' in failures
+        ? throwError(() => failures['disk.query'])
+        : of(options.disks ?? [{ name: 'sda' }]),
+    );
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    return { ctx: { system }, call, query };
+  };
+
+  /** A system with one disk that has a graph. */
+  const healthy = (): Fake => diskSystem({ sda: diskGraph });
+
+  interface Metric {
+    metric: string;
+    disk: string | null;
+    unit: string;
+    min: number | null;
+    max: number | null;
+    mean: number | null;
+    latest: number | null;
+    buckets: (number | null)[];
+    unavailable: string | null;
+  }
+
+  interface Report {
+    start: string;
+    end: string;
+    bucket_seconds: number;
+    metrics: Metric[];
+    truncated_disks: boolean;
+  }
+
+  const reported = async (fake: Fake, args: Record<string, unknown> = {}): Promise<Report> =>
+    (await reportingDiskIo.handler(fake.ctx, args)) as Report;
+
+  /** One metric of a result, by name and by the disk it was measured on. */
+  const metric = (report: Report, name: string, disk: string | null = 'sda'): Metric =>
+    report.metrics.filter((entry) => entry.metric === name && entry.disk === disk)[0];
+
+  it('summarises each direction of throughput over the range and buckets it twelve ways', async () => {
+    expect(metric(await reported(healthy()), 'read_throughput')).toEqual({
+      metric: 'read_throughput',
+      disk: 'sda',
+      unit: 'kibibytes_per_second',
+      min: 100,
+      max: 300,
+      mean: 200,
+      latest: 300,
+      // The second sample sits exactly at the end of the range and lands in the
+      // last bucket rather than one past it.
+      buckets: [100, null, null, null, null, null, null, null, null, null, null, 300],
+      unavailable: null,
+    });
+  });
+
+  it('reports the write direction as a magnitude', async () => {
+    // Writes arrive negative, mirrored below the axis; a disk under write load
+    // must not report as one doing less than nothing.
+    expect(metric(await reported(healthy()), 'write_throughput')).toMatchObject({
+      unit: 'kibibytes_per_second',
+      min: 40,
+      max: 80,
+      mean: 60,
+      latest: 80,
+      unavailable: null,
+    });
+  });
+
+  it('reports IOPS and latency as unavailable where the graph carries no such series', async () => {
+    const report = await reported(healthy());
+    const noSeries = 'the system reported no series this metric can be derived from';
+    for (const name of ['read_iops', 'write_iops', 'read_latency', 'write_latency']) {
+      // Present with a stated reason rather than omitted: that the system
+      // records throughput only is a fact about the system, and dropping the
+      // metrics would read as a disk that did no operations at all.
+      expect(metric(report, name)).toMatchObject({ min: null, buckets: [], unavailable: noSeries });
+    }
+    expect(metric(report, 'read_iops').unit).toBe('operations_per_second');
+    expect(metric(report, 'read_latency').unit).toBe('milliseconds');
+  });
+
+  it('summarises IOPS and latency from a graph that does carry them', async () => {
+    const fake = diskSystem({
+      sda: graph(
+        ['time', 'read_ops', 'write_ops', 'read_await', 'write_await'],
+        [
+          [at(60_000), 20, -10, 1, 3],
+          [at(3_600_000), 40, -30, 2, 5],
+        ],
+      ),
+    });
+    const report = await reported(fake);
+    expect(metric(report, 'read_iops')).toMatchObject({ min: 20, max: 40, mean: 30, latest: 40 });
+    expect(metric(report, 'write_iops')).toMatchObject({ min: 10, max: 30, mean: 20, latest: 30 });
+    expect(metric(report, 'read_latency')).toMatchObject({ mean: 1.5, latest: 2 });
+    expect(metric(report, 'write_latency')).toMatchObject({ mean: 4, latest: 5 });
+  });
+
+  it('states the range it reported on and how wide a bucket is', async () => {
+    expect(await reported(healthy())).toMatchObject({
+      start: '2023-11-14T21:13:20.000Z',
+      end: '2023-11-14T22:13:20.000Z',
+      bucket_seconds: 300,
+      truncated_disks: false,
+    });
+  });
+
+  it('returns only the fields it names', async () => {
+    const report = await reported(healthy());
+    expect(Object.keys(report)).toEqual([
+      'start',
+      'end',
+      'bucket_seconds',
+      'metrics',
+      'truncated_disks',
+    ]);
+    expect(Object.keys(metric(report, 'read_throughput'))).toEqual([
+      'metric',
+      'disk',
+      'unit',
+      'min',
+      'max',
+      'mean',
+      'latest',
+      'buckets',
+      'unavailable',
+    ]);
+  });
+
+  it('asks the system for the disk graph by device name, in unix seconds', async () => {
+    const fake = healthy();
+    await reported(fake);
+    expect(fake.call).toHaveBeenCalledWith('reporting.netdata_get_data', [
+      [{ name: 'disk', identifier: 'sda' }],
+      { start: RANGE_START / 1000, end: NOW / 1000 },
+    ]);
+    // One call per disk, not one per metric: all six come from the same graph.
+    expect(fake.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports six metrics for every disk it covers', async () => {
+    const fake = diskSystem(
+      { sda: diskGraph, sdb: diskGraph },
+      { disks: [{ name: 'sdb' }, { name: 'sda' }] },
+    );
+    const report = await reported(fake);
+    expect(report.metrics).toHaveLength(12);
+    expect(report.metrics.map((entry) => entry.disk)).toEqual([
+      ...new Array<string>(6).fill('sda'),
+      ...new Array<string>(6).fill('sdb'),
+    ]);
+    expect(metric(report, 'read_throughput', 'sdb').mean).toBe(200);
+  });
+
+  it('marks a range the system collected nothing in, rather than returning an empty series', async () => {
+    // The samples all sit after this range, so the graph answered and held
+    // nothing inside it.
+    const report = await reported(healthy(), { start: '2023-10-14', end: '2023-11-14' });
+    expect(metric(report, 'read_throughput')).toMatchObject({
+      min: null,
+      latest: null,
+      buckets: [],
+      unavailable: 'the system collected no data for this metric in this range',
+    });
+  });
+
+  it('names a failed graph read on that disk alone', async () => {
+    const fake = diskSystem(
+      { sdb: diskGraph },
+      {
+        disks: [{ name: 'sda' }, { name: 'sdb' }],
+        failures: { sda: new Error('netdata is not running') },
+      },
+    );
+    const report = await reported(fake);
+    expect(metric(report, 'read_throughput')).toMatchObject({
+      buckets: [],
+      unavailable: 'netdata is not running',
+    });
+    expect(metric(report, 'read_throughput', 'sdb').unavailable).toBeNull();
+  });
+
+  it('still reports every metric when the disk listing could not be read', async () => {
+    const fake = diskSystem({}, { failures: { ['disk.query']: new Error('disks unavailable') } });
+    const report = await reported(fake);
+    // Absent metrics would read as a system with no disks at all.
+    expect(report.metrics).toHaveLength(6);
+    expect(metric(report, 'read_throughput', null)).toMatchObject({
+      disk: null,
+      buckets: [],
+      unavailable: 'disks unavailable',
+    });
+    expect(metric(report, 'write_latency', null).unavailable).toBe('disks unavailable');
+    expect(report.truncated_disks).toBe(false);
+  });
+
+  it('still reports every metric when the system named no disk', async () => {
+    const report = await reported(diskSystem({}, { disks: [] }));
+    expect(metric(report, 'read_throughput', null)).toMatchObject({
+      disk: null,
+      unavailable: 'the system named no disk to graph',
+    });
+  });
+
+  it('covers six disks in name order and says when it left some out', async () => {
+    const fake = diskSystem(
+      {},
+      { disks: ['sdg', 'sdc', 'sda', 'sde', 'sdb', 'sdf', 'sdd'].map((name) => ({ name })) },
+    );
+    const report = await reported(fake);
+    expect(report.truncated_disks).toBe(true);
+    expect(
+      report.metrics.filter((entry) => entry.metric === 'read_throughput').map((e) => e.disk),
+    ).toEqual(['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf']);
+  });
+
+  it('graphs only the disks the system actually named', async () => {
+    const fake = diskSystem(
+      { sda: diskGraph },
+      { disks: [{ name: 'sda' }, { name: '' }, { name: 42 }, {}, null, 'sdz'] },
+    );
+    const report = await reported(fake);
+    expect(
+      report.metrics.filter((entry) => entry.metric === 'write_throughput').map((e) => e.disk),
+    ).toEqual(['sda']);
+  });
+
+  it('reads the range the caller named, in the forms the catalog accepts', async () => {
+    expect(await reported(healthy(), { start: '2023-11-14 21:13:20' })).toMatchObject({
+      start: '2023-11-14T21:13:20.000Z',
+      end: '2023-11-14T22:13:20.000Z',
+    });
+  });
+
+  it('refuses a bound it cannot read rather than silently using the default', async () => {
+    await expect(reportingDiskIo.handler(healthy().ctx, { start: 'last tuesday' })).rejects.toThrow(
+      /must be an ISO 8601 timestamp/,
+    );
+  });
+
+  it('refuses a range that does not run forwards', async () => {
+    await expect(
+      reportingDiskIo.handler(healthy().ctx, {
         start: '2023-11-14T12:00:00Z',
         end: '2023-11-14T11:00:00Z',
       }),


### PR DESCRIPTION
Adds `reporting_disk_io`, a read-only tool returning per-disk throughput, IOPS and latency over a time range.

Fixes #40

## What it does

Same source, range grammar, bucketing and markers as `reporting_utilisation` — the ticket asked for the shape that tool established rather than a second one, so the reporting family reads as one thing: an ISO 8601 `start`/`end` defaulting to the last hour, twelve equal buckets across whatever range is asked for, four summary numbers per metric, and an `unavailable` string that names why there is nothing rather than reporting a zero.

Six metrics per disk: `read_throughput`, `write_throughput`, `read_iops`, `write_iops`, `read_latency`, `write_latency`.

## The unconfirmed notes in the ticket, corrected

**`reporting.netdata_get_data` is in the pinned client.** The ticket flagged it as possibly absent from the `TrueNasEndpoint` enum. It is present (`node_modules/@truenas/api-client/dist/index.d.ts:25852`), and #39 already ships against it.

**Which disk metrics the source exposes — this is the finding worth reading.** The client types the method's graph name as a *closed* union (`GraphIdentifier.name: Name`, `index.d.ts:20146`): `cpu`, `cputemp`, `disk`, `disktemp`, `interface`, `load`, `processes`, `memory`, `uptime`, `arcsize` and the UPS graphs. `disk` is the only per-disk I/O member, and a name outside the union does not typecheck — so there is no second graph to read IOPS or latency from.

Whether IOPS and latency can be reported at all is therefore a question about that one graph's **legend**, and the tool asks it as one: every metric names the dimension it needs, and a graph that does not carry it answers with a stated `unavailable` rather than a number. `reads` and `writes` are netdata's own names for the disk chart's throughput. The four names behind IOPS and latency (`read_ops`, `write_ops`, `read_await`, `write_await`) are guesses at what a release recording those would call them, and **on every release this was written against the graph carries neither** — so the tool's description says plainly that those two are commonly unavailable, and says it is a fact about what the system records rather than about the disk, and not worth retrying.

That is why the metrics are *present and marked* rather than dropped: the ticket's own criterion that a disk with no data is present with an explicit marker applies just as much to a metric the source cannot produce, and omitting them would read as a disk that did no operations at all.

**Unit.** `kibibytes_per_second` for throughput, following netdata's own disk chart. It is unconfirmed against a live middleware and is the one assumption here that would be *wrong* rather than absent if it is — the same trade `NETWORK_UNIT` documents in the same file, and it is stated in the code beside the constant.

## The shared machinery is generalised, not copied

A metric is now a **label** (which measurement it is, and the interface or disk it was measured on) spread ahead of a shared **body** (`unit`, `min`/`max`/`mean`/`latest`, `buckets`, `unavailable`). `summarise`, `unavailable` and `graphMetric` became generic over the label, so both tools share them. `reporting_utilisation`'s result shape is unchanged — key order included, which its own `returns only the fields it names` test asserts. The interface and disk listings share the sort-then-cap step (`graphedNames`) for the same reason; the `query` calls themselves stay inlined, because the client types `query` per method and a method name reaching it through a variable no longer selects an overload.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all run clean locally. 585 tests pass; `src/tools/reporting.ts` is at 100% statements and 100% branches, and the global floors (branches 96 / statements 97) are met at 99.47 / 99.50.

Local review: the project's own reviewer ran here in a separate process — same rubric, threshold and parser as the required check — and returned **nothing at or above MEDIUM**, with six LOWs.

## What I did not change, and why

The six LOWs are all real observations. Four are left for a reviewer or a later ticket, because fixing a LOW is a new diff and a new diff needs another review round:

- **`MAX_DISKS = 6`, alphabetical, with no disk selector, makes disks past the sixth unreachable.** This is the one I would raise as its own ticket. The cap matches `MAX_INTERFACES`, and the ticket asked to bound the result the same way `reporting_utilisation` does — but the cases this tool exists for are large shelves, where reporting `sda`–`sdf` and setting `truncated_disks` is a slice chosen by spelling. A `disks` argument naming which disks to report would fix it properly and is a feature the ticket did not ask for. The description says the limitation out loud in the meantime.
- **Four of six metrics per disk are unavailable on every tested release**, so a six-disk result carries 24 markers out of 36 entries. That follows from the acceptance criteria plus what the source exposes; the markers are cheap (all-null, empty `buckets`) and dropping them would silently answer a different question. Worth revisiting if a release ever confirms the graph records throughput only for good.
- **Each of the six metrics re-runs `columns()` and re-walks every row** of its disk's graph — six passes per disk where one would do. Correct but wasteful; the graphs are twelve-bucket summaries of at most six disks, so it is not hot, and factoring it out would change `graphMetric` for both tools.
- **Two lines run to ~103 and ~110 columns** where siblings wrap near 100. No formatter or CI check enforces width in this repo, so this is a house-style observation rather than a failure.

Two other LOWs *were* fixed, in a second commit, because they were comments asserting more than the code delivers rather than polish: the dimension-name note claimed a wrong guess "never" costs a wrong number (true only for a name no release carries — one carrying *other* semantics would be reported under the asserted unit), and the note on inlining `interface.query` justified itself by a row type `graphedNames` does not use. Comments only, no behaviour change.
