### PR TITLE
feat(tools): add system_health_report, one call for a system's health

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,33 @@ connected to, which `client.connection.hostname$` reports; the configured
 `hostnames` list does not say which of them won a failover, and a download
 fetched from a host that did not mint the token fails.
 
+### A composite tool calls handlers, not the API (#44)
+
+`system_health_report` is the first tool that answers from other tools rather
+than from the middleware: it calls `poolStatus.handler`, `alertsList.handler`,
+`poolTopology.handler` and `updateStatus.handler` and adds no endpoint of its
+own. That is what keeps it from being a second, drifting opinion about what a
+pool's health *is* — there is one normalization per subject and composites read
+through it.
+
+Three things follow, and they are the shape any later composite should take:
+
+- **Every read is caught and its section says why it is empty.** A report that
+  throws because one subsystem is unreachable is useless exactly when it is
+  needed, so each section carries `unavailable`, and null in a section that
+  could not be read means "not read" rather than "nothing to report".
+- **Counts and findings are computed over everything; only the detail lists are
+  capped.** A cap can drop the line describing a finding; it must never drop the
+  finding. That is what makes a fixed-size response safe to act on.
+- **A verdict has a fourth value.** `OK` is the narrow claim that every section
+  was read and none raised anything; anything not established is `UNKNOWN`, not
+  `OK`. This is the null/empty/unreadable convention below, applied one level up
+  to a summary.
+
+A composed handler is typed `Promise<unknown>`, so a composite re-reads every
+field through its own guard and names it explicitly — which is also what keeps a
+field one of those tools grows later out of the composite's result.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
   `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
-  `reporting_app_vm_usage`, `ha_status`.
+  `reporting_app_vm_usage`, `ha_status`, `system_health_report`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,5 +110,6 @@ export {
   reportingSpaceTrends,
   reportingAppVmUsage,
   haStatus,
+  systemHealthReport,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,7 @@ import {
   reportingDiskIo,
   reportingSpaceTrends,
   reportingUtilisation,
+  systemHealthReport,
 } from '@/tools/reporting';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
@@ -23,7 +24,7 @@ import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-three read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-four read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -59,6 +60,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(reportingSpaceTrends);
   catalog.register(reportingAppVmUsage);
   catalog.register(haStatus);
+  catalog.register(systemHealthReport);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -93,6 +95,7 @@ export {
   sharesList,
   snapshotsList,
   snapshotTasksList,
+  systemHealthReport,
   systemInfo,
   tasksRecentRuns,
   updateStatus,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1,6 +1,13 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+// `system_health_report` is composite: it calls these four handlers rather than
+// the API, so that what it reports is by construction what those tools report.
+// None of the four imports this file, so there is no cycle.
+import { alertsList } from '@/tools/alerts';
+import { poolTopology } from '@/tools/pools';
+import { poolStatus } from '@/tools/storage';
+import { updateStatus } from '@/tools/system';
 
 /**
  * Reporting family: how busy a system was over a time range, rather than how
@@ -2091,6 +2098,679 @@ export const reportingAppVmUsage: ReadOnlyTool = {
       failures: [apps.failure, vms.failure, instances.failure].filter(
         (failure): failure is UsageFailure => failure !== null,
       ),
+    };
+  },
+};
+
+/**
+ * `system_health_report`: the requirements' own first question, answered in one
+ * call — "review all my TrueNAS systems' health and let me know of any
+ * potential issues or capacity concerns".
+ *
+ * It is COMPOSITE: it calls four existing tool handlers and adds no endpoint of
+ * its own. `storage_pool_status` gives pool health and capacity,
+ * `storage_pool_topology` the state of each device beneath those pools,
+ * `alerts_list` what the system is complaining about, and
+ * `system_update_status` whether it is behind. Answering the question from
+ * those four separately costs four round trips and an LLM deciding which four;
+ * this makes the headline feature reliable rather than emergent.
+ *
+ * Three properties are what the design is actually for, and each is a rule the
+ * code below follows rather than an implementation detail.
+ *
+ * **A section that failed is present and says so.** A health report that throws
+ * because one subsystem is unreachable is useless precisely when it is needed,
+ * so every read is caught and its section carries `unavailable` naming the
+ * reason. Nothing here rejects.
+ *
+ * **Counts and reasons are computed over everything; only the detail lists are
+ * capped.** {@link MAX_LISTED} bounds how many pools, alerts and devices are
+ * named individually, so the response has a size ceiling regardless of the
+ * system. It can therefore drop the line describing a finding — it can never
+ * drop the finding, which is in `reasons` and in the counts either way.
+ *
+ * **`OK` means every section was read and none of them raised anything.** A
+ * section that could not be read, an alert at a severity this report does not
+ * rank, a pool that reported no capacity: each is a reason of its own at
+ * `unknown`, which makes the verdict `UNKNOWN` rather than letting an absence
+ * of evidence read as evidence of health. That is the same distinction
+ * `system_update_status` and `ha_status` each keep, applied to the verdict.
+ *
+ * **The fields are re-normalized here rather than passed through.** A composed
+ * handler is typed `Promise<unknown>`, so every field is read back through a
+ * guard and named explicitly — which is also what keeps a field one of those
+ * four tools grows later out of this result without a change to this file.
+ */
+
+/**
+ * How many pools, alerts and devices the report names individually.
+ *
+ * The cap is on the DETAIL LISTS ONLY — see the note above. Ten is chosen
+ * against the systems this is asked about rather than as a round number: a
+ * TrueNAS system has a handful of pools, and ten of the worst alerts and ten
+ * failed devices are already more than a reader acts on in one sitting. Each
+ * list carries a `truncated` flag saying whether it left anything out.
+ */
+const MAX_LISTED = 10;
+
+/**
+ * The fill levels this report treats as capacity pressure.
+ *
+ * Both are read off ZFS's own behaviour rather than chosen here: allocation
+ * performance falls away as a pool approaches full, and TrueNAS raises its own
+ * `ZpoolCapacityWarning` at 80%. 90% is where the remaining headroom stops
+ * being enough to resolve the problem comfortably — a pool that full cannot
+ * always be relieved by deleting snapshots, because freeing space in ZFS
+ * briefly needs some.
+ */
+const CAPACITY_WARNING_PERCENT = 80;
+const CAPACITY_CRITICAL_PERCENT = 90;
+
+/**
+ * The alert severities TrueNAS raises, LEAST SEVERE FIRST. The same vocabulary
+ * and the same ordering `alert_settings` states for its `minimum_level`, which
+ * is the field that decides whether an alert is sent anywhere; this file reads
+ * the level off the alert itself.
+ *
+ * The list is the ordering AND the banding: position is the rank, and the two
+ * constants below name where each band starts, so there is one place a level
+ * can be added and no map that can disagree with the order.
+ */
+const ALERT_LEVELS = [
+  'INFO',
+  'NOTICE',
+  'WARNING',
+  'ERROR',
+  'CRITICAL',
+  'ALERT',
+  'EMERGENCY',
+] as const;
+
+/** Where the critical band starts. `ERROR` and above is something already broken. */
+const CRITICAL_FROM = ALERT_LEVELS.indexOf('ERROR');
+
+/** Where the warning band starts. Below it — `NOTICE`, `INFO` — is informational. */
+const WARNING_FROM = ALERT_LEVELS.indexOf('WARNING');
+
+/** The one ZFS device state that is healthy on any vdev. */
+const DEVICE_ONLINE = 'ONLINE';
+
+/**
+ * The two states that are healthy on a SPARE and nowhere else: `AVAIL` is an
+ * idle spare standing by, `INUSE` one that has been swapped in for a failed
+ * disk. Neither is a fault in the spare — and `INUSE` loses nothing, because
+ * the disk it stood in for is itself a leaf of the same tree and is counted
+ * there in whatever failed state it is in.
+ */
+const SPARE_STATES = ['AVAIL', 'INUSE'];
+
+/**
+ * The ZFS device states that make a pool unhealthy, as
+ * `storage_pool_topology`'s own description names them.
+ *
+ * Listed rather than derived from "not ONLINE", so that a state a later TrueNAS
+ * release adds is counted as UNRANKED rather than silently as a failure or
+ * silently as health. Unranked is its own count and its own reason: this report
+ * says it does not know what that state means, which is the answer that can be
+ * checked.
+ */
+const DEVICE_FAILED = ['FAULTED', 'DEGRADED', 'OFFLINE', 'UNAVAIL', 'REMOVED'];
+
+/** How severe a finding is. `unknown` is "not established", never "fine". */
+type Severity = 'critical' | 'warning' | 'unknown';
+
+/** The four sections of the report, each backed by exactly one composed tool. */
+type SectionName = 'pools' | 'alerts' | 'disks' | 'updates';
+
+/** One thing the report found, and which section found it. */
+interface Reason {
+  section: SectionName;
+  severity: Severity;
+  detail: string;
+}
+
+/** The verdict, worst first. `OK` is last because it is the narrowest claim. */
+type Verdict = 'CRITICAL' | 'WARNING' | 'UNKNOWN' | 'OK';
+
+/** A boolean the system reported, or null where it reported anything else. */
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+/** `1 alert` / `2 alerts`, so that a reason reads as English at either count. */
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/** A section that was read, or the reason it could not be. */
+interface SectionRead<T> {
+  value: T | null;
+  unavailable: string | null;
+}
+
+/**
+ * One composed tool's result, normalized, with a failure named rather than
+ * thrown. This is the whole of why the report cannot fail because one
+ * subsystem did.
+ *
+ * The read is passed as a thunk so that the call is made inside the `try`, which
+ * keeps this correct for a handler that throws before it returns a promise at
+ * all — the same reason `alerts.ts` passes its own supplementary read that way.
+ *
+ * `shape` runs inside the same `try`, deliberately. The composed handlers are
+ * typed `Promise<unknown>`, so each reader below takes the container it is given
+ * on the evidence of the tool it reads — an array of rows, or a record — and
+ * reads every FIELD within it through a guard. A handler that one day answers
+ * some other container makes its reader throw, and it lands in this same catch
+ * and is stated as the same kind of gap. One mechanism rather than two, and no
+ * branch here that no test can reach.
+ */
+async function section<T>(
+  read: () => Promise<unknown>,
+  shape: (answer: unknown) => T,
+): Promise<SectionRead<T>> {
+  try {
+    return { value: shape(await read()), unavailable: null };
+  } catch (reason) {
+    return { value: null, unavailable: errorText(reason) };
+  }
+}
+
+/** One pool, as this report states it. */
+interface PoolEntry {
+  name: string | null;
+  status: string | null;
+  healthy: boolean | null;
+  size_bytes: number | null;
+  allocated_bytes: number | null;
+  used_percent: number | null;
+}
+
+/**
+ * The pools `storage_pool_status` reported, with the one figure this report
+ * derives: how full each pool is, as a percentage of its own size.
+ *
+ * Null where it cannot be stated rather than zero — an unreadable size, an
+ * unreadable allocation, or a size of zero, none of which is a pool with room to
+ * spare. A pool whose capacity cannot be stated gets a reason of its own below.
+ */
+function poolEntries(answer: unknown): PoolEntry[] {
+  return (answer as Record<string, unknown>[]).map((row) => {
+    const size = numberOrNull(row['size_bytes']);
+    const allocated = numberOrNull(row['allocated_bytes']);
+    return {
+      name: textOrNull(row['name']),
+      status: textOrNull(row['status']),
+      healthy: booleanOrNull(row['healthy']),
+      size_bytes: size,
+      allocated_bytes: allocated,
+      used_percent:
+        size !== null && allocated !== null && size > 0
+          ? round1((allocated / size) * 100)
+          : null,
+    };
+  });
+}
+
+/** How a pool with no name of its own is referred to in a reason. */
+const UNNAMED_POOL = 'a pool the system did not name';
+
+/** What the pools section finds, over every pool and not only the listed ones. */
+function poolReasons(entries: PoolEntry[]): Reason[] {
+  const reasons: Reason[] = [];
+  for (const pool of entries) {
+    const named = pool.name ?? UNNAMED_POOL;
+    if (pool.healthy === false) {
+      reasons.push({
+        section: 'pools',
+        severity: 'critical',
+        detail: `pool ${named} is not healthy; the system reports its status as ${
+          pool.status ?? 'nothing this report could read'
+        }`,
+      });
+    } else if (pool.healthy === null) {
+      reasons.push({
+        section: 'pools',
+        severity: 'unknown',
+        detail: `pool ${named} did not report whether it is healthy`,
+      });
+    }
+    if (pool.used_percent === null) {
+      reasons.push({
+        section: 'pools',
+        severity: 'unknown',
+        detail: `pool ${named} reported no size and allocation this report could read, so how full it is is not established`,
+      });
+    } else if (pool.used_percent >= CAPACITY_CRITICAL_PERCENT) {
+      reasons.push({
+        section: 'pools',
+        severity: 'critical',
+        detail: `pool ${named} is ${pool.used_percent}% full`,
+      });
+    } else if (pool.used_percent >= CAPACITY_WARNING_PERCENT) {
+      reasons.push({
+        section: 'pools',
+        severity: 'warning',
+        detail: `pool ${named} is ${pool.used_percent}% full`,
+      });
+    }
+  }
+  return reasons;
+}
+
+/** One active alert, as this report states it. */
+interface AlertEntry {
+  level: string | null;
+  klass: string | null;
+  formatted: string | null;
+  dismissed: boolean | null;
+}
+
+/** The alerts `alerts_list` reported, read back through this report's own guards. */
+function alertEntries(answer: unknown): AlertEntry[] {
+  return (answer as Record<string, unknown>[]).map((row) => ({
+    level: textOrNull(row['level']),
+    klass: textOrNull(row['klass']),
+    formatted: textOrNull(row['formatted']),
+    dismissed: booleanOrNull(row['dismissed']),
+  }));
+}
+
+/**
+ * Where a level sits in {@link ALERT_LEVELS}, or -1 for one this report does not
+ * rank — a level the system spelled some other way, a level a later release
+ * adds, or no level at all.
+ */
+function alertRank(level: string | null): number {
+  return level === null ? -1 : ALERT_LEVELS.indexOf(level as (typeof ALERT_LEVELS)[number]);
+}
+
+/**
+ * How severe alerts at a rank are, or null where they are informational and
+ * produce no finding at all.
+ *
+ * An UNRANKED level is `unknown` rather than ignored. Reading a severity this
+ * report does not recognise as harmless is the fail-open worth avoiding: the
+ * system raised something, and what it raised has not been established.
+ */
+function alertSeverity(rank: number): Severity | null {
+  if (rank < 0) return 'unknown';
+  if (rank >= CRITICAL_FROM) return 'critical';
+  if (rank >= WARNING_FROM) return 'warning';
+  return null;
+}
+
+/** How many alerts stand at each level, most severe first. */
+function alertCounts(entries: AlertEntry[]): { level: string | null; count: number }[] {
+  const counts = new Map<string | null, number>();
+  for (const alert of entries) counts.set(alert.level, (counts.get(alert.level) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([level, count]) => ({ level, count }))
+    .sort(
+      (a, b) =>
+        alertRank(b.level) - alertRank(a.level) ||
+        (a.level ?? '').localeCompare(b.level ?? ''),
+    );
+}
+
+/** How a level the system did not name is referred to in a reason. */
+const UNNAMED_LEVEL = 'a severity the system did not name';
+
+/**
+ * What the alerts section finds — one reason per level that has any alerts at
+ * it, computed from the complete counts rather than from the listed alerts, so
+ * the cap on `most_severe` cannot hide a level.
+ */
+function alertReasons(counts: { level: string | null; count: number }[]): Reason[] {
+  const reasons: Reason[] = [];
+  for (const { level, count } of counts) {
+    const severity = alertSeverity(alertRank(level));
+    if (severity === null) continue;
+    reasons.push({
+      section: 'alerts',
+      severity,
+      detail:
+        severity === 'unknown'
+          ? `the system has raised ${plural(count, 'alert')} at ${
+              level ?? UNNAMED_LEVEL
+            }, a severity this report does not rank`
+          : `the system has raised ${plural(count, `${level} alert`)}`,
+    });
+  }
+  return reasons;
+}
+
+/** One device beneath a pool, as this report states it. */
+interface DeviceEntry {
+  pool: string | null;
+  name: string | null;
+  disk: string | null;
+  status: string | null;
+}
+
+/** What the walk over every pool's vdev tree accumulates. */
+interface DeviceTally {
+  total: number;
+  healthy: number;
+  unhealthy: number;
+  unranked: number;
+  /** Every device that is not healthy, in the order the tree was walked. */
+  notable: DeviceEntry[];
+}
+
+/**
+ * Whether a device's state is healthy, a failure, or one this report does not
+ * rank. `category` is the vdev role the device sits under, which is what makes
+ * a spare's own two states readable — see {@link SPARE_STATES}.
+ */
+function deviceState(
+  status: string | null,
+  category: string | null,
+): 'healthy' | 'unhealthy' | 'unranked' {
+  if (status === null) return 'unranked';
+  if (status === DEVICE_ONLINE) return 'healthy';
+  if (category === 'spare' && SPARE_STATES.includes(status)) return 'healthy';
+  if (DEVICE_FAILED.includes(status)) return 'unhealthy';
+  return 'unranked';
+}
+
+/** Add one device to the tally, and to `notable` where it is not healthy. */
+function countDevice(tally: DeviceTally, entry: DeviceEntry, category: string | null): void {
+  tally.total += 1;
+  const state = deviceState(entry.status, category);
+  if (state === 'healthy') {
+    tally.healthy += 1;
+    return;
+  }
+  if (state === 'unhealthy') tally.unhealthy += 1;
+  else tally.unranked += 1;
+  tally.notable.push(entry);
+}
+
+/**
+ * Walk one node of a vdev tree, counting its LEAVES.
+ *
+ * Only leaves are counted, and that is the whole reading: a grouping vdev
+ * carries a status of its own, but a DEGRADED mirror is degraded BECAUSE of a
+ * member, so counting both would report one failed disk as two problems. The
+ * member is where the answer is, and it is what `storage_pool_topology` exists
+ * to expose.
+ *
+ * A device being replaced nests under a `replacing` vdev, and a leaf whose disk
+ * the system can no longer resolve carries a null `disk` — both are ordinary
+ * here: the first is two leaves, and the second is a leaf located by its `name`
+ * in the tree rather than by a disk there is none of.
+ *
+ * A node carrying no readable `devices` is a leaf, which is the reading that
+ * makes this total: a node whose fields cannot be read at all still counts as
+ * one device, at `unranked`, rather than dropping out of the total silently.
+ */
+function walkDevices(
+  node: Record<string, unknown>,
+  category: string | null,
+  pool: string | null,
+  tally: DeviceTally,
+): void {
+  const children = node['devices'] as Record<string, unknown>[];
+  if (children.length > 0) {
+    for (const child of children) walkDevices(child, category, pool, tally);
+    return;
+  }
+  countDevice(
+    tally,
+    {
+      pool,
+      name: textOrNull(node['name']),
+      disk: textOrNull(node['disk']),
+      status: textOrNull(node['status']),
+    },
+    category,
+  );
+}
+
+/** Every device under every pool `storage_pool_topology` reported. */
+function deviceTally(answer: unknown): DeviceTally {
+  const tally: DeviceTally = { total: 0, healthy: 0, unhealthy: 0, unranked: 0, notable: [] };
+  for (const pool of answer as Record<string, unknown>[]) {
+    const name = textOrNull(pool['name']);
+    for (const vdev of pool['vdevs'] as Record<string, unknown>[]) {
+      walkDevices(vdev, textOrNull(vdev['category']), name, tally);
+    }
+  }
+  return tally;
+}
+
+/** What the disks section finds, from the complete counts rather than the list. */
+function deviceReasons(tally: DeviceTally): Reason[] {
+  const reasons: Reason[] = [];
+  if (tally.unhealthy > 0) {
+    reasons.push({
+      section: 'disks',
+      severity: 'critical',
+      detail: `ZFS reports ${plural(tally.unhealthy, 'device')} beneath the pools in a state it treats as a failure`,
+    });
+  }
+  if (tally.unranked > 0) {
+    reasons.push({
+      section: 'disks',
+      severity: 'unknown',
+      detail: `${plural(tally.unranked, 'device')} beneath the pools reported a state this report does not rank`,
+    });
+  }
+  return reasons;
+}
+
+/** Whether the system is behind, as this report states it. */
+interface UpdateReport {
+  update_available: boolean | null;
+  current_version: string | null;
+  new_version: string | null;
+  check_error: string | null;
+}
+
+/** What `system_update_status` reported, read back through this report's guards. */
+function updateReport(answer: unknown): UpdateReport {
+  const row = answer as Record<string, unknown>;
+  return {
+    update_available: booleanOrNull(row['update_available']),
+    current_version: textOrNull(row['current_version']),
+    new_version: textOrNull(row['new_version']),
+    check_error: textOrNull(row['check_error']),
+  };
+}
+
+/**
+ * What the updates section finds — which is NOTHING when the check worked,
+ * whichever answer it gave.
+ *
+ * An available update is reported in the section and is deliberately not a
+ * finding: being one release behind is not a fault, and a verdict that read
+ * `WARNING` on every well-run system with a pending update would stop carrying
+ * information within a week. A check that did NOT complete is the opposite and
+ * is `unknown` — that system may have been unchecked for months, which is the
+ * distinction `system_update_status` exists to keep and the one worth
+ * surfacing.
+ */
+function updateReasons(report: UpdateReport): Reason[] {
+  if (report.update_available !== null) return [];
+  return [
+    {
+      section: 'updates',
+      severity: 'unknown',
+      detail: `the update check did not complete, so whether this system is up to date is not established: ${
+        report.check_error ?? NO_REASON
+      }`,
+    },
+  ];
+}
+
+/**
+ * The verdict, from the reasons and from nothing else — which is what makes it
+ * follow from its own sections.
+ *
+ * `OK` is reachable only with no reason of any kind, and every section carries a
+ * reason when it could not be read, so `OK` states that everything was looked at
+ * and nothing was found. `UNKNOWN` outranks it and is outranked by both real
+ * findings: a problem that HAS been established is more actionable than one that
+ * has not, and the unknowns stay in `reasons` at every verdict so that a
+ * `CRITICAL` report still says which parts of it are incomplete.
+ */
+function verdictOf(reasons: Reason[]): Verdict {
+  if (reasons.some((reason) => reason.severity === 'critical')) return 'CRITICAL';
+  if (reasons.some((reason) => reason.severity === 'warning')) return 'WARNING';
+  if (reasons.some((reason) => reason.severity === 'unknown')) return 'UNKNOWN';
+  return 'OK';
+}
+
+/** The reason a section that could not be read contributes to the verdict. */
+function unavailableReason(name: SectionName, unavailable: string): Reason {
+  return {
+    section: name,
+    severity: 'unknown',
+    detail: `the ${name} section could not be read, so nothing about it is established: ${unavailable}`,
+  };
+}
+
+export const systemHealthReport: ReadOnlyTool = {
+  name: 'system_health_report',
+  description:
+    "One call that answers \"review this TrueNAS system's health and tell me " +
+    'about any issues or capacity concerns". It composes four read-only tools ' +
+    'and adds nothing of its own: `storage_pool_status` for pool health and ' +
+    'capacity, `storage_pool_topology` for the state of the devices beneath ' +
+    'those pools, `alerts_list` for what the system is complaining about, and ' +
+    '`system_update_status` for whether it is behind. Each of those tools ' +
+    'reports its subject in far more detail; this reports enough of each to ' +
+    'reach a verdict, and naming a finding here is the cue to call that tool ' +
+    'for the rest. `verdict` is the headline: `CRITICAL` where something is ' +
+    'already broken, `WARNING` where something needs attention before it ' +
+    'breaks, `UNKNOWN` where nothing bad was found AND SOMETHING COULD NOT BE ' +
+    'ESTABLISHED, and `OK` — which is the narrow claim that EVERY SECTION WAS ' +
+    'READ AND NONE OF THEM RAISED ANYTHING. `UNKNOWN` IS NEVER "HEALTHY": it ' +
+    'is a report with a hole in it, and `reasons` names the hole. `reasons` is ' +
+    'every finding that produced the verdict, and the verdict is derived from ' +
+    'it and from nothing else — `severity` is `critical`, `warning` or ' +
+    '`unknown`, `section` is which of `pools`, `alerts`, `disks` and `updates` ' +
+    'found it, and `detail` states it in words. FINDINGS AT `unknown` ARE ' +
+    'PRESENT AT EVERY VERDICT, so a `CRITICAL` report still says which parts ' +
+    'of itself are incomplete. `reasons` IS EMPTY ONLY WHEN `verdict` IS `OK`. ' +
+    'Each of the four sections carries `unavailable`: null where it was read, ' +
+    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
+    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
+    'report". THIS TOOL NEVER FAILS BECAUSE ONE SUBSYSTEM DID; a report that ' +
+    'throws when part of a system is unreachable is useless exactly when it is ' +
+    'needed. `pools.entries` is one entry per pool with the `name`, `status` ' +
+    'and `healthy` of `storage_pool_status`, its `size_bytes` and ' +
+    '`allocated_bytes`, and `used_percent` — how full it is, to one decimal ' +
+    'place, and null where that cannot be computed rather than zero. A pool at ' +
+    `or above ${CAPACITY_WARNING_PERCENT}% is a warning and one at or above ` +
+    `${CAPACITY_CRITICAL_PERCENT}% is critical. \`pools.reported\` is how many ` +
+    'pools the system reported. `alerts.total` is how many alerts are active ' +
+    'and `alerts.by_level` counts them per severity, most severe first, over ' +
+    'ALL of them; `alerts.most_severe` lists the worst of them individually ' +
+    'with the `level`, `klass`, `formatted` message and `dismissed` flag of ' +
+    '`alerts_list`. A DISMISSED ALERT IS STILL AN ACTIVE CONDITION and is ' +
+    'counted. `ERROR`, `CRITICAL`, `ALERT` and `EMERGENCY` are critical, ' +
+    '`WARNING` is a warning, `INFO` and `NOTICE` produce no finding, and a ' +
+    'level this tool does not recognise is reported at `unknown` RATHER THAN ' +
+    'IGNORED. `disks` counts the LEAF devices beneath every pool — a grouping ' +
+    'vdev is not counted, because a degraded mirror is degraded because of a ' +
+    'member and counting both would report one failed disk twice. `total`, ' +
+    '`healthy`, `unhealthy` and `unranked` are those counts, and `worst` names ' +
+    'the devices that are not healthy, each with the `pool` it is in, its ' +
+    '`name` in the vdev tree, the `disk` it sits on — null where the system can ' +
+    'no longer resolve one, which is what a pulled or dead device looks like — ' +
+    'and its `status`. `FAULTED`, `DEGRADED`, `OFFLINE`, `UNAVAIL` and ' +
+    '`REMOVED` are failures; `ONLINE` is healthy, as are `AVAIL` and `INUSE` ON ' +
+    'A SPARE, where they mean an idle spare and one swapped in for a failed ' +
+    'disk — THE DISK IT REPLACED IS COUNTED SEPARATELY IN WHATEVER STATE IT IS ' +
+    'IN. Any other state is `unranked`, which is this report saying it does not ' +
+    'know what that state means. THIS SECTION IS NOT SMART DATA: it is what ZFS ' +
+    'says about devices that are in a pool, so a disk attached to the system ' +
+    'and belonging to no pool does not appear here at all, and a disk failing ' +
+    'in a way ZFS has not yet noticed reads as `ONLINE`. `updates` carries ' +
+    '`update_available`, `current_version`, `new_version` and `check_error` ' +
+    'exactly as `system_update_status` reports them; AN AVAILABLE UPDATE IS ' +
+    'DELIBERATELY NOT A FINDING and does not move the verdict, because being a ' +
+    'release behind is not a fault, while a check that did not complete IS a ' +
+    'finding at `unknown` — that system may have gone unchecked for months. ' +
+    'EVERY COUNT AND EVERY REASON IS COMPUTED OVER EVERYTHING THE SECTION READ, ' +
+    `and only the three lists are capped, at ${MAX_LISTED} entries each with a ` +
+    '`truncated` flag saying whether anything was left out. So truncation can ' +
+    'drop the line describing a finding and can never drop the finding, which ' +
+    'is in `reasons` and in the counts either way. `pools` and `disks` come ' +
+    'from two SEPARATE reads of the pools, taken at slightly different ' +
+    'instants, so a pool imported or exported between them can appear in one ' +
+    'and not the other. This tool only reads. It does not scrub, replace a ' +
+    'disk, dismiss an alert, free space or install an update. NO field beyond ' +
+    'those named here is returned, whatever a later TrueNAS release adds to any ' +
+    'of the four underlying responses.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler(ctx) {
+    // All four reads are issued before any is awaited, so none waits on the
+    // others, and each is caught: no section may fail the report.
+    const [pools, alerts, disks, updates] = await Promise.all([
+      section(() => poolStatus.handler(ctx, {}), poolEntries),
+      section(() => alertsList.handler(ctx, {}), alertEntries),
+      section(() => poolTopology.handler(ctx, {}), deviceTally),
+      section(() => updateStatus.handler(ctx, {}), updateReport),
+    ]);
+
+    const counts = alerts.value === null ? null : alertCounts(alerts.value);
+    // Ordered here rather than in the section, because this ordering is what
+    // makes the cap below honest: the entries that survive it are the worst
+    // ones. `sort` is stable, so alerts at the same level keep the order the
+    // system listed them in.
+    const bySeverity =
+      alerts.value === null
+        ? null
+        : [...alerts.value].sort((a, b) => alertRank(b.level) - alertRank(a.level));
+
+    const reasons: Reason[] = [
+      ...(pools.unavailable === null ? [] : [unavailableReason('pools', pools.unavailable)]),
+      ...(pools.value === null ? [] : poolReasons(pools.value)),
+      ...(alerts.unavailable === null ? [] : [unavailableReason('alerts', alerts.unavailable)]),
+      ...(counts === null ? [] : alertReasons(counts)),
+      ...(disks.unavailable === null ? [] : [unavailableReason('disks', disks.unavailable)]),
+      ...(disks.value === null ? [] : deviceReasons(disks.value)),
+      ...(updates.unavailable === null ? [] : [unavailableReason('updates', updates.unavailable)]),
+      ...(updates.value === null ? [] : updateReasons(updates.value)),
+    ];
+
+    return {
+      verdict: verdictOf(reasons),
+      reasons,
+      pools: {
+        unavailable: pools.unavailable,
+        reported: pools.value === null ? null : pools.value.length,
+        entries: pools.value === null ? null : pools.value.slice(0, MAX_LISTED),
+        truncated: pools.value === null ? null : pools.value.length > MAX_LISTED,
+      },
+      alerts: {
+        unavailable: alerts.unavailable,
+        total: alerts.value === null ? null : alerts.value.length,
+        by_level: counts,
+        most_severe: bySeverity === null ? null : bySeverity.slice(0, MAX_LISTED),
+        truncated: bySeverity === null ? null : bySeverity.length > MAX_LISTED,
+      },
+      disks: {
+        unavailable: disks.unavailable,
+        total: disks.value?.total ?? null,
+        healthy: disks.value?.healthy ?? null,
+        unhealthy: disks.value?.unhealthy ?? null,
+        unranked: disks.value?.unranked ?? null,
+        worst: disks.value === null ? null : disks.value.notable.slice(0, MAX_LISTED),
+        truncated: disks.value === null ? null : disks.value.notable.length > MAX_LISTED,
+      },
+      updates: {
+        unavailable: updates.unavailable,
+        update_available: updates.value?.update_available ?? null,
+        current_version: updates.value?.current_version ?? null,
+        new_version: updates.value?.new_version ?? null,
+        check_error: updates.value?.check_error ?? null,
+      },
     };
   },
 };

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -2560,12 +2560,22 @@ function deviceReasons(tally: DeviceTally): Reason[] {
   return reasons;
 }
 
-/** Whether the system is behind, as this report states it. */
+/**
+ * Whether the system is behind, as this report states it.
+ *
+ * `system_update_status` has TWO failure channels and both are carried here.
+ * `check_error` is the update check that did not complete, and `version_error`
+ * the SEPARATE read of the version the system is running now — which is why a
+ * `current_version` of null needs one of them beside it to be readable at all.
+ * Dropping the second would leave a system whose version read failed reporting a
+ * null version, no reason, and a verdict that never noticed.
+ */
 interface UpdateReport {
   update_available: boolean | null;
   current_version: string | null;
   new_version: string | null;
   check_error: string | null;
+  version_error: string | null;
 }
 
 /** What `system_update_status` reported, read back through this report's guards. */
@@ -2576,6 +2586,7 @@ function updateReport(answer: unknown): UpdateReport {
     current_version: textOrNull(row['current_version']),
     new_version: textOrNull(row['new_version']),
     check_error: textOrNull(row['check_error']),
+    version_error: textOrNull(row['version_error']),
   };
 }
 
@@ -2590,18 +2601,32 @@ function updateReport(answer: unknown): UpdateReport {
  * is `unknown` — that system may have been unchecked for months, which is the
  * distinction `system_update_status` exists to keep and the one worth
  * surfacing.
+ *
+ * The version read is the section's OTHER failure channel, and it is reported
+ * the same way and independently: it is a SEPARATE read, so a system can answer
+ * the update check and still fail to say what it is running now. Without this,
+ * that second case is a null `current_version` with nothing beside it saying
+ * why — a hole in the report the verdict never sees.
  */
 function updateReasons(report: UpdateReport): Reason[] {
-  if (report.update_available !== null) return [];
-  return [
-    {
+  const reasons: Reason[] = [];
+  if (report.update_available === null) {
+    reasons.push({
       section: 'updates',
       severity: 'unknown',
       detail: `the update check did not complete, so whether this system is up to date is not established: ${
         report.check_error ?? NO_REASON
       }`,
-    },
-  ];
+    });
+  }
+  if (report.version_error !== null) {
+    reasons.push({
+      section: 'updates',
+      severity: 'unknown',
+      detail: `the running version could not be read, so what this system is on is not established: ${report.version_error}`,
+    });
+  }
+  return reasons;
 }
 
 /**
@@ -2689,11 +2714,17 @@ export const systemHealthReport: ReadOnlyTool = {
     'says about devices that are in a pool, so a disk attached to the system ' +
     'and belonging to no pool does not appear here at all, and a disk failing ' +
     'in a way ZFS has not yet noticed reads as `ONLINE`. `updates` carries ' +
-    '`update_available`, `current_version`, `new_version` and `check_error` ' +
-    'exactly as `system_update_status` reports them; AN AVAILABLE UPDATE IS ' +
-    'DELIBERATELY NOT A FINDING and does not move the verdict, because being a ' +
-    'release behind is not a fault, while a check that did not complete IS a ' +
-    'finding at `unknown` — that system may have gone unchecked for months. ' +
+    '`update_available`, `current_version`, `new_version`, `check_error` and ' +
+    '`version_error` exactly as `system_update_status` reports them. AN ' +
+    'AVAILABLE UPDATE IS DELIBERATELY NOT A FINDING and does not move the ' +
+    'verdict, because being a release behind is not a fault. THE SECTION HAS ' +
+    'TWO FAILURE CHANNELS AND EACH IS ITS OWN FINDING AT `unknown`: a check ' +
+    'that did not complete, named by `check_error`, which leaves ' +
+    '`update_available` null — that system may have gone unchecked for months ' +
+    '— and the SEPARATE read of the version it is running now, named by ' +
+    '`version_error`, which leaves `current_version` null. The two are ' +
+    'independent: a system can answer the update check and still fail to say ' +
+    'what it is running. ' +
     'EVERY COUNT AND EVERY REASON IS COMPUTED OVER EVERYTHING THE SECTION READ, ' +
     `and only the three lists are capped, at ${MAX_LISTED} entries each with a ` +
     '`truncated` flag saying whether anything was left out. So truncation can ' +
@@ -2770,6 +2801,7 @@ export const systemHealthReport: ReadOnlyTool = {
         current_version: updates.value?.current_version ?? null,
         new_version: updates.value?.new_version ?? null,
         check_error: updates.value?.check_error ?? null,
+        version_error: updates.value?.version_error ?? null,
       },
     };
   },

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -2501,9 +2501,17 @@ function countDevice(tally: DeviceTally, entry: DeviceEntry, category: string | 
  * here: the first is two leaves, and the second is a leaf located by its `name`
  * in the tree rather than by a disk there is none of.
  *
- * A node carrying no readable `devices` is a leaf, which is the reading that
- * makes this total: a node whose fields cannot be read at all still counts as
- * one device, at `unranked`, rather than dropping out of the total silently.
+ * A LEAF IS A NODE WHOSE `devices` IS EMPTY, not one whose `devices` could not
+ * be read. `storage_pool_topology` builds that array on every node it maps, so
+ * a node carrying anything else is that tool answering a shape this one does not
+ * read — and the cast below throws rather than quietly counting a grouping vdev
+ * as a disk. That throw lands in {@link section}'s catch and the whole disks
+ * section is stated as unreadable, which is the one mechanism this file uses for
+ * every way a composed read can fail.
+ *
+ * A leaf whose individual FIELDS cannot be read is different and is ordinary: it
+ * still counts as one device, at `unranked`, rather than dropping out of the
+ * total silently.
  */
 function walkDevices(
   node: Record<string, unknown>,

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -9897,6 +9897,7 @@ describe('system_health_report', () => {
       current_version: 'TrueNAS-25.04.0',
       new_version: null,
       check_error: null,
+      version_error: null,
     });
   });
 
@@ -10253,7 +10254,50 @@ describe('system_health_report', () => {
       current_version: 'TrueNAS-25.04.0',
       new_version: '25.04.1',
       check_error: null,
+      version_error: null,
     });
+  });
+
+  it('is UNKNOWN when the running version could not be read, though the check worked', async () => {
+    // `system_update_status` reads the version separately from the check, so
+    // this system answers one and not the other. Without a reason of its own
+    // the null `current_version` would sit in an OK report saying nothing.
+    const { ctx } = failingSystem(healthy(), {
+      ['system.version']: new Error('the system did not answer'),
+    });
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result['updates']).toEqual({
+      unavailable: null,
+      update_available: false,
+      current_version: null,
+      new_version: null,
+      check_error: null,
+      version_error: 'the system did not answer',
+    });
+    expect(result.reasons).toEqual([
+      {
+        section: 'updates',
+        severity: 'unknown',
+        detail:
+          'the running version could not be read, so what this system is on is not established: the system did not answer',
+      },
+    ]);
+  });
+
+  it('names both update failures when neither read answered', async () => {
+    const { ctx } = failingSystem(
+      {
+        ...healthy(),
+        ['update.status']: { code: 'ERROR', error: { reason: 'no route to host' }, status: null },
+      },
+      { ['system.version']: new Error('the system did not answer') },
+    );
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result.reasons.map((reason) => reason.detail)).toEqual([
+      'the update check did not complete, so whether this system is up to date is not established: no route to host',
+      'the running version could not be read, so what this system is on is not established: the system did not answer',
+    ]);
   });
 
   it('is UNKNOWN when the update check did not complete, naming what the system said', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -33,6 +33,7 @@ import {
   sharesList,
   snapshotsList,
   snapshotTasksList,
+  systemHealthReport,
   tasksRecentRuns,
   updateStatus,
   usersList,
@@ -81,7 +82,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-four sketch tools', () => {
+  it('registers the thirty-five sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -116,8 +117,15 @@ describe('createDefaultCatalog', () => {
       'reporting_space_trends',
       'reporting_app_vm_usage',
       'ha_status',
+      'system_health_report',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises system_health_report to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'system_health_report',
+    );
   });
 
   it('advertises ha_status to a read-only credential', () => {
@@ -9777,5 +9785,615 @@ describe('ha_status', () => {
     expect(haStatus.mutating).toBe(false);
     expect(haStatus.requiredRole).toBe(Role.ReadOnly);
     expect(haStatus.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+describe('system_health_report', () => {
+  /** One leaf of a vdev tree, as `pool.query` nests it under `topology`. */
+  function device(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return { name: 'sda1', type: 'DISK', status: 'ONLINE', disk: 'sda', children: [], ...over };
+  }
+
+  /**
+   * One pool as `pool.query` reports it. The same rows feed both
+   * `storage_pool_status` and `storage_pool_topology`, which is how the tool
+   * itself reads them: two calls of the same verb.
+   */
+  function pool(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      name: 'tank',
+      status: 'ONLINE',
+      healthy: true,
+      size: 1000,
+      allocated: 100,
+      free: 900,
+      topology: { data: [device()] },
+      ...over,
+    };
+  }
+
+  /** One alert as `alert.list` reports it. */
+  function alert(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: '1',
+      klass: 'ZpoolCapacityWarning',
+      level: 'WARNING',
+      formatted: 'tank is filling up',
+      datetime: { $date: 0 },
+      dismissed: false,
+      ...over,
+    };
+  }
+
+  /** An `update.status` payload for a system that is already up to date. */
+  function upToDate(): Record<string, unknown> {
+    return {
+      code: 'NORMAL',
+      error: null,
+      status: { new_version: null, current_version: { train: 'TN-25.04' } },
+    };
+  }
+
+  /** Every method the four composed tools read, answering a healthy system. */
+  function healthy(over: Partial<Record<string, unknown>> = {}): Partial<Record<string, unknown>> {
+    return {
+      ['pool.query']: [pool()],
+      ['alert.list']: [],
+      ['update.status']: upToDate(),
+      ['system.version']: 'TrueNAS-25.04.0',
+      ...over,
+    };
+  }
+
+  /** The report, typed loosely: the tool's own contract is an opaque object. */
+  type Report = Record<string, Record<string, unknown> & { unavailable: string | null }> & {
+    verdict: string;
+    reasons: { section: string; severity: string; detail: string }[];
+  };
+
+  async function report(responses: Partial<Record<string, unknown>>): Promise<Report> {
+    const { ctx } = fakeSystem(responses);
+    return (await systemHealthReport.handler(ctx, {})) as Report;
+  }
+
+  it('is OK only when every section was read and none of them raised anything', async () => {
+    const result = await report(healthy());
+    expect(result.verdict).toBe('OK');
+    expect(result.reasons).toEqual([]);
+    expect(result['pools']).toEqual({
+      unavailable: null,
+      reported: 1,
+      entries: [
+        {
+          name: 'tank',
+          status: 'ONLINE',
+          healthy: true,
+          size_bytes: 1000,
+          allocated_bytes: 100,
+          used_percent: 10,
+        },
+      ],
+      truncated: false,
+    });
+    expect(result['alerts']).toEqual({
+      unavailable: null,
+      total: 0,
+      by_level: [],
+      most_severe: [],
+      truncated: false,
+    });
+    expect(result['disks']).toEqual({
+      unavailable: null,
+      total: 1,
+      healthy: 1,
+      unhealthy: 0,
+      unranked: 0,
+      worst: [],
+      truncated: false,
+    });
+    expect(result['updates']).toEqual({
+      unavailable: null,
+      update_available: false,
+      current_version: 'TrueNAS-25.04.0',
+      new_version: null,
+      check_error: null,
+    });
+  });
+
+  it('states how full a pool is to one decimal place', async () => {
+    const result = await report(
+      healthy({ ['pool.query']: [pool({ size: 3000, allocated: 1000 })] }),
+    );
+    expect(result['pools']['entries']).toEqual([
+      expect.objectContaining({ used_percent: 33.3 }),
+    ]);
+  });
+
+  it('is CRITICAL for an unhealthy pool, naming the status the system gave', async () => {
+    const result = await report(
+      healthy({ ['pool.query']: [pool({ healthy: false, status: 'DEGRADED' })] }),
+    );
+    expect(result.verdict).toBe('CRITICAL');
+    expect(result.reasons).toContainEqual({
+      section: 'pools',
+      severity: 'critical',
+      detail: 'pool tank is not healthy; the system reports its status as DEGRADED',
+    });
+  });
+
+  it('names an unhealthy pool that reported no status, and one with no name', async () => {
+    const result = await report(
+      healthy({
+        ['pool.query']: [pool({ name: null, healthy: false, status: null, topology: null })],
+      }),
+    );
+    expect(result.reasons).toContainEqual({
+      section: 'pools',
+      severity: 'critical',
+      detail:
+        'pool a pool the system did not name is not healthy; the system reports its status as nothing this report could read',
+    });
+  });
+
+  it('warns at 80% full and is critical at 90%', async () => {
+    const warned = await report(
+      healthy({ ['pool.query']: [pool({ size: 100, allocated: 85 })] }),
+    );
+    expect(warned.verdict).toBe('WARNING');
+    expect(warned.reasons).toEqual([
+      { section: 'pools', severity: 'warning', detail: 'pool tank is 85% full' },
+    ]);
+
+    const critical = await report(
+      healthy({ ['pool.query']: [pool({ size: 100, allocated: 95 })] }),
+    );
+    expect(critical.verdict).toBe('CRITICAL');
+    expect(critical.reasons).toEqual([
+      { section: 'pools', severity: 'critical', detail: 'pool tank is 95% full' },
+    ]);
+  });
+
+  it('does not establish capacity for a pool whose size it could not read', async () => {
+    const result = await report(healthy({ ['pool.query']: [pool({ size: 'lots' })] }));
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result['pools']['entries']).toEqual([
+      expect.objectContaining({ size_bytes: null, used_percent: null }),
+    ]);
+    expect(result.reasons).toEqual([
+      {
+        section: 'pools',
+        severity: 'unknown',
+        detail:
+          'pool tank reported no size and allocation this report could read, so how full it is is not established',
+      },
+    ]);
+  });
+
+  it('does not establish capacity for a pool of no size, rather than reading it as empty', async () => {
+    const result = await report(healthy({ ['pool.query']: [pool({ size: 0, allocated: 0 })] }));
+    expect(result['pools']['entries']).toEqual([
+      expect.objectContaining({ size_bytes: 0, used_percent: null }),
+    ]);
+    expect(result.verdict).toBe('UNKNOWN');
+  });
+
+  it('does not establish health for a pool that did not say whether it is healthy', async () => {
+    const result = await report(healthy({ ['pool.query']: [pool({ healthy: 'yes' })] }));
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result.reasons).toContainEqual({
+      section: 'pools',
+      severity: 'unknown',
+      detail: 'pool tank did not report whether it is healthy',
+    });
+  });
+
+  it('counts alerts per level over all of them, most severe first', async () => {
+    const result = await report(
+      healthy({
+        ['alert.list']: [
+          alert({ level: 'INFO' }),
+          alert({ level: 'CRITICAL' }),
+          alert({ level: 'WARNING' }),
+          alert({ level: 'CRITICAL' }),
+        ],
+      }),
+    );
+    expect(result['alerts']['total']).toBe(4);
+    expect(result['alerts']['by_level']).toEqual([
+      { level: 'CRITICAL', count: 2 },
+      { level: 'WARNING', count: 1 },
+      { level: 'INFO', count: 1 },
+    ]);
+  });
+
+  it('ranks ERROR and above as critical, WARNING as a warning, and INFO and NOTICE as neither', async () => {
+    const result = await report(
+      healthy({
+        ['alert.list']: [
+          alert({ level: 'ERROR' }),
+          alert({ level: 'WARNING' }),
+          alert({ level: 'NOTICE' }),
+          alert({ level: 'INFO' }),
+        ],
+      }),
+    );
+    expect(result.verdict).toBe('CRITICAL');
+    expect(result.reasons).toEqual([
+      { section: 'alerts', severity: 'critical', detail: 'the system has raised 1 ERROR alert' },
+      { section: 'alerts', severity: 'warning', detail: 'the system has raised 1 WARNING alert' },
+    ]);
+  });
+
+  it('counts more than one alert at a level in English', async () => {
+    const result = await report(
+      healthy({ ['alert.list']: [alert({ level: 'EMERGENCY' }), alert({ level: 'EMERGENCY' })] }),
+    );
+    expect(result.reasons).toEqual([
+      {
+        section: 'alerts',
+        severity: 'critical',
+        detail: 'the system has raised 2 EMERGENCY alerts',
+      },
+    ]);
+  });
+
+  it('reports an alert level it does not rank at unknown rather than ignoring it', async () => {
+    const result = await report(healthy({ ['alert.list']: [alert({ level: 'SPICY' })] }));
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result.reasons).toEqual([
+      {
+        section: 'alerts',
+        severity: 'unknown',
+        detail: 'the system has raised 1 alert at SPICY, a severity this report does not rank',
+      },
+    ]);
+  });
+
+  it('reports an alert whose level the system did not name', async () => {
+    const result = await report(healthy({ ['alert.list']: [alert({ level: null })] }));
+    expect(result['alerts']['by_level']).toEqual([{ level: null, count: 1 }]);
+    expect(result.reasons).toEqual([
+      {
+        section: 'alerts',
+        severity: 'unknown',
+        detail:
+          'the system has raised 1 alert at a severity the system did not name, a severity this report does not rank',
+      },
+    ]);
+  });
+
+  it('orders equally severe levels by name, so two calls answer alike', async () => {
+    const result = await report(
+      healthy({
+        ['alert.list']: [
+          alert({ level: 'ZED' }),
+          alert({ level: null }),
+          alert({ level: 'ABLE' }),
+        ],
+      }),
+    );
+    expect(result['alerts']['by_level']).toEqual([
+      { level: null, count: 1 },
+      { level: 'ABLE', count: 1 },
+      { level: 'ZED', count: 1 },
+    ]);
+  });
+
+  it('lists the worst alerts first and caps the list while counting every one', async () => {
+    const alerts = [
+      ...Array.from({ length: 11 }, () => alert({ level: 'INFO', klass: 'Info' })),
+      alert({ level: 'EMERGENCY', klass: 'Fire' }),
+    ];
+    const result = await report(healthy({ ['alert.list']: alerts }));
+    expect(result['alerts']['total']).toBe(12);
+    expect(result['alerts']['truncated']).toBe(true);
+    const listed = result['alerts']['most_severe'] as { klass: string }[];
+    expect(listed).toHaveLength(10);
+    expect(listed[0]).toEqual({
+      level: 'EMERGENCY',
+      klass: 'Fire',
+      formatted: 'tank is filling up',
+      dismissed: false,
+    });
+    // The finding survives the cap even when its alert does not: the eleven
+    // INFO alerts are counted in full and the one EMERGENCY still reasons.
+    expect(result['alerts']['by_level']).toEqual([
+      { level: 'EMERGENCY', count: 1 },
+      { level: 'INFO', count: 11 },
+    ]);
+  });
+
+  it('counts leaf devices only, so one failed disk is not two problems', async () => {
+    const result = await report(
+      healthy({
+        ['pool.query']: [
+          pool({
+            healthy: false,
+            status: 'DEGRADED',
+            topology: {
+              data: [
+                {
+                  name: 'mirror-0',
+                  type: 'MIRROR',
+                  status: 'DEGRADED',
+                  disk: null,
+                  children: [device(), device({ name: 'sdb1', status: 'FAULTED', disk: 'sdb' })],
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(result['disks']).toEqual({
+      unavailable: null,
+      total: 2,
+      healthy: 1,
+      unhealthy: 1,
+      unranked: 0,
+      worst: [{ pool: 'tank', name: 'sdb1', disk: 'sdb', status: 'FAULTED' }],
+      truncated: false,
+    });
+    expect(result.reasons).toContainEqual({
+      section: 'disks',
+      severity: 'critical',
+      detail: 'ZFS reports 1 device beneath the pools in a state it treats as a failure',
+    });
+  });
+
+  it('treats AVAIL and INUSE as healthy on a spare and nowhere else', async () => {
+    const result = await report(
+      healthy({
+        ['pool.query']: [
+          pool({
+            topology: {
+              spare: [
+                device({ name: 'sdy', status: 'AVAIL', disk: 'sdy' }),
+                device({ name: 'sdz', status: 'INUSE', disk: 'sdz' }),
+              ],
+              data: [device({ name: 'sdc1', status: 'AVAIL', disk: 'sdc' })],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(result['disks']).toEqual(
+      expect.objectContaining({ total: 3, healthy: 2, unhealthy: 0, unranked: 1 }),
+    );
+    expect(result['disks']['worst']).toEqual([
+      { pool: 'tank', name: 'sdc1', disk: 'sdc', status: 'AVAIL' },
+    ]);
+  });
+
+  it('reports a device state it does not rank as unranked rather than as healthy', async () => {
+    const result = await report(
+      healthy({ ['pool.query']: [pool({ topology: { data: [device({ status: 'SPICY' })] } })] }),
+    );
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result.reasons).toContainEqual({
+      section: 'disks',
+      severity: 'unknown',
+      detail: '1 device beneath the pools reported a state this report does not rank',
+    });
+  });
+
+  it('reports a device the system reported no state for', async () => {
+    const result = await report(
+      healthy({ ['pool.query']: [pool({ topology: { data: [device({ status: null })] } })] }),
+    );
+    expect(result['disks']['worst']).toEqual([
+      { pool: 'tank', name: 'sda1', disk: 'sda', status: null },
+    ]);
+  });
+
+  it('reports a device it can no longer resolve to a disk, by its place in the tree', async () => {
+    const result = await report(
+      healthy({
+        ['pool.query']: [
+          pool({ topology: { data: [device({ status: 'REMOVED', disk: null })] } }),
+        ],
+      }),
+    );
+    expect(result['disks']['worst']).toEqual([
+      { pool: 'tank', name: 'sda1', disk: null, status: 'REMOVED' },
+    ]);
+  });
+
+  it('counts every failed device while capping the list that names them', async () => {
+    const result = await report(
+      healthy({
+        ['pool.query']: [
+          pool({
+            topology: {
+              data: Array.from({ length: 12 }, (_unused, index) =>
+                device({ name: `sd${index}`, status: 'FAULTED', disk: `sd${index}` }),
+              ),
+            },
+          }),
+        ],
+      }),
+    );
+    expect(result['disks']).toEqual(
+      expect.objectContaining({ total: 12, unhealthy: 12, truncated: true }),
+    );
+    expect(result['disks']['worst']).toHaveLength(10);
+    expect(result.reasons).toContainEqual({
+      section: 'disks',
+      severity: 'critical',
+      detail: 'ZFS reports 12 devices beneath the pools in a state it treats as a failure',
+    });
+  });
+
+  it('counts every pool while capping the list that names them', async () => {
+    const pools = Array.from({ length: 12 }, (_unused, index) => pool({ name: `tank${index}` }));
+    const result = await report(healthy({ ['pool.query']: pools }));
+    expect(result['pools']['reported']).toBe(12);
+    expect(result['pools']['entries']).toHaveLength(10);
+    expect(result['pools']['truncated']).toBe(true);
+  });
+
+  it('reports an available update without moving the verdict', async () => {
+    const result = await report(
+      healthy({
+        ['update.status']: {
+          code: 'NORMAL',
+          error: null,
+          status: {
+            new_version: { version: '25.04.1' },
+            current_version: { train: 'TN-25.04' },
+          },
+        },
+      }),
+    );
+    expect(result.verdict).toBe('OK');
+    expect(result.reasons).toEqual([]);
+    expect(result['updates']).toEqual({
+      unavailable: null,
+      update_available: true,
+      current_version: 'TrueNAS-25.04.0',
+      new_version: '25.04.1',
+      check_error: null,
+    });
+  });
+
+  it('is UNKNOWN when the update check did not complete, naming what the system said', async () => {
+    const result = await report(
+      healthy({
+        ['update.status']: {
+          code: 'ERROR',
+          error: { reason: 'the update server could not be reached', errname: 'ENETUNREACH' },
+          status: null,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result['updates']).toEqual(
+      expect.objectContaining({
+        update_available: null,
+        check_error: 'the update server could not be reached',
+      }),
+    );
+    expect(result.reasons).toEqual([
+      {
+        section: 'updates',
+        severity: 'unknown',
+        detail:
+          'the update check did not complete, so whether this system is up to date is not established: the update server could not be reached',
+      },
+    ]);
+  });
+
+  it('marks the sections a failed read took out, and still reports the rest', async () => {
+    const { ctx } = failingSystem(healthy(), {
+      ['pool.query']: new Error('the middleware is not listening'),
+    });
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result.verdict).toBe('UNKNOWN');
+    // One read, and both sections that stand on it say so independently.
+    expect(result['pools']).toEqual({
+      unavailable: 'the middleware is not listening',
+      reported: null,
+      entries: null,
+      truncated: null,
+    });
+    expect(result['disks']).toEqual({
+      unavailable: 'the middleware is not listening',
+      total: null,
+      healthy: null,
+      unhealthy: null,
+      unranked: null,
+      worst: null,
+      truncated: null,
+    });
+    expect(result.reasons).toEqual([
+      {
+        section: 'pools',
+        severity: 'unknown',
+        detail:
+          'the pools section could not be read, so nothing about it is established: the middleware is not listening',
+      },
+      {
+        section: 'disks',
+        severity: 'unknown',
+        detail:
+          'the disks section could not be read, so nothing about it is established: the middleware is not listening',
+      },
+    ]);
+    // The sections that did not depend on it are unaffected.
+    expect(result['alerts']['unavailable']).toBeNull();
+    expect(result['updates']['update_available']).toBe(false);
+  });
+
+  it('does not reject when every read failed, and says so section by section', async () => {
+    const { ctx } = failingSystem(
+      {},
+      {
+        ['pool.query']: new Error('pools are gone'),
+        ['alert.list']: 'alerts are gone',
+        ['update.status']: { reason: 'updates are gone' },
+      },
+    );
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result.verdict).toBe('UNKNOWN');
+    expect(result['pools']['unavailable']).toBe('pools are gone');
+    expect(result['alerts']['unavailable']).toBe('alerts are gone');
+    expect(result['disks']['unavailable']).toBe('pools are gone');
+    expect(result['updates']['unavailable']).toBe('updates are gone');
+    expect(result.reasons).toHaveLength(4);
+  });
+
+  it('keeps a CRITICAL verdict while still naming the parts it could not read', async () => {
+    const { ctx } = failingSystem(
+      { ...healthy(), ['pool.query']: [pool({ healthy: false, status: 'FAULTED' })] },
+      { ['alert.list']: new Error('alerts are gone') },
+    );
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result.verdict).toBe('CRITICAL');
+    expect(result.reasons.map((reason) => reason.severity)).toEqual(['critical', 'unknown']);
+  });
+
+  it('states a failure the transport gave no words for', async () => {
+    const { ctx } = failingSystem(healthy(), { ['alert.list']: 42 });
+    const result = (await systemHealthReport.handler(ctx, {})) as Report;
+    expect(result['alerts']['unavailable']).toBe('the system reported no reason');
+  });
+
+  it('stays small enough to be read in full on a system of ordinary size', async () => {
+    // Two pools of twelve disks each, one of them degraded with a failed
+    // member, and a dozen alerts — a system with plenty to say. The report is a
+    // fixed shape plus three capped lists, so this is close to its ceiling.
+    const bay = (prefix: string, status: string) =>
+      Array.from({ length: 12 }, (_unused, index) => ({
+        name: `${prefix}-${index}`,
+        type: 'DISK',
+        status: index === 0 ? status : 'ONLINE',
+        disk: `${prefix}${index}`,
+        children: [],
+      }));
+    const result = await report(
+      healthy({
+        ['pool.query']: [
+          pool({ name: 'tank', size: 1e12, allocated: 9.2e11, topology: { data: bay('a', 'FAULTED') } }),
+          pool({ name: 'vault', size: 4e12, allocated: 1e12, topology: { data: bay('b', 'ONLINE') } }),
+        ],
+        ['alert.list']: Array.from({ length: 12 }, (_unused, index) =>
+          alert({
+            level: index % 2 === 0 ? 'WARNING' : 'CRITICAL',
+            klass: 'ZpoolCapacityWarning',
+            formatted: `Pool tank is consuming 92% of its capacity (alert ${index})`,
+          }),
+        ),
+      }),
+    );
+    expect(result.verdict).toBe('CRITICAL');
+    // A ceiling, not a measurement: it fails if a later change makes the report
+    // materially larger, which is the property the ticket asks for.
+    expect(JSON.stringify(result).length).toBeLessThan(4096);
+  });
+
+  it('is read-only and takes no arguments', () => {
+    expect(systemHealthReport.mutating).toBe(false);
+    expect(systemHealthReport.requiredRole).toBe(Role.ReadOnly);
+    expect(systemHealthReport.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 });


### PR DESCRIPTION
Adds `system_health_report`, the one call that answers the requirements' own
first suggested prompt — *"review all my TrueNAS systems' health and let me know
of any potential issues or capacity concerns"* — instead of leaving it to six
round trips and an LLM deciding which six.

Fixes #44

## What it is

**Composite, as the ticket asks.** It calls four existing tool handlers and adds
no endpoint of its own:

| section | composed tool | answers |
|---|---|---|
| `pools` | `storage_pool_status` | pool health **and** capacity pressure |
| `disks` | `storage_pool_topology` | the state of every device beneath those pools |
| `alerts` | `alerts_list` | what the system is complaining about |
| `updates` | `system_update_status` | whether it is behind, and whether that was even established |

Calling the handlers rather than the API is what keeps it from becoming a
second, drifting opinion about what a pool's health *is* — there is one
normalization per subject and this reads through it.

## The three properties the design is for

**A section whose read failed is present and says so.** Each carries
`unavailable`: null where it was read, otherwise the reason it was not, in which
case every other field of that section is null. A report that throws because one
subsystem is unreachable is useless exactly when it is needed, so nothing here
rejects — asserted by a test in which all four reads fail.

**Counts and reasons are computed over everything a section read; only the three
detail lists are capped** (at 10 each, with a `truncated` flag). A cap can drop
the *line describing* a finding; it can never drop the finding, which is in
`reasons` and in the counts either way.

**`OK` is the narrow claim that every section was read and none of them raised
anything.** Anything not established is `UNKNOWN`: a section that failed, an
alert at a severity this report does not rank, a device state it does not rank,
a pool that reported no readable capacity, an update check that did not
complete. `UNKNOWN` is never "healthy" — it is a report with a hole in it, and
`reasons` names the hole. `reasons` is empty only when the verdict is `OK`.

## Measured size

The ticket asks for the measured size on a real system. **No real system was
reachable from this environment, so these are measured on fixtures rather than
on live hardware** — stating that plainly rather than presenting a synthetic
number as a live one:

- **534 bytes** — one healthy pool, one disk, no alerts, up to date.
- **2,558 bytes** (~640 tokens) — two pools of twelve disks, one degraded with a
  faulted member, twelve alerts, verdict `CRITICAL`.

The response is a fixed shape plus three capped lists, so the second figure is
close to the ceiling regardless of how large the system is. A test asserts the
busy case stays under 4,096 bytes, so the property is checked rather than
merely claimed.

## Two judgement calls worth flagging

**An available update is deliberately not a finding** and does not move the
verdict. Being a release behind is not a fault, and a verdict that read
`WARNING` on every well-run system with a pending update would stop carrying
information within a week. A check that *did not complete* is the opposite and
is a finding at `unknown` — that system may have gone unchecked for months,
which is the distinction `system_update_status` exists to keep.

**"Disk health" is read from the pool topology, which is the only disk-health
signal in the catalog.** It is not SMART data: a disk attached to the system and
belonging to no pool does not appear at all, and a disk failing in a way ZFS has
not yet noticed reads as `ONLINE`. The tool description says both. `#48`
(`disks_smart_status`) is the ticket that would add the missing half.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test`, `yarn test:coverage` and
`yarn build` all run clean locally — 738 tests, coverage floors met
(`reporting.ts` at 100% statements / 99.57% branches). Every gating job in
`.github/workflows/ci.yml` was runnable here; none was skipped.

## Local review

Two rounds of the project's own reviewer ran here in a separate process (the
`0`/`1` verdict, not the fallback brief).

Round 1 returned one MEDIUM and it was a real hole, fixed in
`a86123d`: `system_update_status` has **two** failure channels and only one was
being read. `check_error` names an update check that did not complete;
`version_error` names the *separate* read of the version the system is running
now. A system that answered the check and failed to say what it was on reported
`current_version: null` with no reason beside it and, with nothing else wrong, a
verdict of `OK` — precisely the "null reads as nothing to report" failure this
tool exists to close. Both channels are now carried and each is its own
`unknown` finding.

Round 2 returned **nothing at or above MEDIUM**, which ended the work.

## What I did not change, and why

Round 2's LOWs are recorded here rather than fixed, since each fix is a new diff
and a new review round. One was fixed — the `walkDevices` JSDoc claimed a node
with an unreadable `devices` array is treated as a leaf, when in fact the cast
throws and the throw is caught one level up as an unreadable `disks` section.
That is a comment stating the opposite of the code beneath it, so it was
corrected in `f854024` (comment only, no behaviour change). The rest stand:

- **A reason says a pool "reported no size and allocation this report could
  read" when the size was a readable `0`.** The behaviour is right — a pool of
  no size has no percentage, and `used_percent` is null rather than a fabricated
  figure — but the wording is inaccurate for that one input. Worth a follow-up.
- **Unranked alert levels sort below `INFO`, so the cap drops them from
  `most_severe` before informational alerts do.** Deliberate: an unrecognised
  level is not *known* to be severe, so it should not displace an `EMERGENCY`.
  Nothing is lost either way — the level is counted in full in `by_level` and
  still produces its own `unknown` finding.
- **`pools.entries` is capped without being ordered**, unlike `alerts`, so on a
  system with more than ten pools the fullest one can be omitted from the list.
  The finding still appears in `reasons`, naming the pool, which is why this is
  a presentation nit rather than a lost signal.
- **`pool.query` is issued twice per system**, once by each of the two composed
  pool tools. That is the price of composing handlers rather than the API, as
  the ticket's design note asks; it is also why the description states that
  `pools` and `disks` come from two reads taken at slightly different instants.
- **Calling composed handlers directly bypasses the catalog's role gate.** All
  four are `Role.ReadOnly`, as is this tool, so the gate is not currently
  weakened — but nothing asserts they stay that way. A real observation about
  the composite pattern generally, and a good candidate for a follow-up test.
- **The 80%/90% threshold test asserts at 85% and 95%**, so changing `>=` to `>`
  would keep it green. Fixing it means changing assertions rather than prose, so
  it is left for a follow-up.

## Recorded in `app/CLAUDE.md`

This is the first composite tool, and #46 and #47 are both composites too, so
the shape is written down under *Decisions* — call handlers rather than the API,
catch every read and name the gap, compute counts over everything and cap only
the lists, and give the verdict a fourth value.
