### PR TITLE
feat(tools): add reporting_app_vm_usage, per-app and per-VM consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
-  `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`.
+  `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
+  `reporting_app_vm_usage`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,5 +91,6 @@ export {
   reportingUtilisation,
   reportingDiskIo,
   reportingSpaceTrends,
+  reportingAppVmUsage,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,7 +9,12 @@ import { disksList } from '@/tools/disks';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
-import { reportingDiskIo, reportingSpaceTrends, reportingUtilisation } from '@/tools/reporting';
+import {
+  reportingAppVmUsage,
+  reportingDiskIo,
+  reportingSpaceTrends,
+  reportingUtilisation,
+} from '@/tools/reporting';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
@@ -17,7 +22,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-one read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-two read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -51,6 +56,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(reportingUtilisation);
   catalog.register(reportingDiskIo);
   catalog.register(reportingSpaceTrends);
+  catalog.register(reportingAppVmUsage);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -75,6 +81,7 @@ export {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingAppVmUsage,
   reportingDiskIo,
   reportingSpaceTrends,
   reportingUtilisation,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1793,13 +1793,28 @@ const NO_VM_CPU =
   'this system exposes no per-virtual-machine CPU consumption that this tool can read';
 
 /**
- * What a libvirt VM that is not running is marked with.
+ * What a libvirt VM the system reported a state for that is not `RUNNING` is
+ * marked with.
  *
- * Distinct from every other marker here: this one says the workload has no
- * consumption rather than that the figure could not be obtained, and it is what
- * keeps a stopped VM from reading as one whose memory is unknown.
+ * It says what was done rather than what the machine is consuming, because "not
+ * RUNNING" covers two different facts on this stack: a STOPPED machine is
+ * consuming nothing, and a SUSPENDED one may still be holding everything it
+ * had. Nothing here can say which of the two a given state word is, so both are
+ * stated and `state` beside it is what tells them apart.
  */
-const VM_NOT_RUNNING = 'this virtual machine is not running, so it is consuming no memory';
+const VM_NOT_RUNNING =
+  'the system reports this virtual machine as not RUNNING, so no memory was read for it — a ' +
+  'stopped machine is consuming none, and a suspended one may still be holding what it had';
+
+/**
+ * What a libvirt VM the system reported no readable state for is marked with.
+ *
+ * Kept apart from {@link VM_NOT_RUNNING}: an unreadable state is not evidence
+ * that the machine is stopped, and reporting one as the other turns a read that
+ * failed into a claim about a machine that may well be running.
+ */
+const NO_VM_STATE =
+  'the system reported no state for this virtual machine, so its memory was not read';
 
 /**
  * What a libvirt VM the system named no identifier for is marked with. The
@@ -1879,13 +1894,22 @@ interface MemoryRead {
  * {@link NETWORK_UNIT} carries and is stated in the description for the same
  * reason: a memory figure with no unit cannot be compared with anything.
  *
- * A VM that is not running is not asked about. The call would fail on a domain
- * that does not exist, and "not running" is a better answer than the error text
- * that would come back — it is the reason there is no figure, and it is a fact
- * about the VM rather than about the read.
+ * Only a machine the system reported AS RUNNING is asked about. The call would
+ * fail on a domain that is not there, and the state is a better answer than the
+ * error text that would come back: it is the reason there is no figure, and it
+ * is a fact about the machine rather than about the read.
+ *
+ * The three reasons for not asking are kept apart because they are different
+ * facts, and only one of them is about the machine's consumption: no identifier
+ * to ask by, no state to decide from, and a state that is not RUNNING.
  */
-async function vmMemory(system: SystemHandle, id: number | null, state: string | null): Promise<MemoryRead> {
+async function vmMemory(
+  system: SystemHandle,
+  id: number | null,
+  state: string | null,
+): Promise<MemoryRead> {
   if (id === null) return { bytes: null, unavailable: NO_VM_ID };
+  if (state === null) return { bytes: null, unavailable: NO_VM_STATE };
   if (state !== RUNNING) return { bytes: null, unavailable: VM_NOT_RUNNING };
   try {
     const answer = await firstValueFrom(system.client.api.call('vm.get_memory_usage', [id]));
@@ -1977,9 +2001,12 @@ export const reportingAppVmUsage: ReadOnlyTool = {
     'available for any workload; memory is available only for a RUNNING ' +
     'libvirt-backed VM; and per-app CPU and memory are exposed by the system ' +
     'only through a subscription this tool does not open, so an app reports its ' +
-    'name and state and no consumption at all. A VM that is not running says so ' +
-    'in `memory_unavailable`, and that one IS a statement that it is consuming ' +
-    'nothing. A memory read that failed carries the reason the system gave. ' +
+    'name and state and no consumption at all. A libvirt VM the system reports ' +
+    'as anything other than RUNNING is not asked about, and `memory_unavailable` ' +
+    'says so: A STOPPED MACHINE IS CONSUMING NOTHING, WHILE A SUSPENDED ONE MAY ' +
+    'STILL BE HOLDING WHAT IT HAD, and `state` is what tells those apart. A VM ' +
+    'whose state could not be read says that instead, and is not reported as ' +
+    'stopped. A memory read that failed carries the reason the system gave. ' +
     'Entries fail independently, so one VM can report its memory while another ' +
     'cannot. AN EMPTY `entries` LIST WITH AN EMPTY `failures` LIST IS A SYSTEM ' +
     'RUNNING NO APPS AND NO VMs. `failures` names each listing that could not ' +

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1,6 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 
 /**
  * Reporting family: how busy a system was over a time range, rather than how
@@ -1721,6 +1721,322 @@ export const reportingSpaceTrends: ReadOnlyTool = {
       datasets: reported,
       truncated_datasets: datasets.truncated,
       truncated_snapshots: histories.some((history) => history.truncated),
+    };
+  },
+};
+
+/**
+ * App and VM usage: what each application and virtual machine is consuming,
+ * attributed to the workload rather than summed over the host.
+ *
+ * "What is eating my memory" is the question, and nothing else in the catalog
+ * answers it: `reporting_utilisation` reports the host's totals over a range,
+ * and `apps_list` and `vms_list` report what each workload IS — its state, and
+ * the CPU and memory it was GIVEN — rather than what it is using.
+ *
+ * WHAT THIS API SURFACE CAN BE ASKED FOR IS NARROWER THAN THE QUESTION, and the
+ * shape of this tool is that fact rather than a choice. Three listings name the
+ * workloads — `app.query`, `vm.query` and `virt.instance.query` — and not one of
+ * those rows carries a consumption figure of any kind. What the middleware does
+ * expose is, for the most part, not reachable through the pinned client:
+ *
+ * - Per-app CPU and memory are in the `app.stats` EVENT SOURCE, which takes a
+ *   subscribe-time `interval`. The client excludes every event source from
+ *   `api.events` deliberately, and says why: `core.subscribe` is typed as one
+ *   string with no documented encoding for the arguments, so subscribing would
+ *   send the name with the arguments dropped and the server would not honour it.
+ *   There is no supported way to read it from here.
+ * - Per-VM memory on the libvirt stack is `vm.get_memory_usage`, an ordinary
+ *   call. It is the ONE consumption figure this tool can obtain.
+ * - Per-VM CPU has no method on this surface at all, and the incus stack has
+ *   neither figure: a `virt.instance.query` row carries the instance's
+ *   allocation and its status, and `container.metrics` is another event source.
+ *
+ * So every entry carries both figures, and one that could not be obtained is
+ * null beside a marker naming why — never a zero, and never omitted. A tool that
+ * dropped the fields it cannot fill would read as a complete answer to the
+ * attribution question, and one that reported the ALLOCATION under a name
+ * meaning consumption would answer it wrongly. The markers are per figure and
+ * per entry because the reasons differ that finely: on the same system a
+ * running libvirt VM reports its memory, a stopped one has none to report, and
+ * an app has none that can be read at all.
+ */
+
+/** What kind of workload an entry describes. */
+type WorkloadKind = 'app' | 'vm';
+
+/** Which listing an entry was read from. */
+type WorkloadSource = 'app' | 'vm' | 'virt_instance';
+
+/**
+ * The state word both VM stacks use for a machine that is running. Only the
+ * libvirt stack is tested against it — it is what decides whether there is a
+ * memory figure to ask for — and the incus stack uses the same word, which is
+ * why this is not spelled per stack.
+ */
+const RUNNING = 'RUNNING';
+
+/**
+ * What an app's figures are marked with. The reason is a fact about the API
+ * surface rather than about the app, so it is the same on a running app as on a
+ * stopped one: neither has a figure that can be read.
+ */
+const NO_APP_STATS =
+  'this system exposes per-app CPU and memory only through a subscription, which this tool does not open';
+
+/** What an incus-backed instance's figures are marked with, for the same kind of reason. */
+const NO_INSTANCE_STATS =
+  'this system exposes no CPU or memory consumption for an incus-backed instance that this tool can read';
+
+/** What every virtual machine's CPU figure is marked with, on both stacks. */
+const NO_VM_CPU =
+  'this system exposes no per-virtual-machine CPU consumption that this tool can read';
+
+/**
+ * What a libvirt VM that is not running is marked with.
+ *
+ * Distinct from every other marker here: this one says the workload has no
+ * consumption rather than that the figure could not be obtained, and it is what
+ * keeps a stopped VM from reading as one whose memory is unknown.
+ */
+const VM_NOT_RUNNING = 'this virtual machine is not running, so it is consuming no memory';
+
+/**
+ * What a libvirt VM the system named no identifier for is marked with. The
+ * memory read is by id, so a row without one cannot be asked about at all —
+ * which is not the same as a VM that is not running.
+ */
+const NO_VM_ID = 'the system reported no identifier for this virtual machine to read its memory by';
+
+/** What a memory read that answered something other than a number is marked with. */
+const NO_MEMORY_FIGURE = 'the system answered with no memory figure this tool could read';
+
+/**
+ * The rows each listing answers with, taken from the API surface the tools are
+ * typed against rather than restated here — for the reason `vms.ts` gives: read
+ * as bare records the field names below would compile whatever they were asked
+ * for, so a regenerated client that renames one would turn its value into a null
+ * with no build error and with hand-written fixtures that still pass.
+ */
+type AppEntry = ApiSurface['call']['app.query']['entity'];
+type VmEntry = ApiSurface['call']['vm.query']['entity'];
+type VirtInstanceEntry = ApiSurface['call']['virt.instance.query']['entity'];
+
+/** One app or virtual machine, in the shape this tool reports it. */
+interface UsageRow {
+  kind: WorkloadKind;
+  source: WorkloadSource;
+  id: string | number | null;
+  name: string | null;
+  state: string | null;
+  cpu_percent: number | null;
+  cpu_unavailable: string | null;
+  memory_used_bytes: number | null;
+  memory_unavailable: string | null;
+}
+
+/** A listing that could not be read at all, named by the source it was against. */
+interface UsageFailure {
+  source: WorkloadSource;
+  error: string;
+}
+
+/** A listing that produced rows, or the failure that stopped it. */
+interface Listing<T> {
+  rows: T[];
+  failure: UsageFailure | null;
+}
+
+/**
+ * One listing, with a failure caught and named rather than thrown.
+ *
+ * NO LISTING IS ALLOWED TO FAIL THE TOOL, as in `vms_list`: a system may
+ * legitimately have only one of the two VM stacks, and an app listing that fails
+ * must not take the VMs down with it. The read is passed as a thunk so the call
+ * is made inside the `try`, which keeps this correct for one that throws before
+ * it returns a promise at all.
+ */
+async function listing<T>(source: WorkloadSource, read: () => Promise<T[]>): Promise<Listing<T>> {
+  try {
+    return { rows: await read(), failure: null };
+  } catch (reason) {
+    return { rows: [], failure: { source, error: errorText(reason) } };
+  }
+}
+
+/** One VM's memory consumption, or the stated reason there is no figure. */
+interface MemoryRead {
+  bytes: number | null;
+  unavailable: string | null;
+}
+
+/**
+ * One libvirt VM's memory consumption, or the stated reason none was read.
+ *
+ * (unconfirmed) THE FIGURE IS BYTES. It is passed through under a name that says
+ * bytes, so a release reporting it in kibibytes would be reported a thousandfold
+ * small — wrong rather than absent, which is the same kind of assumption
+ * {@link NETWORK_UNIT} carries and is stated in the description for the same
+ * reason: a memory figure with no unit cannot be compared with anything.
+ *
+ * A VM that is not running is not asked about. The call would fail on a domain
+ * that does not exist, and "not running" is a better answer than the error text
+ * that would come back — it is the reason there is no figure, and it is a fact
+ * about the VM rather than about the read.
+ */
+async function vmMemory(system: SystemHandle, id: number | null, state: string | null): Promise<MemoryRead> {
+  if (id === null) return { bytes: null, unavailable: NO_VM_ID };
+  if (state !== RUNNING) return { bytes: null, unavailable: VM_NOT_RUNNING };
+  try {
+    const answer = await firstValueFrom(system.client.api.call('vm.get_memory_usage', [id]));
+    const bytes = numberOrNull(answer);
+    return bytes === null ? { bytes: null, unavailable: NO_MEMORY_FIGURE } : { bytes, unavailable: null };
+  } catch (reason) {
+    return { bytes: null, unavailable: errorText(reason) };
+  }
+}
+
+/** An application as `app.query` reports it. Neither figure is readable here. */
+function fromApp(entry: AppEntry): UsageRow {
+  return {
+    kind: 'app',
+    source: 'app',
+    id: textOrNull(entry.id),
+    name: textOrNull(entry.name),
+    state: textOrNull(entry.state),
+    cpu_percent: null,
+    cpu_unavailable: NO_APP_STATS,
+    memory_used_bytes: null,
+    memory_unavailable: NO_APP_STATS,
+  };
+}
+
+/**
+ * A libvirt-backed VM as `vm.query` reports it, with the memory figure already
+ * read for it.
+ *
+ * `status.state` is the middleware's own word, read the way `vms_list` reads it:
+ * the type declares `status` present and non-null, and a system that reported
+ * neither must answer a null state rather than throw.
+ */
+function fromVm(entry: VmEntry, memory: MemoryRead): UsageRow {
+  return {
+    kind: 'vm',
+    source: 'vm',
+    id: numberOrNull(entry.id),
+    name: textOrNull(entry.name),
+    state: textOrNull(property(entry.status, 'state')),
+    cpu_percent: null,
+    cpu_unavailable: NO_VM_CPU,
+    memory_used_bytes: memory.bytes,
+    memory_unavailable: memory.unavailable,
+  };
+}
+
+/** An incus-backed VM as `virt.instance.query` reports it. Neither figure is readable. */
+function fromInstance(entry: VirtInstanceEntry): UsageRow {
+  return {
+    kind: 'vm',
+    source: 'virt_instance',
+    id: textOrNull(entry.id),
+    name: textOrNull(entry.name),
+    state: textOrNull(entry.status),
+    cpu_percent: null,
+    cpu_unavailable: NO_VM_CPU,
+    memory_used_bytes: null,
+    memory_unavailable: NO_INSTANCE_STATS,
+  };
+}
+
+export const reportingAppVmUsage: ReadOnlyTool = {
+  name: 'reporting_app_vm_usage',
+  description:
+    'What each application and virtual machine on a TrueNAS system is ' +
+    'consuming right now, attributed per workload. This is what answers "which ' +
+    'app is eating my memory" — `reporting_utilisation` reports the host TOTAL ' +
+    'over a range and cannot attribute any of it, and `apps_list` and ' +
+    '`vms_list` report what each workload was GIVEN rather than what it is ' +
+    'using. `entries` holds one entry per app and per virtual machine, in one ' +
+    'list: `kind` is `app` or `vm`, and `source` is which listing it came from ' +
+    '— `app`, `vm` for the older libvirt-backed VMs, or `virt_instance` for the ' +
+    'newer incus-backed ones. Apps are listed first, then `vm` entries, then ' +
+    '`virt_instance` ones, each in the order the system listed them. `id` is ' +
+    'the identifier that listing uses and is unique only within its own ' +
+    '`source`, so two entries may share a `name` or an `id` while being ' +
+    'different things. `state` is the state word the system itself used, ' +
+    'untranslated: an app is `RUNNING`, `STOPPED`, `CRASHED`, `DEPLOYING` or ' +
+    '`STOPPING`; an incus instance one of `RUNNING`, `STOPPED`, `STARTING`, ' +
+    '`STOPPING`, `FROZEN`, `FREEZING`, `THAWED`, `ABORTING`, `ERROR` or ' +
+    '`UNKNOWN`; a libvirt VM the middleware\'s own narrower vocabulary, in ' +
+    'which a VM that died commonly reads `STOPPED` — `vms_list` is what carries ' +
+    'libvirt\'s own state beside it. `memory_used_bytes` is the memory the ' +
+    'workload is actually using, IN BYTES, and `cpu_percent` its share of CPU. ' +
+    'MOST OF THOSE FIGURES CANNOT BE READ ON THIS API, AND WHERE ONE CANNOT IT ' +
+    'IS NULL WITH `memory_unavailable` OR `cpu_unavailable` NAMING WHY — WHICH ' +
+    'IS NEVER A WORKLOAD CONSUMING NOTHING. Specifically: no CPU figure is ' +
+    'available for any workload; memory is available only for a RUNNING ' +
+    'libvirt-backed VM; and per-app CPU and memory are exposed by the system ' +
+    'only through a subscription this tool does not open, so an app reports its ' +
+    'name and state and no consumption at all. A VM that is not running says so ' +
+    'in `memory_unavailable`, and that one IS a statement that it is consuming ' +
+    'nothing. A memory read that failed carries the reason the system gave. ' +
+    'Entries fail independently, so one VM can report its memory while another ' +
+    'cannot. AN EMPTY `entries` LIST WITH AN EMPTY `failures` LIST IS A SYSTEM ' +
+    'RUNNING NO APPS AND NO VMs. `failures` names each listing that could not ' +
+    'be read at all, as `source` and the `error` the system gave, and WHILE IT ' +
+    'IS NOT EMPTY THE LIST IS INCOMPLETE — a system whose VMs all live in the ' +
+    'stack that failed reports none of them. A stack absent from a given ' +
+    'TrueNAS release appears here as a failure for that reason. Incus ' +
+    'containers are excluded, as in `vms_list`. This tool reports consumption ' +
+    'now, not over a range: `reporting_utilisation` is the host over time, ' +
+    '`reporting_disk_io` is per-disk activity, and `vms_list` and `apps_list` ' +
+    'are what a workload is allocated and what version it runs. It does not ' +
+    'report per-process usage, per-container or per-device breakdowns, disk or ' +
+    'network traffic per workload, and it starts, stops and changes nothing. NO ' +
+    'field beyond those named here is returned, whatever a later TrueNAS ' +
+    'release adds to any of the three records.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // All three listings are issued before any is awaited, and each is caught:
+    // see `listing` for why none of them may fail the tool.
+    const [apps, vms, instances] = await Promise.all([
+      listing('app', () => firstValueFrom(system.client.api.query('app.query'))),
+      listing('vm', () => firstValueFrom(system.client.api.query('vm.query'))),
+      listing('virt_instance', () =>
+        firstValueFrom(
+          // The filter is inlined so the call's own parameter types apply, as
+          // in `vms_list`: written to a `const` first it widens and no longer
+          // satisfies the filter tuple.
+          system.client.api.query('virt.instance.query', [['type', '=', 'VM']]),
+        ),
+      ),
+    ]);
+
+    // One read per VM, all issued together. Only a running VM with a readable
+    // id is actually asked about; the rest resolve to their stated reason
+    // without a call, which is what keeps this bounded by the RUNNING VMs
+    // rather than by every row the stack holds.
+    const memories = await Promise.all(
+      vms.rows.map((entry) =>
+        vmMemory(system, numberOrNull(entry.id), textOrNull(property(entry.status, 'state'))),
+      ),
+    );
+
+    return {
+      entries: [
+        ...apps.rows.map(fromApp),
+        ...vms.rows.map((entry, position) => fromVm(entry, memories[position])),
+        // The `type` filter above is asked of the middleware; this re-checks it
+        // on what came back, as `vms_list` does. A query parameter a release
+        // does not recognise is dropped rather than refused, and the result of
+        // that is containers in a list of virtual machines.
+        ...instances.rows.filter((entry) => entry.type === 'VM').map(fromInstance),
+      ],
+      failures: [apps.failure, vms.failure, instances.failure].filter(
+        (failure): failure is UsageFailure => failure !== null,
+      ),
     };
   },
 };

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1936,20 +1936,46 @@ function fromApp(entry: AppEntry): UsageRow {
 }
 
 /**
- * A libvirt-backed VM as `vm.query` reports it, with the memory figure already
- * read for it.
+ * What a libvirt VM's row says about itself: the identifier its memory is read
+ * by, and the middleware's own state word.
  *
- * `status.state` is the middleware's own word, read the way `vms_list` reads it:
- * the type declares `status` present and non-null, and a system that reported
- * neither must answer a null state rather than throw.
+ * Derived ONCE and then used both to decide the memory read and to fill the
+ * entry. Deriving it twice would let the state a result reports drift from the
+ * state that decided whether to read its memory, so an entry could say RUNNING
+ * beside a marker saying it is not.
  */
-function fromVm(entry: VmEntry, memory: MemoryRead): UsageRow {
+interface VmReading {
+  id: number | null;
+  state: string | null;
+}
+
+/**
+ * `status` read back as a partial of ITS OWN TYPE, which is how `vms_list` reads
+ * it and is what checks the field name below against the generated client.
+ * Reached through {@link property} instead it would be an unchecked string key:
+ * a client that renamed the field would null every VM's state here and skip
+ * every memory read with it, silently and with the fixtures still passing.
+ *
+ * The type declares `status` present and non-null; a system that sent neither
+ * must still answer a null state rather than throw, so it is read through the
+ * optional chain rather than trusted.
+ */
+function vmReading(entry: VmEntry): VmReading {
+  const status = entry.status as Partial<VmEntry['status']> | null | undefined;
+  return { id: numberOrNull(entry.id), state: textOrNull(status?.state) };
+}
+
+/**
+ * A libvirt-backed VM as `vm.query` reports it, with its reading and the memory
+ * figure already taken from it.
+ */
+function fromVm(entry: VmEntry, reading: VmReading, memory: MemoryRead): UsageRow {
   return {
     kind: 'vm',
     source: 'vm',
-    id: numberOrNull(entry.id),
+    id: reading.id,
     name: textOrNull(entry.name),
-    state: textOrNull(property(entry.status, 'state')),
+    state: reading.state,
     cpu_percent: null,
     cpu_unavailable: NO_VM_CPU,
     memory_used_bytes: memory.bytes,
@@ -2041,20 +2067,21 @@ export const reportingAppVmUsage: ReadOnlyTool = {
       ),
     ]);
 
+    // Read once, and used both to decide the memory read and to fill the entry:
+    // see {@link VmReading}.
+    const readings = vms.rows.map(vmReading);
     // One read per VM, all issued together. Only a running VM with a readable
     // id is actually asked about; the rest resolve to their stated reason
     // without a call, which is what keeps this bounded by the RUNNING VMs
     // rather than by every row the stack holds.
     const memories = await Promise.all(
-      vms.rows.map((entry) =>
-        vmMemory(system, numberOrNull(entry.id), textOrNull(property(entry.status, 'state'))),
-      ),
+      readings.map((reading) => vmMemory(system, reading.id, reading.state)),
     );
 
     return {
       entries: [
         ...apps.rows.map(fromApp),
-        ...vms.rows.map((entry, position) => fromVm(entry, memories[position])),
+        ...vms.rows.map((entry, position) => fromVm(entry, readings[position], memories[position])),
         // The `type` filter above is asked of the middleware; this re-checks it
         // on what came back, as `vms_list` does. A query parameter a release
         // does not recognise is dropped rather than refused, and the result of

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -23,6 +23,7 @@ import {
   poolTopology,
   quotaReport,
   replicationStatus,
+  reportingAppVmUsage,
   reportingDiskIo,
   reportingSpaceTrends,
   reportingUtilisation,
@@ -79,7 +80,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-two sketch tools', () => {
+  it('registers the thirty-three sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -112,6 +113,7 @@ describe('createDefaultCatalog', () => {
       'reporting_utilisation',
       'reporting_disk_io',
       'reporting_space_trends',
+      'reporting_app_vm_usage',
       'snapshots_create',
     ]);
   });
@@ -131,6 +133,12 @@ describe('createDefaultCatalog', () => {
   it('advertises reporting_space_trends to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'reporting_space_trends',
+    );
+  });
+
+  it('advertises reporting_app_vm_usage to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'reporting_app_vm_usage',
     );
   });
 
@@ -9249,5 +9257,296 @@ describe('reporting_space_trends', () => {
     await expect(
       reportingSpaceTrends.handler(healthy().ctx, { start: '2023-11-14', end: '2023-10-14' }),
     ).rejects.toThrow('"start" must be before "end"');
+  });
+});
+
+describe('reporting_app_vm_usage', () => {
+  /**
+   * An app as `app.query` reports one. `config` is the install-time form the
+   * user filled in and routinely holds a credential; it is on the fixture so
+   * that the test that it does not survive the mapping is worth something.
+   */
+  const app = (over: Record<string, unknown> = {}) => ({
+    id: 'plex',
+    name: 'plex',
+    state: 'RUNNING',
+    version: '1.2.3',
+    active_workloads: { containers: 1 },
+    config: { plex_claim_token: 'SECRET-CLAIM-TOKEN' },
+    ...over,
+  });
+
+  /** A libvirt-backed VM as `vm.query` reports one: the state nested in `status`. */
+  const vm = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'buildbox',
+    memory: 4096,
+    autostart: true,
+    status: { state: 'RUNNING', pid: 1234, domain_state: 'RUNNING' },
+    devices: [{ dtype: 'DISK', attributes: { path: '/dev/zvol/tank/buildbox' } }],
+    ...over,
+  });
+
+  /** An incus-backed VM as `virt.instance.query` reports one: one flat status word. */
+  const instance = (over: Record<string, unknown> = {}) => ({
+    id: 'web',
+    name: 'web',
+    type: 'VM',
+    status: 'RUNNING',
+    cpu: '4',
+    memory: 8589934592,
+    environment: { API_TOKEN: 'SECRET-GUEST-TOKEN' },
+    ...over,
+  });
+
+  interface Entry {
+    kind: string;
+    source: string;
+    id: string | number | null;
+    name: string | null;
+    state: string | null;
+    cpu_percent: number | null;
+    cpu_unavailable: string | null;
+    memory_used_bytes: number | null;
+    memory_unavailable: string | null;
+  }
+
+  interface Report {
+    entries: Entry[];
+    failures: { source: string; error: string }[];
+  }
+
+  interface Fake {
+    ctx: ToolContext;
+    call: ReturnType<typeof vi.fn>;
+    query: ReturnType<typeof vi.fn>;
+  }
+
+  interface Options {
+    apps?: unknown[];
+    vms?: unknown[];
+    instances?: unknown[];
+    /** What `vm.get_memory_usage` answers, per VM id. */
+    memory?: Record<number, unknown>;
+    /** Keyed by method, or by `vm.get_memory_usage:<id>` for one VM's read. */
+    failures?: Record<string, unknown>;
+  }
+
+  /**
+   * A SystemHandle answering per listing, and per VM ID for the memory read —
+   * which neither `fakeSystem` nor `failingSystem` can do: they key on the
+   * method alone, and every VM's memory comes back from the same method
+   * distinguished only by the id asked for.
+   */
+  const usageSystem = (options: Options = {}): Fake => {
+    const failures = options.failures ?? {};
+    const memory = options.memory ?? { 1: 2147483648 };
+    const listings: Record<string, unknown> = {
+      ['app.query']: options.apps ?? [app()],
+      ['vm.query']: options.vms ?? [vm()],
+      ['virt.instance.query']: options.instances ?? [instance()],
+    };
+    const query = vi.fn((method: string) =>
+      method in failures ? throwError(() => failures[method]) : of(listings[method]),
+    );
+    // The client takes a call's parameters as one tuple, so the id arrives
+    // wrapped: `call('vm.get_memory_usage', [1])`.
+    const call = vi.fn((method: string, params: [number]) => {
+      const key = `${method}:${params[0]}`;
+      return key in failures ? throwError(() => failures[key]) : of(memory[params[0]]);
+    });
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    return { ctx: { system }, call, query };
+  };
+
+  const reported = async (fake: Fake): Promise<Report> =>
+    (await reportingAppVmUsage.handler(fake.ctx, {})) as Report;
+
+  /** The entries a system of these listings reports. */
+  const entries = async (options: Options = {}): Promise<Entry[]> =>
+    (await reported(usageSystem(options))).entries;
+
+  /** The one entry a system holding a single workload of that kind reports. */
+  const oneApp = async (over: Record<string, unknown>): Promise<Entry> =>
+    (await entries({ apps: [app(over)], vms: [], instances: [] }))[0];
+
+  const oneVm = async (
+    over: Record<string, unknown>,
+    memory?: Record<number, unknown>,
+  ): Promise<Entry> => (await entries({ apps: [], vms: [vm(over)], instances: [], memory }))[0];
+
+  const oneInstance = async (over: Record<string, unknown>): Promise<Entry> =>
+    (await entries({ apps: [], vms: [], instances: [instance(over)] }))[0];
+
+  it('reports every app and virtual machine in one list, each tagged with its kind', async () => {
+    expect(await reported(usageSystem())).toEqual({
+      entries: [
+        {
+          kind: 'app',
+          source: 'app',
+          id: 'plex',
+          name: 'plex',
+          state: 'RUNNING',
+          cpu_percent: null,
+          cpu_unavailable: expect.stringContaining('subscription'),
+          memory_used_bytes: null,
+          memory_unavailable: expect.stringContaining('subscription'),
+        },
+        {
+          kind: 'vm',
+          source: 'vm',
+          id: 1,
+          name: 'buildbox',
+          state: 'RUNNING',
+          cpu_percent: null,
+          cpu_unavailable: expect.stringContaining('no per-virtual-machine CPU'),
+          memory_used_bytes: 2147483648,
+          memory_unavailable: null,
+        },
+        {
+          kind: 'vm',
+          source: 'virt_instance',
+          id: 'web',
+          name: 'web',
+          state: 'RUNNING',
+          cpu_percent: null,
+          cpu_unavailable: expect.stringContaining('no per-virtual-machine CPU'),
+          memory_used_bytes: null,
+          memory_unavailable: expect.stringContaining('incus-backed'),
+        },
+      ],
+      failures: [],
+    });
+  });
+
+  it('reads a running libvirt VM by its own id, so two VMs do not share one figure', async () => {
+    const fake = usageSystem({
+      apps: [],
+      instances: [],
+      vms: [vm(), vm({ id: 2, name: 'mailer' })],
+      memory: { 1: 2147483648, 2: 536870912 },
+    });
+    expect((await reported(fake)).entries.map((entry) => entry.memory_used_bytes)).toEqual([
+      2147483648, 536870912,
+    ]);
+    expect(fake.call.mock.calls).toEqual([
+      ['vm.get_memory_usage', [1]],
+      ['vm.get_memory_usage', [2]],
+    ]);
+  });
+
+  it('reports a stopped VM as stopped rather than as consuming nothing', async () => {
+    const fake = usageSystem({
+      apps: [],
+      instances: [],
+      vms: [vm({ status: { state: 'STOPPED', domain_state: 'SHUTOFF' } })],
+    });
+    const [entry] = (await reported(fake)).entries;
+    expect(entry.state).toBe('STOPPED');
+    expect(entry.memory_used_bytes).toBeNull();
+    expect(entry.memory_unavailable).toMatch(/not running/);
+    // Nothing is asked about a VM that is not running: the call would fail on a
+    // domain that does not exist, and that error text would be a worse answer
+    // than the reason there is no figure.
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('reports the reason the system gave when a memory read fails', async () => {
+    const [entry] = await entries({
+      apps: [],
+      instances: [],
+      failures: { ['vm.get_memory_usage:1']: { reason: 'domain not found' } },
+    });
+    expect(entry.memory_used_bytes).toBeNull();
+    expect(entry.memory_unavailable).toBe('domain not found');
+  });
+
+  it('reports no figure where the system answered with something that is not one', async () => {
+    const entry = await oneVm({}, { 1: 'a lot' });
+    expect(entry.memory_used_bytes).toBeNull();
+    expect(entry.memory_unavailable).toMatch(/no memory figure/);
+  });
+
+  it('reports no figure, and asks nothing, where a VM has no identifier to ask by', async () => {
+    const fake = usageSystem({ apps: [], instances: [], vms: [vm({ id: null })] });
+    const [entry] = (await reported(fake)).entries;
+    expect(entry.id).toBeNull();
+    expect(entry.memory_unavailable).toMatch(/no identifier/);
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('reports a state it could not read as null rather than as a state', async () => {
+    expect(await oneApp({ state: 42 })).toMatchObject({ state: null });
+    // A row whose `status` is not a record at all: the type declares it present
+    // and non-null, and a system that sent neither must answer null.
+    expect(await oneVm({ status: null })).toMatchObject({ state: null });
+    expect(await oneInstance({ status: '' })).toMatchObject({ state: null });
+  });
+
+  it('excludes incus containers even where the middleware kept them', async () => {
+    const fake = usageSystem({
+      apps: [],
+      vms: [],
+      instances: [instance(), instance({ id: 'dns', name: 'dns', type: 'CONTAINER' })],
+    });
+    expect((await reported(fake)).entries.map((entry) => entry.id)).toEqual(['web']);
+    // The filter is asked of the middleware too; an unrecognised one is dropped
+    // rather than refused, which is what the re-check above is for.
+    expect(fake.query).toHaveBeenCalledWith('virt.instance.query', [['type', '=', 'VM']]);
+  });
+
+  it('surfaces neither the install-time config nor a field a later release adds', async () => {
+    const report = await reported(
+      usageSystem({
+        apps: [app({ future_field: 'added by a later TrueNAS release' })],
+        vms: [vm({ future_field: 'added by a later TrueNAS release' })],
+        instances: [instance({ future_field: 'added by a later TrueNAS release' })],
+      }),
+    );
+    expect(JSON.stringify(report)).not.toMatch(/SECRET|future_field/);
+    expect(Object.keys(report.entries[0])).toEqual([
+      'kind',
+      'source',
+      'id',
+      'name',
+      'state',
+      'cpu_percent',
+      'cpu_unavailable',
+      'memory_used_bytes',
+      'memory_unavailable',
+    ]);
+  });
+
+  it('reports the listings that answered when another one fails', async () => {
+    const report = await reported(
+      usageSystem({ failures: { ['app.query']: new Error('apps are not installed') } }),
+    );
+    expect(report.entries.map((entry) => entry.source)).toEqual(['vm', 'virt_instance']);
+    expect(report.failures).toEqual([{ source: 'app', error: 'apps are not installed' }]);
+  });
+
+  it('names every listing that failed rather than reporting an empty system', async () => {
+    const report = await reported(
+      usageSystem({
+        failures: {
+          ['app.query']: 'apps unavailable',
+          ['vm.query']: 'vm stack absent',
+          ['virt.instance.query']: 'virt stack absent',
+        },
+      }),
+    );
+    expect(report.entries).toEqual([]);
+    expect(report.failures).toEqual([
+      { source: 'app', error: 'apps unavailable' },
+      { source: 'vm', error: 'vm stack absent' },
+      { source: 'virt_instance', error: 'virt stack absent' },
+    ]);
+  });
+
+  it('reports a system running nothing as empty, with nothing to explain', async () => {
+    expect(await reported(usageSystem({ apps: [], vms: [], instances: [] }))).toEqual({
+      entries: [],
+      failures: [],
+    });
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -9444,7 +9444,8 @@ describe('reporting_app_vm_usage', () => {
     const [entry] = (await reported(fake)).entries;
     expect(entry.state).toBe('STOPPED');
     expect(entry.memory_used_bytes).toBeNull();
-    expect(entry.memory_unavailable).toMatch(/not running/);
+    expect(entry.memory_unavailable).toMatch(/not RUNNING/);
+    expect(entry.memory_unavailable).toMatch(/stopped machine is consuming none/);
     // Nothing is asked about a VM that is not running: the call would fail on a
     // domain that does not exist, and that error text would be a worse answer
     // than the reason there is no figure.
@@ -9481,6 +9482,25 @@ describe('reporting_app_vm_usage', () => {
     // and non-null, and a system that sent neither must answer null.
     expect(await oneVm({ status: null })).toMatchObject({ state: null });
     expect(await oneInstance({ status: '' })).toMatchObject({ state: null });
+  });
+
+  it('does not report a VM whose state it could not read as one that is stopped', async () => {
+    const fake = usageSystem({ apps: [], instances: [], vms: [vm({ status: null })] });
+    const [entry] = (await reported(fake)).entries;
+    expect(entry.memory_unavailable).toMatch(/reported no state/);
+    // An unreadable state is not evidence the machine is stopped, so nothing
+    // here may say it is consuming nothing.
+    expect(entry.memory_unavailable).not.toMatch(/consuming none/);
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('does not claim a suspended VM is consuming nothing', async () => {
+    const entry = await oneVm({ status: { state: 'SUSPENDED', domain_state: 'PAUSED' } });
+    expect(entry.state).toBe('SUSPENDED');
+    expect(entry.memory_used_bytes).toBeNull();
+    // The marker is the same one a stopped machine carries, and it states both
+    // readings rather than asserting the wrong one: `state` says which this is.
+    expect(entry.memory_unavailable).toMatch(/suspended one may still be holding/);
   });
 
   it('excludes incus containers even where the middleware kept them', async () => {


### PR DESCRIPTION
Adds `reporting_app_vm_usage`, a read-only tool listing every app and virtual machine on a system with what each is consuming — the attribution question (`which app is eating my memory`) that `reporting_utilisation` cannot answer, because it reports the host total, and that `apps_list` and `vms_list` cannot, because they report what a workload was *given*.

Fixes #43.

## What this API surface can actually be asked for

The ticket flagged per-app stats as unconfirmed and per-VM attribution as possibly needing a different source. Both were checked against the pinned client's generated directory, and the answer shapes the tool:

- **No listing carries a consumption figure.** `AppEntry`, `VMEntry` and `VirtInstanceEntry` each carry state and *allocation* only.
- **Per-app CPU and memory exist only as an event source.** `app.stats` is in the client's *event* directory, with a subscribe-time `interval` argument, and `EventName` excludes every event source from `api.events` deliberately: `core.subscribe` is typed as one string with no documented encoding for the arguments, so subscribing would send the name with the arguments dropped and the server would not honour it. There is no supported way to read it from here.
- **Per-VM CPU has no method at all**, on either stack, and `container.metrics` is another event source.
- **`vm.get_memory_usage` is a plain call** on the default surface, and is the one consumption figure obtainable — for a libvirt-backed VM that is running.

So every entry carries both figures, and one that could not be obtained is `null` beside a marker naming why, rather than being omitted or reported as a zero. Omitting the fields would make an incomplete answer read as a complete one; reporting the *allocation* under a name meaning consumption would answer the question wrongly.

## Shape

`entries`, one per app and per virtual machine, each with `kind` (`app` / `vm`), `source` (`app` / `vm` / `virt_instance`), `id`, `name`, `state`, `cpu_percent` + `cpu_unavailable`, and `memory_used_bytes` + `memory_unavailable`. `failures` names each listing that could not be read at all, as in `vms_list`, so a system whose VMs all live in the stack that failed does not read as one with no VMs. Incus containers are excluded, and the `type` filter is re-checked on the response because an unrecognised query parameter is dropped rather than refused.

A libvirt VM is only asked about when the system reports it as `RUNNING`; the three reasons for not asking are kept apart, because only one of them is about consumption — no identifier to ask by, no readable state, and a state that is not `RUNNING`.

`memory_used_bytes` is **(unconfirmed) bytes**: `vm.get_memory_usage` is passed through under a name asserting the unit, so a release reporting kibibytes would be reported a thousandfold small. That is the same class of assumption `NETWORK_UNIT` carries in this file, and it is stated in the tool description for the same reason — a memory figure with no unit cannot be compared with anything.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test`, `yarn test:coverage` and `yarn build` all pass locally. Coverage: 99.55% statements / 99.46% branches overall, against floors of 97 / 96; `reporting.ts` is 100% statements, 99.68% branches. The exact-list assertion in `describe('createDefaultCatalog')`, its count in the test name, the catalog comment and the README's read-only family line are all updated.

## Review

Three local rounds of the same reviewer the required check runs, in a separate process. Round 1 raised a HIGH — every state that was not `RUNNING` read as "not running, so consuming no memory", which is wrong for a VM whose `status` could not be read and for a `SUSPENDED` one that may still hold its memory. Round 2 raised a MEDIUM — `status.state` reached through an unchecked string key, so a client rename would null every state and skip every memory read silently. Both are fixed, in the two commits after the first. Round 3 returned nothing at or above MEDIUM.

### LOWs left unfixed, and why

- **The per-VM `vm.get_memory_usage` fan-out is uncapped**, unlike `MAX_INTERFACES` / `MAX_DISKS` / `MAX_DATASETS` in this file. Those caps bound the *response*: each covered thing costs two to six metrics. Here each workload costs one small entry, and dropping a VM from an attribution answer defeats the tool — the caller asked which workload is using the memory. The calls are bounded by the number of *running* libvirt VMs, since nothing else is asked about. A cap with a `truncated_vms` signal is a reasonable follow-up if a real system shows this to be expensive.
- **`NO_INSTANCE_STATS` names "CPU or memory"** while filling `memory_unavailable` only; the sibling `cpu_unavailable` covers CPU. Prose, and true as written.
- **The description does not say `id`, `name` and `state` may be null**, where `vms_list`'s does. Worth adding; it is a description edit, not a behaviour one.
- **A `SUSPENDED` domain might well answer `vm.get_memory_usage`**, since it still exists — reading it would resolve the ambiguity the marker states rather than describing it. That is a behaviour change resting on middleware behaviour this cannot confirm from here, so it is a follow-up rather than a guess.
- **`RUNNING` is matched exactly** against a field the pinned client types as a bare `string`, and the constant carries no `(unconfirmed)` marker the way this file's other unconfirmed readings do.
- **Two test gaps**: no case has one VM's memory read fail while another's succeeds (the description promises entries fail independently), and none mixes a non-running VM *before* a running one, which would pin the `readings`/`memories` index alignment against a later filter-before-map refactor.
