### PR TITLE
feat(tools): add ha_status, HA state, active node and failover readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
   `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
-  `reporting_app_vm_usage`.
+  `reporting_app_vm_usage`, `ha_status`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,5 +92,6 @@ export {
   reportingDiskIo,
   reportingSpaceTrends,
   reportingAppVmUsage,
+  haStatus,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -1,0 +1,245 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+
+/**
+ * Fleet family: read-only inspection of how a system stands as one part of
+ * something larger — the other node of its HA pair, and the fleet around it.
+ */
+
+/**
+ * A string the system reported, or null where it reported anything else.
+ *
+ * An empty string is read as no value rather than as text of no characters: a
+ * status of no characters names nothing a caller could act on, and passing it
+ * through would put a field in the result that says nothing.
+ *
+ * `system.ts`, `accounts.ts`, `shares.ts` and `block.ts` each hold the same
+ * reading under their own names, and this restates rather than shares it for the
+ * reason `shares.ts` gives for restating its own guards: a tool file is read on
+ * its own.
+ */
+function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** What a failure carrying no text of its own is reported as. */
+const NO_REASON = 'the system reported no reason';
+
+/**
+ * Why a read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Anything else
+ * still becomes a stated absence rather than `"[object Object]"`, and the
+ * result is never empty: a failure with no text still has to read as a failure.
+ * The same reading `system.ts` holds of a failed version read.
+ */
+function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/**
+ * The status a system reports when it is not one node of an HA pair.
+ *
+ * (unconfirmed against a live middleware) The client types `failover.status` as
+ * a bare string and lists no values, so this is read from what TrueNAS reports:
+ * `SINGLE` on a system with no peer — an unlicensed one, a community one, or
+ * one half of a pair that was never completed — and `MASTER`, `BACKUP`,
+ * `ELECTING` or `IMPORTING` on a system that is part of one. Getting this wrong
+ * in the direction that matters is guarded structurally rather than by the
+ * spelling: only the exact word `SINGLE` short-circuits, so a status this
+ * constant does not match is treated as an HA pair and the reasons are read,
+ * which is the answer that can be checked rather than the one that quietly says
+ * "not applicable".
+ */
+const SINGLE = 'SINGLE';
+
+/** Which node answered, or the failure that stopped it being read. */
+interface NodeAttempt {
+  value: string | null;
+  error: string | null;
+}
+
+/**
+ * Which node of the pair this call was answered by, with a failure named rather
+ * than thrown.
+ *
+ * Reported rather than fatal for the reason `accounts.ts` gives for its
+ * configuration read: the question the tool is asked — can this pair survive
+ * losing a node right now — is answered by the status and the disabled reasons
+ * on their own, and losing the node's identity must not lose that answer too.
+ */
+async function readNode(system: SystemHandle): Promise<NodeAttempt> {
+  try {
+    const node = await firstValueFrom(system.client.api.call('failover.node'));
+    return { value: textOrNull(node), error: null };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/** What the system says stands in the way of a failover. */
+interface ReasonsAttempt {
+  /** The reasons this tool could read, or null where the read itself failed. */
+  value: string[] | null;
+  /**
+   * How many reasons the system named, readable or not — null where the read
+   * failed. This rather than `value.length` is what says whether failover is
+   * possible: a reason the system named and this tool could not read is still a
+   * reason failover would not work, and counting only the readable ones would
+   * turn an answer of "something is wrong here" into "everything is fine".
+   */
+  count: number | null;
+  error: string | null;
+}
+
+/** What a system answering with something other than a list is reported as. */
+const NOT_A_LIST = 'the system did not answer with a list of reasons';
+
+/**
+ * Everything the system says would stop a failover working, with a failure
+ * named rather than thrown — the same reading as {@link readNode}, and the read
+ * this tool exists for: `failover.status` says which node is active, and only
+ * this says whether the other one could take over.
+ */
+async function readDisabledReasons(system: SystemHandle): Promise<ReasonsAttempt> {
+  let answer: unknown;
+  try {
+    answer = await firstValueFrom(system.client.api.call('failover.disabled.reasons'));
+  } catch (reason) {
+    return { value: null, count: null, error: errorText(reason) };
+  }
+  // Fatal to the reasons rather than to the tool, and null rather than empty: a
+  // system that answered something other than a list has not said that nothing
+  // is in the way, and an empty list is exactly the claim that must not be made
+  // on its behalf.
+  if (!Array.isArray(answer)) return { value: null, count: null, error: NOT_A_LIST };
+  const readable: string[] = [];
+  for (const entry of answer) {
+    const reason = textOrNull(entry);
+    if (reason !== null) readable.push(reason);
+  }
+  const unreadable = answer.length - readable.length;
+  return {
+    value: readable,
+    count: answer.length,
+    // A shortfall is stated with its numbers rather than passed over, because
+    // the list that comes back is then not every reason the system gave and the
+    // acceptance criterion this tool is written against says it should be.
+    error:
+      unreadable === 0
+        ? null
+        : `the system named ${answer.length} reasons and ${unreadable} could not be read`,
+  };
+}
+
+/**
+ * Whether this pair could survive losing a node right now.
+ *
+ * The question is asked least and matters most, because checking it by hand is
+ * tedious: a standby that has quietly stopped being able to take over is
+ * invisible until the failover that needed it. So the two answers this tool
+ * keeps apart are "failover works" and "nothing here has been established" —
+ * never collapsing the second into the first.
+ *
+ * The other distinction it keeps is a single-node system from a broken one.
+ * Most systems are not HA pairs at all, and a tool that reported every one of
+ * them as unable to fail over would be reporting the ordinary case as a fault.
+ * A system that says `SINGLE` is answered with `ha_configured: false` and
+ * nothing else read, rather than with a list of reasons it cannot do something
+ * it was never meant to do.
+ */
+export const haStatus: ReadOnlyTool = {
+  name: 'ha_status',
+  description:
+    'Whether this TrueNAS system is one node of a high-availability pair, which ' +
+    'node it is, and whether a failover would work right now. `ha_configured` ' +
+    'is the marker to read first: FALSE MEANS THIS IS A SINGLE-NODE SYSTEM, ' +
+    'which is the ordinary case and IS NOT A FAULT OR A DEGRADED PAIR — it has ' +
+    'no second node to fail over to and was never meant to have one. It is ' +
+    'true where the system reports any HA state at all, and null where the ' +
+    'system reported no state, which settles nothing either way. `status` is ' +
+    "the system's own HA state verbatim — `SINGLE` on a system that is not " +
+    'part of a pair, and `MASTER` (this node is the active one), `BACKUP` ' +
+    '(this node is the standby), `ELECTING` or `IMPORTING` (a failover is in ' +
+    'progress) on one that is; a state a later TrueNAS release adds is passed ' +
+    'through as the system spelled it. `node` is which node of the pair ' +
+    'answered this call, such as `A` or `B`. `failover_possible` is whether ' +
+    'the pair could fail over right now: true when the system named nothing ' +
+    'standing in the way, false when it named something, and NULL WHEN NOTHING ' +
+    'WAS ESTABLISHED — either this is a single-node system, where the question ' +
+    'does not apply, or the check could not be read. NULL IS NEVER "FAILOVER ' +
+    'WORKS". `failover_disabled_reasons` lists every reason the system gives, ' +
+    'in its own words — `NO_VOLUME`, `NO_VIP`, `NO_SYSTEM_READY`, `NO_PONG`, ' +
+    '`NO_FAILOVER`, `NO_LICENSE`, `DISAGREE_VIP`, `MISMATCH_DISKS` and the ' +
+    'like, passed through as the system spelled them. It is an empty list when ' +
+    'the system named none, and null WHERE IT WAS NOT READ AT ALL — which is ' +
+    'the case on a single-node system, where it is not asked for, and where the ' +
+    'read failed. `node_error` and `reasons_error` name what the system said ' +
+    'when a read failed, and `node` and `failover_disabled_reasons` are null ' +
+    'while the matching error is non-null BECAUSE THEY COULD NOT BE READ, not ' +
+    'because the system has no node or nothing in the way; `node` null with ' +
+    '`node_error` null is a pair that answered the read with no node. ' +
+    '`reasons_error` is ' +
+    'also set, with the list still returned, where the system named a reason ' +
+    'this tool could not read: the list is then shorter than what the system ' +
+    'gave, and `failover_possible` is still false, because a reason that could ' +
+    'not be read is still a reason. ON A SINGLE-NODE SYSTEM `node`, ' +
+    '`failover_possible`, `failover_disabled_reasons`, `node_error` and ' +
+    '`reasons_error` ARE ALL NULL BECAUSE NONE OF THEM WAS READ — a system ' +
+    'with no pair has no node identity, no failover and nothing standing in the ' +
+    'way of one. This tool only reports. IT DOES NOT INITIATE A FAILOVER, ' +
+    'switch which node is active, or change anything about the pair.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // The one read that may fail the tool. Every other field describes a pair
+    // this system may not be part of, so without the state there is no answer
+    // for them to qualify — an error naming what the system said is more use
+    // than a result of nulls that reads as a system with nothing to report.
+    const status = textOrNull(await firstValueFrom(system.client.api.call('failover.status')));
+
+    // A system with no pair has no node and no failover, so those reads are not
+    // made at all rather than made and discarded. That is what keeps the
+    // ordinary case out of the degraded one structurally: there is no list of
+    // reasons to be misread as faults, because none was asked for. A system
+    // that reported no state at all takes the same exit for the same reason —
+    // nothing has placed it in a pair, and reading a pair's fields off it would
+    // report about a pair that has not been shown to exist.
+    if (status === null || status === SINGLE) {
+      return {
+        status,
+        ha_configured: status === null ? null : false,
+        node: null,
+        failover_possible: null,
+        failover_disabled_reasons: null,
+        node_error: null,
+        reasons_error: null,
+      };
+    }
+
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other.
+    const [node, reasons] = await Promise.all([readNode(system), readDisabledReasons(system)]);
+    return {
+      status,
+      ha_configured: true,
+      node: node.value,
+      // Read from the count rather than the list, for the reason
+      // `ReasonsAttempt.count` gives.
+      failover_possible: reasons.count === null ? null : reasons.count === 0,
+      failover_disabled_reasons: reasons.value,
+      node_error: node.error,
+      reasons_error: reasons.error,
+    };
+  },
+};

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -165,8 +165,9 @@ export const haStatus: ReadOnlyTool = {
     'is the marker to read first: FALSE MEANS THIS IS A SINGLE-NODE SYSTEM, ' +
     'which is the ordinary case and IS NOT A FAULT OR A DEGRADED PAIR — it has ' +
     'no second node to fail over to and was never meant to have one. It is ' +
-    'true where the system reports any HA state at all, and null where the ' +
-    'system reported no state, which settles nothing either way. `status` is ' +
+    'true where the system reports any state other than `SINGLE`, and null ' +
+    'where the system reported no state at all, which settles nothing either ' +
+    'way. `status` is ' +
     "the system's own HA state verbatim — `SINGLE` on a system that is not " +
     'part of a pair, and `MASTER` (this node is the active one), `BACKUP` ' +
     '(this node is the standby), `ELECTING` or `IMPORTING` (a failover is in ' +

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import { iscsiList, nvmeofList } from '@/tools/block';
 import { certificatesList } from '@/tools/certificates';
 import { cloudCredentialsList } from '@/tools/credentials';
 import { disksList } from '@/tools/disks';
+import { haStatus } from '@/tools/fleet';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
@@ -22,7 +23,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-two read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-three read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -57,6 +58,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(reportingDiskIo);
   catalog.register(reportingSpaceTrends);
   catalog.register(reportingAppVmUsage);
+  catalog.register(haStatus);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -72,6 +74,7 @@ export {
   createSnapshot,
   directoryServicesStatus,
   disksList,
+  haStatus,
   iscsiList,
   listDatasets,
   networkConfig,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -9739,13 +9739,13 @@ describe('ha_status', () => {
     });
   });
 
-  it('returns only the fields it names, and no field a later release adds', async () => {
-    const result = await reported({
-      ['failover.status']: 'MASTER',
-      ['failover.node']: 'A',
-      ['failover.disabled.reasons']: [],
-    });
-    expect(Object.keys(result)).toEqual([
+  it('returns only the fields it names', async () => {
+    // Not phrased as the "no field a later release adds" check the tools
+    // reading object payloads carry: none of the three reads here answers with
+    // an object, so there is nothing a middleware field could arrive on. What
+    // holds the guarantee is the flat literal the handler builds, and this is
+    // the assertion on it.
+    expect(Object.keys(await reported())).toEqual([
       'status',
       'ha_configured',
       'node',

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -14,6 +14,7 @@ import {
   createSnapshot,
   directoryServicesStatus,
   disksList,
+  haStatus,
   iscsiList,
   listDatasets,
   networkConfig,
@@ -80,7 +81,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-three sketch tools', () => {
+  it('registers the thirty-four sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -114,8 +115,13 @@ describe('createDefaultCatalog', () => {
       'reporting_disk_io',
       'reporting_space_trends',
       'reporting_app_vm_usage',
+      'ha_status',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises ha_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('ha_status');
   });
 
   it('advertises reporting_utilisation to a read-only credential', () => {
@@ -9568,5 +9574,208 @@ describe('reporting_app_vm_usage', () => {
       entries: [],
       failures: [],
     });
+  });
+});
+
+describe('ha_status', () => {
+  /** An HA pair with nothing in the way of a failover. */
+  const pair = (over: Partial<Record<string, unknown>> = {}) => ({
+    ['failover.status']: 'MASTER',
+    ['failover.node']: 'A',
+    ['failover.disabled.reasons']: [],
+    ...over,
+  });
+
+  const reported = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = failingSystem(pair(rows), failures);
+    return (await haStatus.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('reports the state, the node and that a failover would work', async () => {
+    expect(await reported()).toEqual({
+      status: 'MASTER',
+      ha_configured: true,
+      node: 'A',
+      failover_possible: true,
+      failover_disabled_reasons: [],
+      node_error: null,
+      reasons_error: null,
+    });
+  });
+
+  it('reports the standby node as part of a working pair', async () => {
+    expect(await reported({ ['failover.status']: 'BACKUP', ['failover.node']: 'B' })).toMatchObject({
+      status: 'BACKUP',
+      ha_configured: true,
+      node: 'B',
+      failover_possible: true,
+    });
+  });
+
+  it('reports every reason the system gives for a failover not being possible', async () => {
+    expect(
+      await reported({
+        ['failover.disabled.reasons']: ['NO_VIP', 'MISMATCH_DISKS', 'NO_PONG'],
+      }),
+    ).toMatchObject({
+      failover_possible: false,
+      failover_disabled_reasons: ['NO_VIP', 'MISMATCH_DISKS', 'NO_PONG'],
+      reasons_error: null,
+    });
+  });
+
+  it('passes through a state a later release adds, as an HA pair', async () => {
+    // Only the exact word `SINGLE` is read as "not a pair". Anything else is
+    // treated as one and the reasons are read, so a state this library has
+    // never seen produces a checkable answer rather than a silent
+    // "not applicable".
+    expect(
+      await reported({ ['failover.status']: 'RESILVERING', ['failover.disabled.reasons']: ['X'] }),
+    ).toMatchObject({
+      status: 'RESILVERING',
+      ha_configured: true,
+      failover_possible: false,
+      failover_disabled_reasons: ['X'],
+    });
+  });
+
+  it('reports a single-node system as not an HA pair, and never as degraded', async () => {
+    expect(await reported({ ['failover.status']: 'SINGLE' })).toEqual({
+      status: 'SINGLE',
+      ha_configured: false,
+      node: null,
+      failover_possible: null,
+      failover_disabled_reasons: null,
+      node_error: null,
+      reasons_error: null,
+    });
+  });
+
+  it('never asks a single-node system about a pair it is not part of', async () => {
+    // The structural half of the criterion above: the reasons a single-node
+    // system would give for being unable to fail over are never read, so there
+    // is nothing that could be presented as a fault.
+    const { ctx, call } = fakeSystem({ ['failover.status']: 'SINGLE' });
+    await haStatus.handler(ctx, {});
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith('failover.status');
+  });
+
+  it('reports a system that answered with no state as settling nothing', async () => {
+    // Not false: nothing has placed this system outside a pair either, so the
+    // fields that describe one are left unread rather than answered about a
+    // pair that has not been shown to exist.
+    for (const empty of ['', undefined]) {
+      expect(await reported({ ['failover.status']: empty })).toEqual({
+        status: null,
+        ha_configured: null,
+        node: null,
+        failover_possible: null,
+        failover_disabled_reasons: null,
+        node_error: null,
+        reasons_error: null,
+      });
+    }
+  });
+
+  it('fails the tool when the state itself cannot be read', async () => {
+    // The one read with no partial answer behind it: every other field
+    // describes a pair this system has not been shown to be part of.
+    await expect(reported({}, { ['failover.status']: new Error('websocket closed') })).rejects.toThrow(
+      'websocket closed',
+    );
+  });
+
+  it('names a failed node read and still answers about the failover', async () => {
+    expect(await reported({}, { ['failover.node']: new Error('node unreachable') })).toEqual({
+      status: 'MASTER',
+      ha_configured: true,
+      node: null,
+      failover_possible: true,
+      failover_disabled_reasons: [],
+      node_error: 'node unreachable',
+      reasons_error: null,
+    });
+  });
+
+  it('reports a pair that answered the node read with no node', async () => {
+    expect(await reported({ ['failover.node']: 42 })).toMatchObject({
+      node: null,
+      node_error: null,
+    });
+  });
+
+  it('does not read an unreadable reasons check as a working failover', async () => {
+    expect(
+      await reported({}, { ['failover.disabled.reasons']: new Error('peer did not answer') }),
+    ).toMatchObject({
+      failover_possible: null,
+      failover_disabled_reasons: null,
+      reasons_error: 'peer did not answer',
+    });
+  });
+
+  it('does not read a non-list answer as nothing standing in the way', async () => {
+    expect(await reported({ ['failover.disabled.reasons']: { reasons: [] } })).toMatchObject({
+      failover_possible: null,
+      failover_disabled_reasons: null,
+      reasons_error: 'the system did not answer with a list of reasons',
+    });
+  });
+
+  it('keeps a failover impossible when a reason it named could not be read', async () => {
+    // The count is what answers `failover_possible`, not the list: dropping an
+    // unreadable entry and then reading the shorter list as empty would turn
+    // "something is wrong here" into "everything is fine".
+    expect(
+      await reported({ ['failover.disabled.reasons']: ['NO_VIP', '', 'NO_PONG'] }),
+    ).toMatchObject({
+      failover_possible: false,
+      failover_disabled_reasons: ['NO_VIP', 'NO_PONG'],
+      reasons_error: 'the system named 3 reasons and 1 could not be read',
+    });
+  });
+
+  it('returns only the fields it names, and no field a later release adds', async () => {
+    const result = await reported({
+      ['failover.status']: 'MASTER',
+      ['failover.node']: 'A',
+      ['failover.disabled.reasons']: [],
+    });
+    expect(Object.keys(result)).toEqual([
+      'status',
+      'ha_configured',
+      'node',
+      'failover_possible',
+      'failover_disabled_reasons',
+      'node_error',
+      'reasons_error',
+    ]);
+  });
+
+  it('names a failure in whatever shape the transport rejected with', async () => {
+    // The client rejects with whatever it was given, so each shape it documents
+    // is read, and one it does not still has to read as a failure rather than
+    // as "[object Object]".
+    const named = async (failure: unknown): Promise<unknown> =>
+      (await reported({}, { ['failover.node']: failure }))['node_error'];
+    expect(await named(new Error(''))).toBe('the system reported no reason');
+    expect(await named({ reason: 'middleware refused' })).toBe('middleware refused');
+    expect(await named({ message: 'json-rpc refused' })).toBe('json-rpc refused');
+    expect(await named({})).toBe('the system reported no reason');
+    expect(await named('the transport gave a bare string')).toBe(
+      'the transport gave a bare string',
+    );
+    expect(await named(42)).toBe('the system reported no reason');
+    expect(await named(null)).toBe('the system reported no reason');
+  });
+
+  it('is read-only and takes no arguments', () => {
+    expect(haStatus.mutating).toBe(false);
+    expect(haStatus.requiredRole).toBe(Role.ReadOnly);
+    expect(haStatus.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 });


### PR DESCRIPTION
Adds the fleet family (`src/tools/fleet.ts`) with its first tool, `ha_status`:
HA state, which node answered, and whether a failover would work right now.

Fixes #45

## The two distinctions it keeps

**A single-node system is not a degraded pair.** Most systems are not HA pairs
at all. `failover.disabled.reasons` on one of those answers with reasons it
cannot fail over, and reporting those would present the ordinary case as a
fault. So a system whose `failover.status` is `SINGLE` short-circuits: the node
and reasons reads are **never made**, and `ha_configured: false` is the
not-applicable marker. That is structural rather than a filter — there is no
list of reasons to be misread, because none was asked for. A test asserts the
call count, not just the shape.

Only the exact word `SINGLE` short-circuits. A state this library has never seen
— one a later TrueNAS release adds — is treated as an HA pair and the reasons
are read, so it produces a checkable answer rather than a quiet
"not applicable".

**"Nothing was established" is never "failover works."** `failover_possible` is
null on a single-node system and null where the check could not be read; it is
only ever true when the system was asked and named nothing standing in the way.

## Reading the count, not the list

`failover_possible` comes from **how many reasons the system named**, not from
how many of them this tool could parse. An entry that is not a readable string
still means something is in the way, so dropping it and reading the shorter list
as empty would turn "something is wrong here" into "everything is fine". The
readable reasons are still returned, and `reasons_error` says how many were not.

## Failure handling

`failover.status` is the one read that may fail the tool — every other field
describes a pair this system has not been shown to be part of, so without the
state there is nothing for them to qualify. `failover.node` and
`failover.disabled.reasons` fail independently and are reported as
`node_error` / `reasons_error` with the field left null, following
`directory_services_status`.

## Acceptance criteria

- [x] Reports HA status, which node this is, and whether failover is possible
- [x] Every reason the system gives is reported where failover is not possible
- [x] A single-node system returns an explicit not-applicable marker
      (`ha_configured: false`) and is never reported as degraded
- [x] `createDefaultCatalog().list(Role.ReadOnly)` includes `ha_status`
- [x] Only the fields the tool names are returned — the handler builds a flat
      object literal, and none of the three reads answers with an object a
      middleware field could arrive on
- [x] The exact-list `toEqual` assertion in `describe('createDefaultCatalog')`
      is updated
- [x] The README's "Read-only family" line names `ha_status`
- [x] `yarn test:coverage` passes — `fleet.ts` is at 100% statements, branches,
      functions and lines

`yarn lint`, `yarn typecheck`, `yarn test` and `yarn test:coverage` all run
clean locally. Every gating job in `.github/workflows/` was runnable here.

## Review

`local-review.py` ran the project's own reviewer in a separate process (the
same rubric, threshold and parser as the required check) and **found nothing at
or above MEDIUM**. Three LOWs; two of them were prose that contradicted the
diff and are fixed in the second commit:

- the description claimed `ha_configured` is true "where the system reports any
  HA state at all", which `SINGLE` — a state the system reports — makes false;
- the keys assertion was named for the "no field a later release adds" check
  the tools reading object payloads carry, and that scenario is not exercisable
  here for the reason recorded beside it now.

### Not changed, and why

The shortfall message is not pluralised: one unreadable entry renders as
`the system named 1 reasons and 1 could not be read`. It is a LOW in a
diagnostic string that appears only when the middleware sends a
`failover.disabled.reasons` entry that is not a string — a case the client's
own types say cannot happen — and fixing it means a new branch, a new test and
another review round. Worth taking on a later pass or alongside the next change
to this file.
