### PR TITLE
feat(tools): add reporting_space_trends, how pool and dataset space usage has moved over time

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
-  `reporting_utilisation`, `reporting_disk_io`.
+  `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,5 +90,6 @@ export {
   cloudCredentialsList,
   reportingUtilisation,
   reportingDiskIo,
+  reportingSpaceTrends,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,7 +9,7 @@ import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
-import { reportingDiskIo, reportingUtilisation } from '@/tools/reporting';
+import { reportingDiskIo, reportingSpaceTrends, reportingUtilisation } from '@/tools/reporting';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
@@ -17,7 +17,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-one read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -50,6 +50,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(alertSettings);
   catalog.register(reportingUtilisation);
   catalog.register(reportingDiskIo);
+  catalog.register(reportingSpaceTrends);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -75,6 +76,7 @@ export {
   quotaReport,
   replicationStatus,
   reportingDiskIo,
+  reportingSpaceTrends,
   reportingUtilisation,
   scrubHistory,
   shareAccess,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1198,9 +1198,30 @@ const TRUNCATED_READ =
   'the system holds more snapshots of this dataset than were read, and no two of ' +
   'the ones read fall at different times in this range';
 
-/** What a pool none of whose reported datasets yielded a change is marked with. */
-const NO_OBSERVED_DATASETS =
-  'no dataset reported for this pool had snapshots at two different times in this range';
+/**
+ * What a pool none of whose reported datasets yielded a change is marked with.
+ *
+ * A statement about what was OBTAINED rather than about the pool's snapshots,
+ * and that is the whole distinction: the datasets that yielded nothing may have
+ * yielded nothing because their reads failed or were cut short, and a pool-level
+ * "these datasets have no snapshots at two different times" would then be
+ * asserting the same thing {@link TRUNCATED_READ} exists to stop each dataset
+ * asserting. Each of them names its own reason, so this points there.
+ */
+const NO_CHANGE_MEASURED =
+  'no dataset reported for this pool yielded a change in this range; each of them names why';
+
+/**
+ * What a pool none of whose datasets are among the ones reported is marked with.
+ *
+ * Distinct from {@link NO_CHANGE_MEASURED}, which would be vacuously true here
+ * and would read as a finding about this pool. Nothing of it was looked at:
+ * `MAX_DATASETS` is a cap over the whole system rather than per pool, so a pool
+ * holding only small datasets can be crowded out of the reporting entirely by
+ * another pool's large ones.
+ */
+const NO_DATASETS_REPORTED =
+  'no dataset of this pool is among the ones reported, so nothing was measured for it';
 
 /** What a pool the system did not list is marked with, in place of its levels. */
 const NOT_LISTED = 'the system did not list this pool';
@@ -1521,6 +1542,12 @@ function trendOf(row: DatasetRow, history: History): { trend: Trend; measured: M
   };
 }
 
+/** Why a pool has no change to report, or null where it has one. */
+function poolReason(measured: number, reportedDatasets: number): string | null {
+  if (measured > 0) return null;
+  return reportedDatasets === 0 ? NO_DATASETS_REPORTED : NO_CHANGE_MEASURED;
+}
+
 /** Usage as a percentage of a pool's size, to one decimal place. */
 function percentOf(used: number | null, total: number | null): number | null {
   if (used === null || total === null || total <= 0) return null;
@@ -1546,7 +1573,9 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     'dataset shrank; `change_bytes_per_day`, that change as a rate, so a ' +
     'projection needs no arithmetic over a series; `observed_start` and ' +
     '`observed_end`, the instants those two snapshots were actually taken; and ' +
-    '`snapshots_observed`, how many snapshots of it fell in the range. THE ' +
+    '`snapshots_observed`, how many snapshots of it were read that fell in the ' +
+    'range AND carried a readable time and size — one the system reported ' +
+    'neither of is not counted, because it places nothing. THE ' +
     'OBSERVED WINDOW IS NOT THE RANGE, and the rate is per day of that window ' +
     'rather than of the range: a month-long range over a dataset snapshotted ' +
     'twice on its first day describes that day. `referenced` is the data the ' +
@@ -1580,7 +1609,11 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     '`used_percent` for how full the pool is now. `unavailable` is null on an ' +
     'entry with a change to report and otherwise names why there is none — the ' +
     'system holds no snapshot of that dataset in the range, or none at two ' +
-    'different times, or the read failed with the reason the system gave. ' +
+    'different times, or the read was cut short, or it failed with the reason ' +
+    'the system gave. On a POOL it says instead that none of the datasets ' +
+    'reported for it yielded a change — each of those names its own reason — ' +
+    'or that none of its datasets is among the ones reported at all, which the ' +
+    'ten-dataset cap can do to a pool holding only small ones. ' +
     'WHERE IT IS NON-NULL EVERY FIGURE DERIVED FROM THE HISTORY IS NULL, and ' +
     'that is never a dataset that did not change: nothing was measured. ' +
     '`used_bytes` and the pool levels are read separately and are reported ' +
@@ -1650,6 +1683,7 @@ export const reportingSpaceTrends: ReadOnlyTool = {
       pools: names.map((name) => {
         const levels = pools.levels.get(name);
         const mine = measured.filter((entry) => entry.pool === name);
+        const ours = reported.filter((row) => row.pool === name);
         return {
           pool: name,
           used_bytes: levels?.used ?? null,
@@ -1676,7 +1710,7 @@ export const reportingSpaceTrends: ReadOnlyTool = {
             datasets.error === null
               ? datasets.all.filter((row) => row.pool === name).length
               : null,
-          unavailable: datasets.error ?? (mine.length === 0 ? NO_OBSERVED_DATASETS : null),
+          unavailable: datasets.error ?? poolReason(mine.length, ours.length),
         };
       }),
       datasets: reported,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1587,8 +1587,9 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     'reading them — and `truncated_datasets` is true when the system has more. ' +
     'At most a thousand snapshots are read per dataset, and no order is asked ' +
     'for, so they are an arbitrary thousand; `truncated_snapshots` is true ' +
-    'when some dataset had more, and the window observed for it is then ' +
-    'narrower than the range. Such a dataset that yielded no change SAYS SO IN ' +
+    'when some dataset had more, and the window observed for it may then be ' +
+    'narrower than the range — how much narrower is not knowable, since which ' +
+    'thousand were read is not. Such a dataset that yielded no change SAYS SO IN ' +
     '`unavailable` rather than reporting that the system holds no snapshot of ' +
     'it — the part not read cannot be spoken for. `pools` holds one entry per ' +
     'pool, each ' +
@@ -1615,8 +1616,11 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     'reported for it yielded a change — each of those names its own reason — ' +
     'or that none of its datasets is among the ones reported at all, which the ' +
     'ten-dataset cap can do to a pool holding only small ones. ' +
-    'WHERE IT IS NON-NULL EVERY FIGURE DERIVED FROM THE HISTORY IS NULL, and ' +
-    'that is never a dataset that did not change: nothing was measured. ' +
+    'WHERE IT IS NON-NULL EVERY MEASUREMENT IS NULL — the two referenced ' +
+    'figures, the change, the rate and both instants — and that is never a ' +
+    'dataset that did not change: nothing was measured. `snapshots_observed` ' +
+    'is still reported there, and is what says whether the reason was none at ' +
+    'all or too few. ' +
     '`used_bytes` and the pool levels are read separately and are reported ' +
     'whatever `unavailable` says. Entries fail independently, so one dataset ' +
     'can report while another cannot. `start` and `end` are the range asked ' +

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -36,6 +36,11 @@ import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
  * tool here, so a caller who has learned one of them has learned the family.
  * What differs per tool is the label a metric carries — the interface it was
  * measured on, or the disk — and which dimension each metric is derived from.
+ *
+ * Everything above holds of the two tools that read graphs. `reporting_space_trends`
+ * is in this family for the question it answers and shares its range grammar,
+ * and shares neither the source nor the bucketing: the system records no space
+ * graph to read. What it reads instead, and why, is at {@link reportingSpaceTrends}.
  */
 
 /**
@@ -1105,3 +1110,548 @@ function graphMetric<L extends object>(
   }
   return unavailable(label, unit, NO_DATA);
 }
+
+/**
+ * Space trends: how much data a dataset held, over time.
+ *
+ * Not netdata, and not bucketed — which is why this tool sits apart from the two
+ * above rather than sharing their shape. `reporting.netdata_get_data` types its
+ * graph name as a CLOSED UNION — cpu, cputemp, disk, disktemp, interface, load,
+ * processes, memory, uptime, the ARC graphs and the UPS ones — and not one of
+ * them is pool or dataset space. `reporting.get_data` takes the same union. So
+ * there is no recorded space series on this API surface at all, and a tool that
+ * bucketed one would be inventing it.
+ *
+ * What the system does retain is ZFS's own record. Every snapshot carries the
+ * instant it was taken and the bytes the dataset REFERENCED at that instant, and
+ * `snapshots_list` already reads exactly those two properties. A dataset that is
+ * snapshotted therefore has a space history, sampled at whatever times its
+ * snapshot task happens to run; one that is not has none, and says so.
+ *
+ * Three consequences follow, and each is stated in the description rather than
+ * smoothed over, because each is a way this answer is narrower than its name:
+ * the samples are not evenly spaced and are not the range's own ends; `used` —
+ * the dataset with its descendants and its snapshots — has no history, because a
+ * snapshot's own `used` is the space unique to that snapshot rather than the
+ * dataset's; and a pool's free space has none either, which is why the pool
+ * levels here are current readings carrying their own timestamp instead of a
+ * value at each end of the range.
+ */
+
+/**
+ * How many datasets are reported.
+ *
+ * The same kind of cap as {@link MAX_DISKS} and for the same reason — a dataset
+ * listing is unbounded — but chosen ON SIZE rather than in name order, which is
+ * the one place this tool departs from its siblings. Space is what is being
+ * reported, the largest datasets are where a pool's space goes, and an
+ * alphabetical slice of a hundred datasets would answer a capacity question with
+ * whichever ones happen to sort first. `truncated_datasets` says when the cap
+ * removed any, and ties break on the dataset name so the choice stays
+ * deterministic.
+ */
+const MAX_DATASETS = 10;
+
+/**
+ * How many snapshots are read per dataset.
+ *
+ * A nightly task holds a thousand snapshots within three years and an hourly one
+ * within six weeks, so this bites on real systems. What it costs when it does is
+ * a NARROWER observed window rather than a wrong number: the two ends actually
+ * used are reported as `observed_start` and `observed_end`, and every figure
+ * beside them is a true statement about that window. `truncated_snapshots` says
+ * when some dataset held more than were read.
+ *
+ * The same bound `snapshots_list` applies to its own listing, deliberately: two
+ * tools reading the same rows should not disagree about how many of them are too
+ * many.
+ */
+const MAX_SNAPSHOTS = 1000;
+
+/** What a rate is stated per, in milliseconds. */
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** What a dataset the system holds no snapshot of in the range is marked with. */
+const NO_SNAPSHOTS = 'the system holds no snapshot of this dataset in this range';
+
+/**
+ * What a dataset whose snapshots in the range were all taken at one instant is
+ * marked with. Distinct from {@link NO_SNAPSHOTS}: the dataset IS snapshotted
+ * and there is a level to be had, and what is missing is the second instant that
+ * would make it a change.
+ */
+const ONE_INSTANT =
+  'the system holds no two snapshots of this dataset taken at different times in this range';
+
+/** What a pool none of whose reported datasets yielded a change is marked with. */
+const NO_OBSERVED_DATASETS =
+  'no dataset reported for this pool had snapshots at two different times in this range';
+
+/** What a pool the system did not list is marked with, in place of its levels. */
+const NOT_LISTED = 'the system did not list this pool';
+
+/**
+ * A ZFS property as the middleware reports it. `pool.dataset.query` and
+ * `pool.snapshot.query` both answer rows typed `Record<string, unknown>`, so the
+ * parsed value has to be restated — as `storage.ts` and `snapshots.ts` each
+ * restate it, and local here for the reason those files give: a tool file is
+ * read on its own.
+ */
+interface ZfsProperty {
+  parsed?: unknown;
+  rawvalue?: unknown;
+}
+
+/**
+ * The numeric value of a byte-count property, or null where the middleware
+ * reported none. Null rather than a coerced zero: a dataset whose size could not
+ * be read must not report as one holding nothing.
+ */
+function propertyBytes(property: unknown): number | null {
+  const parsed = (property as ZfsProperty | undefined)?.parsed;
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null;
+}
+
+/** A finite number, or null where the system reported anything else. */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * One entry of a row's `properties` map, or undefined where the row carries no
+ * map to read it from. Guarded rather than asserted, because a row that sends
+ * something other than an object is exactly what the assertion would get wrong.
+ */
+function property(properties: unknown, name: string): unknown {
+  return typeof properties === 'object' && properties !== null
+    ? (properties as Record<string, unknown>)[name]
+    : undefined;
+}
+
+/**
+ * When a snapshot was taken, in milliseconds since the epoch, or null where the
+ * system reported no time this tool can read.
+ *
+ * ZFS reports `creation` as whole seconds since the epoch and `rawvalue` is that
+ * number as ZFS itself states it, which is why the raw value is read here rather
+ * than `parsed` — the middleware's own rendering of the same instant has changed
+ * format between releases. The same reading `snapshots_list` applies.
+ */
+function creationMillis(properties: unknown): number | null {
+  const raw = (property(properties, 'creation') as ZfsProperty | undefined)?.rawvalue;
+  // Digits or nothing: `Number('')` is 0, which would place a snapshot whose
+  // creation time is an empty string at the epoch.
+  const seconds =
+    typeof raw === 'number' ? raw : typeof raw === 'string' && /^-?\d+$/.test(raw) ? Number(raw) : null;
+  if (seconds === null || !Number.isFinite(seconds)) return null;
+  const millis = seconds * 1000;
+  // Beyond what a `Date` can hold, `toISOString` throws rather than answering,
+  // and one absurd creation time would take the whole result down with it.
+  return Number.isFinite(millis) && Math.abs(millis) <= 8.64e15 ? millis : null;
+}
+
+/** A dataset the system listed, reduced to what this tool needs of it. */
+interface DatasetRow {
+  id: string;
+  pool: string;
+  used: number | null;
+}
+
+/** What the dataset listing produced, with a failure named rather than thrown. */
+interface DatasetListing {
+  /** Every dataset the system named, which is what `datasets_total` counts. */
+  all: DatasetRow[];
+  /** The ones actually reported on: the largest, up to the cap. */
+  reported: DatasetRow[];
+  truncated: boolean;
+  error: string | null;
+}
+
+/** Largest first, and by name where two are the same size or neither is readable. */
+function byLargestFirst(a: DatasetRow, b: DatasetRow): number {
+  if (a.used !== b.used) {
+    // A dataset whose size could not be read is ordered last rather than as
+    // empty: it may be the largest one there is, and nothing here can say.
+    if (a.used === null) return 1;
+    if (b.used === null) return -1;
+    return b.used - a.used;
+  }
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Every dataset the system lists, and the largest of them up to the cap.
+ *
+ * A row without a readable `id` names nothing that could be asked about, so it
+ * is dropped — the id is what the snapshot listing is filtered by. A row whose
+ * `pool` is unreadable is kept and attributed by the first segment of its id,
+ * which is what a ZFS dataset name means; dropping it would lose a large dataset
+ * from a pool's total over a field this tool only groups by.
+ */
+async function datasetListing(system: SystemHandle): Promise<DatasetListing> {
+  try {
+    // Filters and options are inlined so the call's own parameter types apply,
+    // as in `storage.ts`. `retrieve_children` walks the whole tree and the
+    // response is already flat, each entry additionally nesting its descendants
+    // under `children` — so the top-level entries are every dataset exactly
+    // once, and walking `children` would count each of them again.
+    const rows = await firstValueFrom(
+      system.client.api.query('pool.dataset.query', [], {
+        extra: { retrieve_children: true, properties: ['used'] },
+      }),
+    );
+    const all = rows.flatMap((row) => {
+      if (typeof row !== 'object' || row === null) return [];
+      const held = row as Record<string, unknown>;
+      const id = textOrNull(held['id']);
+      if (id === null) return [];
+      return [{ id, pool: textOrNull(held['pool']) ?? id.split('/')[0], used: propertyBytes(held['used']) }];
+    });
+    const largest = [...all].sort(byLargestFirst);
+    return {
+      all,
+      reported: largest.slice(0, MAX_DATASETS),
+      truncated: largest.length > MAX_DATASETS,
+      error: null,
+    };
+  } catch (reason) {
+    return { all: [], reported: [], truncated: false, error: errorText(reason) };
+  }
+}
+
+/** A pool's space as the system reports it right now. */
+interface PoolLevels {
+  used: number | null;
+  free: number | null;
+  total: number | null;
+}
+
+/** What the pool listing produced, with a failure named rather than thrown. */
+interface PoolListing {
+  levels: Map<string, PoolLevels>;
+  error: string | null;
+}
+
+/**
+ * Each pool's current space, keyed by pool name.
+ *
+ * Current rather than historical, because there is no historical: this is the
+ * one place a caller can read the LEVEL a change should be judged against, and
+ * it is stamped with `as_of` rather than presented as either end of the range.
+ */
+async function poolListing(system: SystemHandle): Promise<PoolListing> {
+  try {
+    const pools = await firstValueFrom(system.client.api.query('pool.query'));
+    const levels = new Map<string, PoolLevels>();
+    for (const pool of pools) {
+      const name = textOrNull(pool.name);
+      if (name === null) continue;
+      levels.set(name, {
+        used: numberOrNull(pool.allocated),
+        free: numberOrNull(pool.free),
+        total: numberOrNull(pool.size),
+      });
+    }
+    return { levels, error: null };
+  } catch (reason) {
+    return { levels: new Map(), error: errorText(reason) };
+  }
+}
+
+/** One snapshot's contribution to a dataset's history. */
+interface Sample {
+  at: number;
+  bytes: number;
+}
+
+/** What the snapshot listing for one dataset produced. */
+interface History {
+  /** The samples inside the range, in whatever order the system listed them. */
+  samples: Sample[];
+  truncated: boolean;
+  error: string | null;
+}
+
+/**
+ * One dataset's space history over the range, from its snapshots.
+ *
+ * Read per dataset rather than in one listing of every snapshot, and the bound
+ * is why: a single bounded listing would hold whichever snapshots the system
+ * returned first, so one heavily snapshotted dataset could crowd out every other
+ * one's history entirely. Per dataset the bound applies per dataset, and they
+ * are all issued together.
+ *
+ * No `order_by`, for the reason `snapshots_list` gives at length: no field of a
+ * snapshot row orders it in time soundly — `createtxg` is a string and is the
+ * receiving system's on a replication target, and the creation time itself is
+ * nested inside `properties`. Asking for an order that is wrong on those systems
+ * would decide WHICH snapshots a truncated listing holds, which is worse than
+ * asking for none, since the ends actually observed are reported either way.
+ */
+async function snapshotHistory(
+  system: SystemHandle,
+  dataset: string,
+  range: Range,
+): Promise<History> {
+  try {
+    const rows = await firstValueFrom(
+      system.client.api.query('pool.snapshot.query', [['dataset', '=', dataset]], {
+        // One more row than the bound. That extra row is what says the system
+        // held more than fit; it is counted and then dropped.
+        limit: MAX_SNAPSHOTS + 1,
+        // Only the two properties this tool reads. A snapshot row otherwise
+        // carries every ZFS property of the snapshot, on every row.
+        extra: { properties: ['creation', 'referenced'] },
+      }),
+    );
+    const samples: Sample[] = [];
+    for (const row of rows.slice(0, MAX_SNAPSHOTS)) {
+      const properties = row['properties'];
+      const at = creationMillis(properties);
+      const bytes = propertyBytes(property(properties, 'referenced'));
+      // Both or neither: a snapshot with no readable size places nothing, and
+      // one with no readable time cannot be placed. Either way it is not a
+      // sample, and counting it would report a history it does not carry.
+      if (at === null || bytes === null) continue;
+      if (at < range.start || at > range.end) continue;
+      samples.push({ at, bytes });
+    }
+    return { samples, truncated: rows.length > MAX_SNAPSHOTS, error: null };
+  } catch (reason) {
+    return { samples: [], truncated: false, error: errorText(reason) };
+  }
+}
+
+/** What one dataset's history says, as the result states it. */
+interface Trend {
+  referenced_start_bytes: number | null;
+  referenced_end_bytes: number | null;
+  change_bytes: number | null;
+  change_bytes_per_day: number | null;
+  observed_start: string | null;
+  observed_end: string | null;
+  snapshots_observed: number;
+  unavailable: string | null;
+}
+
+/** The same change, kept in the numbers a pool's aggregate is summed from. */
+interface Measured {
+  pool: string;
+  change: number;
+  perDay: number;
+  startAt: number;
+  endAt: number;
+}
+
+/** A dataset with no change to report, and why. Its sample count is still stated. */
+function noTrend(reason: string, observed: number): Trend {
+  return {
+    referenced_start_bytes: null,
+    referenced_end_bytes: null,
+    change_bytes: null,
+    change_bytes_per_day: null,
+    observed_start: null,
+    observed_end: null,
+    snapshots_observed: observed,
+    unavailable: reason,
+  };
+}
+
+/**
+ * The change between the ends of one dataset's history, and the rate it implies.
+ *
+ * The ends are the earliest and latest samples IN THE RANGE rather than the
+ * range's own bounds, and they are reported, because they are what the numbers
+ * beside them are true of: a range of a month over a dataset snapshotted twice
+ * on its first day describes that day.
+ *
+ * The rate is taken over the observed window rather than over the range, for the
+ * same reason. Dividing by the range would report a dataset that grew 10 GiB in
+ * an hour as growing 10 GiB a month, which is the projection a caller would then
+ * make from it.
+ */
+function trendOf(row: DatasetRow, history: History): { trend: Trend; measured: Measured | null } {
+  if (history.error !== null) return { trend: noTrend(history.error, 0), measured: null };
+  if (history.samples.length === 0) return { trend: noTrend(NO_SNAPSHOTS, 0), measured: null };
+  let first = history.samples[0];
+  let last = history.samples[0];
+  for (const sample of history.samples) {
+    if (sample.at < first.at) first = sample;
+    if (sample.at > last.at) last = sample;
+  }
+  if (first.at === last.at) {
+    return { trend: noTrend(ONE_INSTANT, history.samples.length), measured: null };
+  }
+  const change = last.bytes - first.bytes;
+  const perDay = Math.round(change / ((last.at - first.at) / MILLIS_PER_DAY));
+  return {
+    trend: {
+      referenced_start_bytes: first.bytes,
+      referenced_end_bytes: last.bytes,
+      change_bytes: change,
+      change_bytes_per_day: perDay,
+      observed_start: new Date(first.at).toISOString(),
+      observed_end: new Date(last.at).toISOString(),
+      snapshots_observed: history.samples.length,
+      unavailable: null,
+    },
+    measured: { pool: row.pool, change, perDay, startAt: first.at, endAt: last.at },
+  };
+}
+
+/** Usage as a percentage of a pool's size, to one decimal place. */
+function percentOf(used: number | null, total: number | null): number | null {
+  if (used === null || total === null || total <= 0) return null;
+  return round1((used / total) * 100);
+}
+
+export const reportingSpaceTrends: ReadOnlyTool = {
+  name: 'reporting_space_trends',
+  description:
+    'How pool and dataset space usage has MOVED over a time range, which is a ' +
+    'different question from how full something is now — a pool at 60% that ' +
+    'gained 30 points this month is a problem, and one that has sat at 85% for ' +
+    'two years is not. THE HISTORY COMES FROM ZFS SNAPSHOTS, not from a ' +
+    'recorded space graph: the system keeps no space series of any kind, so ' +
+    'what is available is the bytes each snapshot records its dataset as ' +
+    'REFERENCING at the instant it was taken. Everything about the answer ' +
+    'follows from that. `datasets` holds one entry per dataset, each with: ' +
+    '`dataset` and `pool`, matching `id` and `pool` in `storage_list_datasets`; ' +
+    '`used_bytes`, the CURRENT size of the dataset with its descendants and ' +
+    'snapshots; `referenced_start_bytes` and `referenced_end_bytes`, what the ' +
+    'dataset itself referenced at the first and last snapshot found in the ' +
+    'range; `change_bytes`, the second minus the first, NEGATIVE where the ' +
+    'dataset shrank; `change_bytes_per_day`, that change as a rate, so a ' +
+    'projection needs no arithmetic over a series; `observed_start` and ' +
+    '`observed_end`, the instants those two snapshots were actually taken; and ' +
+    '`snapshots_observed`, how many snapshots of it fell in the range. THE ' +
+    'OBSERVED WINDOW IS NOT THE RANGE, and the rate is per day of that window ' +
+    'rather than of the range: a month-long range over a dataset snapshotted ' +
+    'twice on its first day describes that day. `referenced` is the data the ' +
+    'dataset itself holds, which is what ZFS records at snapshot time; `used` ' +
+    'has no history at all, and neither does free space, so `used_bytes` is a ' +
+    'reading taken now and stamped `as_of` rather than a value at either end ' +
+    'of the range. At most ten datasets are reported, THE LARGEST BY CURRENT ' +
+    '`used_bytes` — not the fastest growing, which cannot be known before ' +
+    'reading them — and `truncated_datasets` is true when the system has more. ' +
+    'At most a thousand snapshots are read per dataset; `truncated_snapshots` ' +
+    'is true when some dataset had more, and the window observed for it is ' +
+    'then narrower than the range. `pools` holds one entry per pool, each ' +
+    'with: `used_bytes`, `free_bytes`, `total_bytes` and `used_percent`, the ' +
+    "pool's space AS OF NOW rather than over the range, with " +
+    '`levels_unavailable` naming why where they could not be read; ' +
+    '`referenced_change_bytes` and `referenced_change_bytes_per_day`, the SUM ' +
+    'of those figures over the datasets reported for that pool; ' +
+    '`observed_start` and `observed_end`, the earliest and latest instants any ' +
+    'of them was observed at, which means the summed figures cover windows ' +
+    'that may differ between datasets; and `datasets_observed` against ' +
+    '`datasets_total`, which is how far the sum covers the pool at all. THAT ' +
+    'SUM IS NOT THE CHANGE IN THE POOL\'S USED SPACE and is a lower bound on ' +
+    'it: it omits every dataset not reported, every dataset with too few ' +
+    'snapshots, and space held only by snapshots of deleted data, which is ' +
+    'space a pool loses nothing by keeping and gains nothing by counting here. ' +
+    'Read it as the direction the datasets it names are moving in, and read ' +
+    '`used_percent` for how full the pool is now. `unavailable` is null on an ' +
+    'entry with a change to report and otherwise names why there is none — the ' +
+    'system holds no snapshot of that dataset in the range, or none at two ' +
+    'different times, or the read failed with the reason the system gave. ' +
+    'WHERE IT IS NON-NULL EVERY FIGURE DERIVED FROM THE HISTORY IS NULL, and ' +
+    'that is never a dataset that did not change: nothing was measured. ' +
+    '`used_bytes` and the pool levels are read separately and are reported ' +
+    'whatever `unavailable` says. Entries fail independently, so one dataset ' +
+    'can report while another cannot. `start` and `end` are the range asked ' +
+    'about, as ISO 8601 UTC timestamps. Give them to bound it; OMITTED, THE ' +
+    'LAST HOUR ending now, which for this tool is almost never what is wanted ' +
+    '— snapshots are hours or days apart, so ask for weeks or months. This ' +
+    'tool reads what snapshots record. It does not report which files grew, ' +
+    'per-share or per-app usage, quota headroom — `datasets_quota_report` ' +
+    'answers that — or what a pool held before its oldest surviving snapshot, ' +
+    'and it changes nothing.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      start: {
+        type: 'string',
+        description:
+          'The beginning of the range, as an ISO 8601 timestamp — ' +
+          '"2026-08-29T09:00:00Z" — or a date, "2026-08-29", which is ' +
+          'midnight. A time given without a timezone is read as UTC. Omitted, ' +
+          'one hour before the end of the range.',
+      },
+      end: {
+        type: 'string',
+        description: 'The end of the range, in the same forms as `start`. Omitted, now.',
+      },
+    },
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // The range is resolved before anything is read, so an unreadable bound is
+    // an error rather than a query the system answers over the wrong interval.
+    const now = Date.now();
+    const range = resolveRange(args, now);
+    const [datasets, pools] = await Promise.all([datasetListing(system), poolListing(system)]);
+    // Nothing to report and no pool entry to carry the reason. Named rather
+    // than answered with an empty result, which would read as a system holding
+    // no storage at all.
+    if (datasets.error !== null && pools.error !== null) throw new Error(datasets.error);
+
+    const histories = await Promise.all(
+      datasets.reported.map((row) => snapshotHistory(system, row.id, range)),
+    );
+    const measured: Measured[] = [];
+    const reported = datasets.reported.map((row, position) => {
+      const answer = trendOf(row, histories[position]);
+      if (answer.measured !== null) measured.push(answer.measured);
+      return { dataset: row.id, pool: row.pool, used_bytes: row.used, ...answer.trend };
+    });
+
+    // Every pool either listing named. A pool with no dataset listed still
+    // reports its levels, and a pool whose datasets were listed still reports
+    // its coverage, which is what keeps one failed read from hiding the other's
+    // answer.
+    const names = [...new Set([...datasets.all.map((row) => row.pool), ...pools.levels.keys()])];
+    names.sort();
+    return {
+      start: new Date(range.start).toISOString(),
+      end: new Date(range.end).toISOString(),
+      as_of: new Date(now).toISOString(),
+      pools: names.map((name) => {
+        const levels = pools.levels.get(name);
+        const mine = measured.filter((entry) => entry.pool === name);
+        return {
+          pool: name,
+          used_bytes: levels?.used ?? null,
+          free_bytes: levels?.free ?? null,
+          total_bytes: levels?.total ?? null,
+          used_percent: percentOf(levels?.used ?? null, levels?.total ?? null),
+          levels_unavailable: levels === undefined ? (pools.error ?? NOT_LISTED) : null,
+          referenced_change_bytes:
+            mine.length === 0 ? null : mine.reduce((total, entry) => total + entry.change, 0),
+          referenced_change_bytes_per_day:
+            mine.length === 0 ? null : mine.reduce((total, entry) => total + entry.perDay, 0),
+          observed_start:
+            mine.length === 0
+              ? null
+              : new Date(Math.min(...mine.map((entry) => entry.startAt))).toISOString(),
+          observed_end:
+            mine.length === 0
+              ? null
+              : new Date(Math.max(...mine.map((entry) => entry.endAt))).toISOString(),
+          datasets_observed: mine.length,
+          // Null rather than zero where the listing failed: "this pool has no
+          // datasets" is a claim, and nothing here looked.
+          datasets_total:
+            datasets.error === null
+              ? datasets.all.filter((row) => row.pool === name).length
+              : null,
+          unavailable: datasets.error ?? (mine.length === 0 ? NO_OBSERVED_DATASETS : null),
+        };
+      }),
+      datasets: reported,
+      truncated_datasets: datasets.truncated,
+      truncated_snapshots: histories.some((history) => history.truncated),
+    };
+  },
+};

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1601,11 +1601,12 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     'of them was observed at, which means the summed figures cover windows ' +
     'that may differ between datasets; and `datasets_observed` against ' +
     '`datasets_total`, which is how far the sum covers the pool at all. THAT ' +
-    'SUM IS NOT THE CHANGE IN THE POOL\'S USED SPACE and is a lower bound on ' +
-    'it: it omits every dataset not reported, every dataset with too few ' +
-    'snapshots, and space held only by snapshots of deleted data, which is ' +
-    'space a pool loses nothing by keeping and gains nothing by counting here. ' +
-    'Read it as the direction the datasets it names are moving in, and read ' +
+    'SUM IS NOT THE CHANGE IN THE POOL\'S USED SPACE, and is not a bound on it ' +
+    'in either direction: it omits every dataset not reported and every dataset ' +
+    'with too few snapshots — EACH OF WHICH MAY HAVE GROWN OR SHRUNK, so the ' +
+    'sum can fall on either side of the pool\'s own change — and it omits space ' +
+    'held only by snapshots of data since deleted. Read it as the direction the ' +
+    'datasets it names are moving in, against `datasets_observed`, and read ' +
     '`used_percent` for how full the pool is now. `unavailable` is null on an ' +
     'entry with a change to report and otherwise names why there is none — the ' +
     'system holds no snapshot of that dataset in the range, or none at two ' +

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1183,6 +1183,21 @@ const NO_SNAPSHOTS = 'the system holds no snapshot of this dataset in this range
 const ONE_INSTANT =
   'the system holds no two snapshots of this dataset taken at different times in this range';
 
+/**
+ * What a dataset whose snapshot listing was CUT SHORT, and that yielded no
+ * change from the part of it that was read, is marked with.
+ *
+ * Neither {@link NO_SNAPSHOTS} nor {@link ONE_INSTANT} may be used there, and
+ * this is the whole reason this constant exists: no order is asked for, so the
+ * thousand snapshots read are an arbitrary thousand, and every one of them
+ * falling outside the range says nothing whatever about the ones that were not
+ * read. Claiming the system holds no snapshot in the range would be a statement
+ * about the system made from evidence that does not reach it.
+ */
+const TRUNCATED_READ =
+  'the system holds more snapshots of this dataset than were read, and no two of ' +
+  'the ones read fall at different times in this range';
+
 /** What a pool none of whose reported datasets yielded a change is marked with. */
 const NO_OBSERVED_DATASETS =
   'no dataset reported for this pool had snapshots at two different times in this range';
@@ -1472,7 +1487,13 @@ function noTrend(reason: string, observed: number): Trend {
  */
 function trendOf(row: DatasetRow, history: History): { trend: Trend; measured: Measured | null } {
   if (history.error !== null) return { trend: noTrend(history.error, 0), measured: null };
-  if (history.samples.length === 0) return { trend: noTrend(NO_SNAPSHOTS, 0), measured: null };
+  // A cut-short listing supports neither of the claims below, for the reason
+  // {@link TRUNCATED_READ} gives. It still supports a change where one was
+  // found: that is a statement about the two snapshots named beside it.
+  if (history.samples.length === 0) {
+    const reason = history.truncated ? TRUNCATED_READ : NO_SNAPSHOTS;
+    return { trend: noTrend(reason, 0), measured: null };
+  }
   let first = history.samples[0];
   let last = history.samples[0];
   for (const sample of history.samples) {
@@ -1480,7 +1501,8 @@ function trendOf(row: DatasetRow, history: History): { trend: Trend; measured: M
     if (sample.at > last.at) last = sample;
   }
   if (first.at === last.at) {
-    return { trend: noTrend(ONE_INSTANT, history.samples.length), measured: null };
+    const reason = history.truncated ? TRUNCATED_READ : ONE_INSTANT;
+    return { trend: noTrend(reason, history.samples.length), measured: null };
   }
   const change = last.bytes - first.bytes;
   const perDay = Math.round(change / ((last.at - first.at) / MILLIS_PER_DAY));
@@ -1534,9 +1556,13 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     'of the range. At most ten datasets are reported, THE LARGEST BY CURRENT ' +
     '`used_bytes` — not the fastest growing, which cannot be known before ' +
     'reading them — and `truncated_datasets` is true when the system has more. ' +
-    'At most a thousand snapshots are read per dataset; `truncated_snapshots` ' +
-    'is true when some dataset had more, and the window observed for it is ' +
-    'then narrower than the range. `pools` holds one entry per pool, each ' +
+    'At most a thousand snapshots are read per dataset, and no order is asked ' +
+    'for, so they are an arbitrary thousand; `truncated_snapshots` is true ' +
+    'when some dataset had more, and the window observed for it is then ' +
+    'narrower than the range. Such a dataset that yielded no change SAYS SO IN ' +
+    '`unavailable` rather than reporting that the system holds no snapshot of ' +
+    'it — the part not read cannot be spoken for. `pools` holds one entry per ' +
+    'pool, each ' +
     'with: `used_bytes`, `free_bytes`, `total_bytes` and `used_percent`, the ' +
     "pool's space AS OF NOW rather than over the range, with " +
     '`levels_unavailable` naming why where they could not be read; ' +
@@ -1592,10 +1618,20 @@ export const reportingSpaceTrends: ReadOnlyTool = {
     const now = Date.now();
     const range = resolveRange(args, now);
     const [datasets, pools] = await Promise.all([datasetListing(system), poolListing(system)]);
-    // Nothing to report and no pool entry to carry the reason. Named rather
-    // than answered with an empty result, which would read as a system holding
-    // no storage at all.
-    if (datasets.error !== null && pools.error !== null) throw new Error(datasets.error);
+    // Every pool either listing named. A pool with no dataset listed still
+    // reports its levels, and a pool whose datasets were listed still reports
+    // its coverage, which is what keeps one failed read from hiding the other's
+    // answer.
+    const names = [...new Set([...datasets.all.map((row) => row.pool), ...pools.levels.keys()])];
+    names.sort();
+    // A failure with nowhere to be reported is thrown instead. Every failure
+    // this tool catches is carried by a pool entry, so no pool entries means no
+    // pool named it — and answering an empty result would read as a system
+    // holding no storage at all. The test is what the result CAN carry rather
+    // than which read failed: a dataset listing that failed beside a pool one
+    // that answered nothing leaves the same silence as both of them failing.
+    const failure = datasets.error ?? pools.error;
+    if (names.length === 0 && failure !== null) throw new Error(failure);
 
     const histories = await Promise.all(
       datasets.reported.map((row) => snapshotHistory(system, row.id, range)),
@@ -1607,12 +1643,6 @@ export const reportingSpaceTrends: ReadOnlyTool = {
       return { dataset: row.id, pool: row.pool, used_bytes: row.used, ...answer.trend };
     });
 
-    // Every pool either listing named. A pool with no dataset listed still
-    // reports its levels, and a pool whose datasets were listed still reports
-    // its coverage, which is what keeps one failed read from hiding the other's
-    // answer.
-    const names = [...new Set([...datasets.all.map((row) => row.pool), ...pools.levels.keys()])];
-    names.sort();
     return {
       start: new Date(range.start).toISOString(),
       end: new Date(range.end).toISOString(),

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -9075,7 +9075,36 @@ describe('reporting_space_trends', () => {
       observed_end: null,
       datasets_observed: 0,
       datasets_total: 2,
-      unavailable: 'no dataset reported for this pool had snapshots at two different times in this range',
+      unavailable:
+        'no dataset reported for this pool yielded a change in this range; each of them names why',
+    });
+  });
+
+  it('does not blame a pool whose datasets the cap left out entirely', async () => {
+    // The cap is over the whole system, so one pool's large datasets can crowd
+    // another's out. Nothing of `spare` was looked at, and saying its datasets
+    // yielded no change would read as a finding about it.
+    const report = await reported(
+      spaceSystem({
+        datasets: [
+          ...Array.from({ length: 10 }, (_, index) =>
+            dataset(`tank/d${index}`, 'tank', (index + 2) * 1e9),
+          ),
+          dataset('spare/small', 'spare', 1e9),
+        ],
+        pools: [
+          { name: 'tank', size: 10e9, allocated: 6e9, free: 4e9 },
+          { name: 'spare', size: 2e9, allocated: 1e9, free: 1e9 },
+        ],
+      }),
+    );
+    expect(report.datasets.map((row) => row.pool)).not.toContain('spare');
+    expect(report.pools.filter((row) => row.pool === 'spare')[0]).toMatchObject({
+      used_percent: 50,
+      datasets_observed: 0,
+      datasets_total: 1,
+      unavailable:
+        'no dataset of this pool is among the ones reported, so nothing was measured for it',
     });
   });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8880,7 +8880,6 @@ describe('reporting_space_trends', () => {
   });
 
   it('marks a dataset the system holds no snapshot of in the range', async () => {
-    expect(entry(await reported(healthy()), 'tank/vm')).toBeDefined();
     const report = await reported(spaceSystem({}));
     expect(entry(report, 'tank/media')).toMatchObject({
       used_bytes: 5e9,
@@ -9035,6 +9034,37 @@ describe('reporting_space_trends', () => {
     });
   });
 
+  it('does not claim a dataset holds no snapshot when it read only some of them', async () => {
+    // A thousand snapshots read, all of them before the range, and no order was
+    // asked for — so what lies inside the range is exactly what was not read.
+    const many = Array.from({ length: 1001 }, (_, index) =>
+      snap(day(300) + index * 60_000, 1000 + index),
+    );
+    const report = await reported(spaceSystem({ snapshots: { 'tank/media': many } }));
+    expect(report.truncated_snapshots).toBe(true);
+    expect(entry(report, 'tank/media')).toMatchObject({
+      snapshots_observed: 0,
+      change_bytes: null,
+      unavailable:
+        'the system holds more snapshots of this dataset than were read, and no two of ' +
+        'the ones read fall at different times in this range',
+    });
+  });
+
+  it('says the same of a truncated read that found only one instant', async () => {
+    // Every snapshot read is at one instant inside the range, so what would
+    // have given a second instant is exactly what was left unread.
+    const many = Array.from({ length: 1001 }, (_, index) => snap(day(30), 1000 + index));
+    const report = await reported(spaceSystem({ snapshots: { 'tank/media': many } }));
+    expect(entry(report, 'tank/media')).toMatchObject({
+      snapshots_observed: 1000,
+      change_bytes: null,
+      unavailable:
+        'the system holds more snapshots of this dataset than were read, and no two of ' +
+        'the ones read fall at different times in this range',
+    });
+  });
+
   it('marks a pool no dataset of which could be measured', async () => {
     const report = await reported(spaceSystem({}));
     expect(report.pools[0]).toMatchObject({
@@ -9121,6 +9151,33 @@ describe('reporting_space_trends', () => {
     await expect(reportingSpaceTrends.handler(fake.ctx, RANGE)).rejects.toThrow(
       'datasets unavailable',
     );
+  });
+
+  it('fails rather than hiding a failed listing behind a listing that named nothing', async () => {
+    // The pool read succeeded and named no pool, so there is no entry to carry
+    // the dataset read's failure — which is the same silence as both failing.
+    const fake = spaceSystem({
+      pools: [],
+      failures: { 'pool.dataset.query': new Error('datasets unavailable') },
+    });
+    await expect(reportingSpaceTrends.handler(fake.ctx, RANGE)).rejects.toThrow(
+      'datasets unavailable',
+    );
+  });
+
+  it('fails when the pool listing failed and the system listed no dataset either', async () => {
+    const fake = spaceSystem({
+      datasets: [],
+      failures: { 'pool.query': new Error('pools unavailable') },
+    });
+    await expect(reportingSpaceTrends.handler(fake.ctx, RANGE)).rejects.toThrow(
+      'pools unavailable',
+    );
+  });
+
+  it('answers a system that holds nothing, which is not a failure', async () => {
+    const report = await reported(spaceSystem({ datasets: [], pools: [] }));
+    expect(report).toMatchObject({ pools: [], datasets: [], truncated_datasets: false });
   });
 
   it('reports on what the system named a dataset, and attributes one whose pool it did not', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -24,6 +24,7 @@ import {
   quotaReport,
   replicationStatus,
   reportingDiskIo,
+  reportingSpaceTrends,
   reportingUtilisation,
   scrubHistory,
   shareAccess,
@@ -78,7 +79,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-one sketch tools', () => {
+  it('registers the thirty-two sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -110,6 +111,7 @@ describe('createDefaultCatalog', () => {
       'alert_settings',
       'reporting_utilisation',
       'reporting_disk_io',
+      'reporting_space_trends',
       'snapshots_create',
     ]);
   });
@@ -123,6 +125,12 @@ describe('createDefaultCatalog', () => {
   it('advertises reporting_disk_io to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'reporting_disk_io',
+    );
+  });
+
+  it('advertises reporting_space_trends to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'reporting_space_trends',
     );
   });
 
@@ -8626,6 +8634,534 @@ describe('reporting_disk_io', () => {
         start: '2023-11-14T12:00:00Z',
         end: '2023-11-14T11:00:00Z',
       }),
+    ).rejects.toThrow('"start" must be before "end"');
+  });
+});
+
+describe('reporting_space_trends', () => {
+  /** The same fixed present as the two graph tools, for the same reason. */
+  const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** An instant that many days before the fixed present. */
+  const day = (before: number): number => NOW - before * 24 * 60 * 60 * 1000;
+
+  /**
+   * A range wide enough to hold every fixture below. The default range is one
+   * hour, which no snapshot in these tests falls in — which is itself the point
+   * the tool's description makes about its own default.
+   */
+  const RANGE = { start: '2023-10-01', end: '2023-12-01' };
+
+  /** A snapshot row as `pool.snapshot.query` answers with one. */
+  const snap = (at: number, bytes: number): unknown => ({
+    name: `tank/x@${at}`,
+    dataset: 'tank/x',
+    // Seconds as a string, which is how ZFS states `creation`'s raw value.
+    properties: { creation: { rawvalue: String(at / 1000) }, referenced: { parsed: bytes } },
+  });
+
+  /** A dataset row as `pool.dataset.query` answers with one. */
+  const dataset = (id: string, pool: string, used: number | null): unknown => ({
+    id,
+    pool,
+    used: used === null ? undefined : { parsed: used },
+  });
+
+  interface Fake {
+    ctx: ToolContext;
+    query: ReturnType<typeof vi.fn>;
+  }
+
+  /**
+   * A SystemHandle answering the three listings this tool reads. Snapshots are
+   * keyed by the dataset the call filtered on, since every dataset's history
+   * comes back from the same method; a key present in `failures` — a method name
+   * or a dataset name — rejects instead.
+   */
+  const spaceSystem = (
+    options: {
+      datasets?: unknown[];
+      pools?: unknown[];
+      snapshots?: Record<string, unknown[]>;
+      failures?: Record<string, unknown>;
+    } = {},
+  ): Fake => {
+    const failures = options.failures ?? {};
+    const query = vi.fn((method: string, filters?: unknown) => {
+      if (method === 'pool.snapshot.query') {
+        const asked = (filters as [string, string, string][])[0][2];
+        return asked in failures
+          ? throwError(() => failures[asked])
+          : of(options.snapshots?.[asked] ?? []);
+      }
+      if (method in failures) return throwError(() => failures[method]);
+      if (method === 'pool.query') {
+        return of(options.pools ?? [{ name: 'tank', size: 10e9, allocated: 6e9, free: 4e9 }]);
+      }
+      return of(
+        options.datasets ?? [dataset('tank/media', 'tank', 5e9), dataset('tank/vm', 'tank', 1e9)],
+      );
+    });
+    const system = { name: 'nas', client: { api: { query } } } as unknown as SystemHandle;
+    return { ctx: { system }, query };
+  };
+
+  /** Two datasets with histories: one growing over twenty days, one shrinking over ten. */
+  const healthy = (): Fake =>
+    spaceSystem({
+      snapshots: {
+        'tank/media': [snap(day(30), 1e9), snap(day(10), 3e9)],
+        'tank/vm': [snap(day(30), 5e8), snap(day(20), 3e8)],
+      },
+    });
+
+  interface Trend {
+    referenced_start_bytes: number | null;
+    referenced_end_bytes: number | null;
+    change_bytes: number | null;
+    change_bytes_per_day: number | null;
+    observed_start: string | null;
+    observed_end: string | null;
+    snapshots_observed: number;
+    unavailable: string | null;
+  }
+
+  interface DatasetEntry extends Trend {
+    dataset: string;
+    pool: string;
+    used_bytes: number | null;
+  }
+
+  interface PoolEntry {
+    pool: string;
+    used_bytes: number | null;
+    free_bytes: number | null;
+    total_bytes: number | null;
+    used_percent: number | null;
+    levels_unavailable: string | null;
+    referenced_change_bytes: number | null;
+    referenced_change_bytes_per_day: number | null;
+    observed_start: string | null;
+    observed_end: string | null;
+    datasets_observed: number;
+    datasets_total: number | null;
+    unavailable: string | null;
+  }
+
+  interface Report {
+    start: string;
+    end: string;
+    as_of: string;
+    pools: PoolEntry[];
+    datasets: DatasetEntry[];
+    truncated_datasets: boolean;
+    truncated_snapshots: boolean;
+  }
+
+  const reported = async (fake: Fake, args: Record<string, unknown> = RANGE): Promise<Report> =>
+    (await reportingSpaceTrends.handler(fake.ctx, args)) as Report;
+
+  /** One dataset of a result, by name. */
+  const entry = (report: Report, name: string): DatasetEntry =>
+    report.datasets.filter((row) => row.dataset === name)[0];
+
+  it('reports what a dataset referenced at each end of its history and the rate between', async () => {
+    expect(entry(await reported(healthy()), 'tank/media')).toEqual({
+      dataset: 'tank/media',
+      pool: 'tank',
+      used_bytes: 5e9,
+      referenced_start_bytes: 1e9,
+      referenced_end_bytes: 3e9,
+      change_bytes: 2e9,
+      // Two gibibytes over the twenty days actually observed, not over the two
+      // months asked about.
+      change_bytes_per_day: 1e8,
+      observed_start: '2023-10-15T22:13:20.000Z',
+      observed_end: '2023-11-04T22:13:20.000Z',
+      snapshots_observed: 2,
+      unavailable: null,
+    });
+  });
+
+  it('reports a dataset that shrank as a negative change', async () => {
+    expect(entry(await reported(healthy()), 'tank/vm')).toMatchObject({
+      change_bytes: -2e8,
+      change_bytes_per_day: -2e7,
+    });
+  });
+
+  it('states the range it was asked about and when the levels were read', async () => {
+    expect(await reported(healthy())).toMatchObject({
+      start: '2023-10-01T00:00:00.000Z',
+      end: '2023-12-01T00:00:00.000Z',
+      as_of: '2023-11-14T22:13:20.000Z',
+      truncated_datasets: false,
+      truncated_snapshots: false,
+    });
+  });
+
+  it('returns only the fields it names', async () => {
+    const report = await reported(healthy());
+    expect(Object.keys(report)).toEqual([
+      'start',
+      'end',
+      'as_of',
+      'pools',
+      'datasets',
+      'truncated_datasets',
+      'truncated_snapshots',
+    ]);
+    expect(Object.keys(entry(report, 'tank/media'))).toEqual([
+      'dataset',
+      'pool',
+      'used_bytes',
+      'referenced_start_bytes',
+      'referenced_end_bytes',
+      'change_bytes',
+      'change_bytes_per_day',
+      'observed_start',
+      'observed_end',
+      'snapshots_observed',
+      'unavailable',
+    ]);
+    expect(Object.keys(report.pools[0])).toEqual([
+      'pool',
+      'used_bytes',
+      'free_bytes',
+      'total_bytes',
+      'used_percent',
+      'levels_unavailable',
+      'referenced_change_bytes',
+      'referenced_change_bytes_per_day',
+      'observed_start',
+      'observed_end',
+      'datasets_observed',
+      'datasets_total',
+      'unavailable',
+    ]);
+  });
+
+  it("sums the pool's change over the datasets it reported, and says how far that reaches", async () => {
+    expect((await reported(healthy())).pools[0]).toEqual({
+      pool: 'tank',
+      used_bytes: 6e9,
+      free_bytes: 4e9,
+      total_bytes: 10e9,
+      used_percent: 60,
+      levels_unavailable: null,
+      referenced_change_bytes: 1.8e9,
+      referenced_change_bytes_per_day: 8e7,
+      // The widest window any contributing dataset was observed over.
+      observed_start: '2023-10-15T22:13:20.000Z',
+      observed_end: '2023-11-04T22:13:20.000Z',
+      datasets_observed: 2,
+      datasets_total: 2,
+      unavailable: null,
+    });
+  });
+
+  it('drops samples outside the range rather than measuring against them', async () => {
+    const fake = spaceSystem({
+      snapshots: { 'tank/media': [snap(day(300), 1e6), snap(day(30), 1e9), snap(day(10), 3e9)] },
+    });
+    expect(entry(await reported(fake), 'tank/media')).toMatchObject({
+      referenced_start_bytes: 1e9,
+      snapshots_observed: 2,
+    });
+  });
+
+  it('marks a dataset the system holds no snapshot of in the range', async () => {
+    expect(entry(await reported(healthy()), 'tank/vm')).toBeDefined();
+    const report = await reported(spaceSystem({}));
+    expect(entry(report, 'tank/media')).toMatchObject({
+      used_bytes: 5e9,
+      change_bytes: null,
+      change_bytes_per_day: null,
+      observed_start: null,
+      snapshots_observed: 0,
+      unavailable: 'the system holds no snapshot of this dataset in this range',
+    });
+  });
+
+  it('marks a dataset snapshotted only at one instant as a level rather than a change', async () => {
+    // Two snapshots, one instant: there is something to read and it is not a
+    // change, and reporting zero would say the dataset held still.
+    const fake = spaceSystem({
+      snapshots: { 'tank/media': [snap(day(30), 1e9), snap(day(30), 2e9)] },
+    });
+    expect(entry(await reported(fake), 'tank/media')).toMatchObject({
+      change_bytes: null,
+      snapshots_observed: 2,
+      unavailable:
+        'the system holds no two snapshots of this dataset taken at different times in this range',
+    });
+  });
+
+  it('names a failed snapshot read on that dataset alone', async () => {
+    const fake = spaceSystem({
+      snapshots: { 'tank/vm': [snap(day(30), 5e8), snap(day(20), 3e8)] },
+      failures: { 'tank/media': new Error('dataset is locked') },
+    });
+    const report = await reported(fake);
+    expect(entry(report, 'tank/media')).toMatchObject({
+      change_bytes: null,
+      snapshots_observed: 0,
+      unavailable: 'dataset is locked',
+    });
+    expect(entry(report, 'tank/vm').unavailable).toBeNull();
+    // The pool still reports the dataset that did answer, over one of two.
+    expect(report.pools[0]).toMatchObject({ datasets_observed: 1, datasets_total: 2 });
+  });
+
+  it('reports a failure carrying no text of its own rather than an empty reason', async () => {
+    const fake = spaceSystem({ failures: { 'tank/media': { reason: 'ENOENT' } } });
+    expect(entry(await reported(fake), 'tank/media').unavailable).toBe('ENOENT');
+    const bare = spaceSystem({ failures: { 'tank/media': '' } });
+    expect(entry(await reported(bare), 'tank/media').unavailable).toBe(
+      'the system reported no reason',
+    );
+  });
+
+  it('ignores a snapshot whose time or size it cannot read', async () => {
+    const fake = spaceSystem({
+      snapshots: {
+        'tank/media': [
+          snap(day(30), 1e9),
+          { name: 'x', properties: { creation: { rawvalue: 'yesterday' }, referenced: {} } },
+          { name: 'y', properties: { creation: { rawvalue: '' }, referenced: { parsed: 5 } } },
+          { name: 'z', properties: { creation: { rawvalue: 1e15 }, referenced: { parsed: 5 } } },
+          { name: 'w' },
+          snap(day(10), 3e9),
+        ],
+      },
+    });
+    expect(entry(await reported(fake), 'tank/media')).toMatchObject({
+      snapshots_observed: 2,
+      change_bytes: 2e9,
+    });
+  });
+
+  it('takes the ends of the history whatever order the system listed it in', async () => {
+    // No order is asked for, so none is assumed: the same two snapshots listed
+    // newest first must give the same change rather than its negation.
+    const fake = spaceSystem({
+      snapshots: { 'tank/media': [snap(day(10), 3e9), snap(day(20), 2e9), snap(day(30), 1e9)] },
+    });
+    expect(entry(await reported(fake), 'tank/media')).toMatchObject({
+      referenced_start_bytes: 1e9,
+      referenced_end_bytes: 3e9,
+      change_bytes: 2e9,
+      observed_start: '2023-10-15T22:13:20.000Z',
+      observed_end: '2023-11-04T22:13:20.000Z',
+    });
+  });
+
+  it('reads the creation time whether the system states it as digits or as a number', async () => {
+    const fake = spaceSystem({
+      snapshots: {
+        'tank/media': [
+          { properties: { creation: { rawvalue: day(30) / 1000 }, referenced: { parsed: 1e9 } } },
+          snap(day(10), 3e9),
+        ],
+      },
+    });
+    expect(entry(await reported(fake), 'tank/media').observed_start).toBe(
+      '2023-10-15T22:13:20.000Z',
+    );
+  });
+
+  it('reports the ten largest datasets and says when it left some out', async () => {
+    const many = Array.from({ length: 12 }, (_, index) =>
+      dataset(`tank/d${index}`, 'tank', index * 1e9),
+    );
+    const report = await reported(spaceSystem({ datasets: many }));
+    expect(report.truncated_datasets).toBe(true);
+    // Largest first, and the two smallest left out — not the alphabetical ten.
+    expect(report.datasets.map((row) => row.dataset)).toEqual([
+      'tank/d11',
+      'tank/d10',
+      'tank/d9',
+      'tank/d8',
+      'tank/d7',
+      'tank/d6',
+      'tank/d5',
+      'tank/d4',
+      'tank/d3',
+      'tank/d2',
+    ]);
+    // Every dataset the system named counts towards the pool's coverage, not
+    // only the ten reported.
+    expect(report.pools[0].datasets_total).toBe(12);
+  });
+
+  it('breaks a tie on the dataset name and orders an unreadable size last', async () => {
+    const report = await reported(
+      spaceSystem({
+        datasets: [
+          dataset('tank/b', 'tank', 1e9),
+          dataset('tank/unknown', 'tank', null),
+          dataset('tank/a', 'tank', 1e9),
+        ],
+      }),
+    );
+    expect(report.datasets.map((row) => row.dataset)).toEqual([
+      'tank/a',
+      'tank/b',
+      'tank/unknown',
+    ]);
+    expect(entry(report, 'tank/unknown').used_bytes).toBeNull();
+  });
+
+  it('says when a dataset held more snapshots than it read', async () => {
+    const many = Array.from({ length: 1001 }, (_, index) =>
+      snap(day(30) + index * 60_000, 1000 + index),
+    );
+    const report = await reported(spaceSystem({ snapshots: { 'tank/media': many } }));
+    expect(report.truncated_snapshots).toBe(true);
+    // The thousand it read, and the ends of those rather than of the range.
+    expect(entry(report, 'tank/media')).toMatchObject({
+      snapshots_observed: 1000,
+      referenced_start_bytes: 1000,
+      referenced_end_bytes: 1999,
+    });
+  });
+
+  it('marks a pool no dataset of which could be measured', async () => {
+    const report = await reported(spaceSystem({}));
+    expect(report.pools[0]).toMatchObject({
+      used_percent: 60,
+      referenced_change_bytes: null,
+      referenced_change_bytes_per_day: null,
+      observed_start: null,
+      observed_end: null,
+      datasets_observed: 0,
+      datasets_total: 2,
+      unavailable: 'no dataset reported for this pool had snapshots at two different times in this range',
+    });
+  });
+
+  it('names a pool the system did not list, in place of its levels', async () => {
+    const report = await reported(spaceSystem({ pools: [] }));
+    expect(report.pools[0]).toMatchObject({
+      pool: 'tank',
+      used_bytes: null,
+      free_bytes: null,
+      total_bytes: null,
+      used_percent: null,
+      levels_unavailable: 'the system did not list this pool',
+    });
+  });
+
+  it('reports levels it cannot read as null rather than as an empty pool', async () => {
+    const report = await reported(
+      spaceSystem({ pools: [{ name: 'tank' }, { name: '' }, { size: 1 }] }),
+    );
+    expect(report.pools).toHaveLength(1);
+    expect(report.pools[0]).toMatchObject({
+      used_bytes: null,
+      total_bytes: null,
+      used_percent: null,
+      levels_unavailable: null,
+    });
+  });
+
+  it('states no percentage of a pool whose size the system reported as zero', async () => {
+    const report = await reported(
+      spaceSystem({ pools: [{ name: 'tank', size: 0, allocated: 0, free: 0 }] }),
+    );
+    expect(report.pools[0]).toMatchObject({ total_bytes: 0, used_percent: null });
+  });
+
+  it('still reports the trends when the pool listing could not be read', async () => {
+    const fake = spaceSystem({
+      snapshots: { 'tank/media': [snap(day(30), 1e9), snap(day(10), 3e9)] },
+      failures: { 'pool.query': new Error('pools unavailable') },
+    });
+    const report = await reported(fake);
+    expect(report.pools[0]).toMatchObject({
+      used_bytes: null,
+      levels_unavailable: 'pools unavailable',
+      referenced_change_bytes: 2e9,
+      datasets_total: 2,
+      unavailable: null,
+    });
+    expect(entry(report, 'tank/media').change_bytes).toBe(2e9);
+  });
+
+  it('still reports the pools when the dataset listing could not be read', async () => {
+    const fake = spaceSystem({ failures: { 'pool.dataset.query': new Error('datasets unavailable') } });
+    const report = await reported(fake);
+    expect(report.datasets).toEqual([]);
+    expect(report.pools[0]).toMatchObject({
+      pool: 'tank',
+      used_percent: 60,
+      // Not zero: "this pool has no datasets" is a claim, and nothing looked.
+      datasets_total: null,
+      unavailable: 'datasets unavailable',
+    });
+  });
+
+  it('fails with the system\'s own reason when neither listing could be read', async () => {
+    const fake = spaceSystem({
+      failures: {
+        'pool.dataset.query': new Error('datasets unavailable'),
+        'pool.query': new Error('pools unavailable'),
+      },
+    });
+    // An empty result would read as a system holding no storage at all.
+    await expect(reportingSpaceTrends.handler(fake.ctx, RANGE)).rejects.toThrow(
+      'datasets unavailable',
+    );
+  });
+
+  it('reports on what the system named a dataset, and attributes one whose pool it did not', async () => {
+    const report = await reported(
+      spaceSystem({
+        datasets: [
+          dataset('tank/media', 'tank', 5e9),
+          { id: 'other/vm', used: { parsed: 2e9 } },
+          { pool: 'tank', used: { parsed: 9e9 } },
+          null,
+          'tank/nope',
+        ],
+      }),
+    );
+    expect(report.datasets.map((row) => row.dataset)).toEqual(['tank/media', 'other/vm']);
+    expect(entry(report, 'other/vm').pool).toBe('other');
+    expect(report.pools.map((row) => row.pool)).toEqual(['other', 'tank']);
+  });
+
+  it('asks the system for each dataset\'s snapshots by name, bounded, with two properties', async () => {
+    const fake = healthy();
+    await reported(fake);
+    expect(fake.query).toHaveBeenCalledWith(
+      'pool.snapshot.query',
+      [['dataset', '=', 'tank/media']],
+      { limit: 1001, extra: { properties: ['creation', 'referenced'] } },
+    );
+    expect(fake.query).toHaveBeenCalledWith('pool.dataset.query', [], {
+      extra: { retrieve_children: true, properties: ['used'] },
+    });
+  });
+
+  it('refuses a bound it cannot read rather than silently using the default', async () => {
+    await expect(
+      reportingSpaceTrends.handler(healthy().ctx, { start: 'last month' }),
+    ).rejects.toThrow(/must be an ISO 8601 timestamp/);
+  });
+
+  it('refuses a range that does not run forwards', async () => {
+    await expect(
+      reportingSpaceTrends.handler(healthy().ctx, { start: '2023-11-14', end: '2023-10-14' }),
     ).rejects.toThrow('"start" must be before "end"');
   });
 });


### PR DESCRIPTION
Adds `reporting_space_trends`, the read-only tool asked for in #41: how pool and dataset space usage has moved over a time range.

Fixes #41

## The ticket's unconfirmed design note, resolved

The note asked me to confirm whether `reporting.netdata_get_data` is in the pinned client's enum, and to correct it here with what I found. Two separate things, and only one of them is the problem:

- **The method is there.** `reporting.netdata_get_data` appears in every API directory the pinned client declares. The note is wrong about that.
- **The graph name has no space graph.** The method's first parameter is `GraphIdentifier[]`, whose `name` is a closed union — `cpu`, `cputemp`, `disk`, `disktemp`, `interface`, `load`, `processes`, `memory`, `uptime`, the ARC graphs and the UPS ones. Nothing for pool or dataset space. `reporting.get_data` takes the same union.

So **"same source and bucketing as `reporting_utilisation`" is not achievable**: this API surface records no space series at all, and a bucketed one would have been invented rather than read.

The note also asked whether dataset-level history is retained or only pool-level. It is neither, in the sense the note meant, and the answer is the reverse of the shape it anticipated: what the system retains is **ZFS's own record**. Every snapshot carries the instant it was taken and the bytes its dataset `referenced` then — the two properties `snapshots_list` already reads — so every dataset that is snapshotted has a genuine, unevenly sampled space history, and one that is not has none.

## What that means for the acceptance criteria

Stated plainly, because one of them cannot be met as written and the rest are met differently than the ticket assumed.

| Criterion | Status |
|---|---|
| Each pool reports used and free space at the range's start and end, and the change between them | **Partly.** Used, free, total and percent are reported per pool as CURRENT readings stamped `as_of`, because nothing on this API surface records pool space over time. The change is reported as a sum over the datasets reported for the pool, with `datasets_observed`/`datasets_total` beside it |
| Dataset-level history reported the same way, or the description says where it does not exist | **Yes.** Per dataset: `referenced_start_bytes`, `referenced_end_bytes`, `change_bytes`, and the two instants those came from |
| A rate of change in bytes per day | **Yes**, `change_bytes_per_day`, over the window actually observed rather than over the range — dividing by the range would turn 10 GiB in an hour into 10 GiB a month |
| Bounded consistently with the rest of the reporting family | **Yes.** Ten datasets, a thousand snapshots each, both flagged |
| `createDefaultCatalog().list(Role.ReadOnly)` includes it | Yes |
| Only fields the tool names explicitly | Yes, and asserted with `toEqual` on `Object.keys` for the result, a pool entry and a dataset entry |
| The exact-list assertion in `tools.spec.ts` is updated | Yes |
| README's "Read-only family" line | Yes |
| `yarn test:coverage` passes the floors | Yes — branches 99.45 against a floor of 96, statements 99.54 against 97 |

**The pool figure is the one to read carefully, and the description says so at length.** It is a sum of per-dataset `referenced` changes over the datasets reported for that pool. `referenced` is descendant-exclusive, so summing a parent and its child does not double-count — but the sum omits datasets not reported, datasets with too few snapshots, and space held only by snapshots of deleted data, and since changes are signed it is not a bound in either direction. `used_percent` is what answers "how full is it now".

## Verification

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all run locally and pass. 619 tests, 34 of them new.

## Review

Four local rounds with the same reviewer, rubric and threshold the required check runs — `local-review.py` exit `0`, so this is the check's own verdict rather than a subagent's. Rounds 1-3 returned three findings at MEDIUM or above, all fixed:

1. **HIGH** — a dataset with more snapshots than the thousand read reported "the system holds no snapshot of this dataset in this range". No order is asked for, so those thousand are an arbitrary thousand and say nothing about the rest. A cut-short read that yields no change now says that it was cut short.
2. **HIGH** — the both-listings-failed guard keyed on both errors, so a failed dataset read beside a pool read that succeeded and named no pool returned an entirely empty result naming no failure. The guard now tests what the result can carry.
3. **MEDIUM** — the same over-claim one level up: a pool whose datasets all failed or were truncated said "no dataset reported for this pool had snapshots at two different times", a claim about the pool's snapshots made from reads that never landed.
4. **MEDIUM** — the description called the pool sum a lower bound on the pool's used-space change. Changes are signed, so an unreported dataset that shrank puts the sum above it.

The fourth round was clean at MEDIUM and above. Two of its LOWs were description text contradicting the code and are fixed in the same commit shape as the rest — `snapshots_observed` IS reported alongside a non-null `unavailable`, and a truncated read only MAY narrow the observed window.

### LOWs left alone, deliberately

- **Selection by `used` ranks ancestors ahead of leaves.** `MAX_DATASETS` takes the ten largest by `used`, which is descendant-inclusive, so a pool root can take a slot while its own `referenced` barely moves. Real, and I left it: `used` is what "how big is this dataset" means everywhere else in this catalog, and the pool sum is unaffected because `referenced` is exclusive. Ranking by `referenced` instead would be a better answer to a slightly different question and is worth its own ticket.
- **`snapshotHistory` reads `row['properties']` unguarded**, so a null row in the listing throws a `TypeError` whose message becomes that dataset's `unavailable`. Contained by the surrounding `catch` — one dataset degrades, the rest of the result stands — and ugly rather than wrong.
- **A pool's `unavailable` can carry the dataset-listing error**, a third value beyond the two the description enumerates for a pool.
- **`MAX_SNAPSHOTS` documents itself as matching `MAX_LIMIT` in `snapshots.ts`** without anything asserting the equality.
- **`propertyBytes`'s parameter shadows the `property()` helper** declared below it, where `snapshots.ts` avoided the same collision by naming its accessor `snapshotProperty`.
- **Ties on a snapshot creation instant** make which sample is taken as first/last depend on the system's listing order. Two snapshots of one dataset at the identical second is not a state ZFS produces.

## Not covered

Nothing here has run against a live middleware. The unconfirmed readings are the ones `snapshots_list` already relies on — that `creation`'s `rawvalue` is whole unix seconds and `referenced`'s `parsed` is a byte count — plus the reading that a snapshot's `referenced` is what its dataset referenced when it was taken, which is ZFS's own definition rather than a guess about this middleware.
