### PR TITLE
feat(tools): add vm_logs, the recent log output of one virtual machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_info`, `system_update_status`, `audit_log_query`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
-  `vms_list`, `alerts_list`, `snapshots_list`, `replication_status`,
+  `vms_list`, `vm_logs`, `alerts_list`, `snapshots_list`, `replication_status`,
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `tasks_recent_runs`,
   `shares_list`, `share_access`, `iscsi_list`, `nvmeof_list`, `users_list`,
   `directory_services_status`, `network_interfaces`, `network_config`,
@@ -37,7 +37,9 @@ confirmation UX, audit sinks) enters through injected interfaces.
   tool the last N lines of a path on one system, over `core.download` and an
   adapter-supplied `ContentFetcher`. The line and byte bounds are enforced on
   this side, and the minted download URL never reaches a tool. Absent unless
-  `connectSystems` is given a `ContentReaderFactory`; see `CLAUDE.md`.
+  `connectSystems` is given a `ContentReaderFactory`, and `vm_logs` — the one
+  tool that reads through it — reports that rather than an empty log; see
+  `CLAUDE.md`.
 - **Stubs** — role mapping (always Full), audit sinks (console/noop).
 
 ## Usage sketch

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export {
   disksList,
   appsList,
   vmsList,
+  vmLogs,
   alertsList,
   alertSettings,
   snapshotsList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,9 +22,9 @@ import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
 import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
-import { vmsList } from '@/tools/vms';
+import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-four read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-five read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -38,6 +38,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(disksList);
   catalog.register(appsList);
   catalog.register(vmsList);
+  catalog.register(vmLogs);
   catalog.register(alertsList);
   catalog.register(snapshotsList);
   catalog.register(replicationStatus);
@@ -100,5 +101,6 @@ export {
   tasksRecentRuns,
   updateStatus,
   usersList,
+  vmLogs,
   vmsList,
 };

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { of, throwError } from 'rxjs';
 import { SystemHandle, ToolContext } from '@/catalog/tool';
+import { FileContentError } from '@/content/file-content';
 import { Role } from '@/interfaces';
+import type { FileTail } from '@/interfaces';
 import {
   alertSettings,
   alertsList,
@@ -37,6 +39,7 @@ import {
   tasksRecentRuns,
   updateStatus,
   usersList,
+  vmLogs,
   vmsList,
 } from '@/tools/index';
 
@@ -82,7 +85,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-five sketch tools', () => {
+  it('registers the thirty-six sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -95,6 +98,7 @@ describe('createDefaultCatalog', () => {
       'disks_list',
       'apps_list',
       'vms_list',
+      'vm_logs',
       'alerts_list',
       'snapshots_list',
       'replication_status',
@@ -196,6 +200,10 @@ describe('createDefaultCatalog', () => {
 
   it('advertises vms_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('vms_list');
+  });
+
+  it('advertises vm_logs to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('vm_logs');
   });
 
   it('advertises apps_list to a read-only credential', () => {
@@ -7831,6 +7839,311 @@ describe('vms_list', () => {
     await vmsList.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('vm.query');
     expect(query).toHaveBeenCalledWith('virt.instance.query', [['type', '=', 'VM']]);
+  });
+});
+
+describe('vm_logs', () => {
+  const LOG_PATH = '/var/log/libvirt/qemu/1_buildbox.log';
+
+  /** A libvirt VM as `vm.query` reports one; only the id and name are read here. */
+  const vm = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'buildbox',
+    vcpus: 1,
+    cores: 1,
+    threads: 1,
+    memory: 4096,
+    min_memory: null,
+    autostart: true,
+    status: { state: 'RUNNING', domain_state: 'RUNNING' },
+    ...over,
+  });
+
+  /** An incus instance as `virt.instance.query` reports one. */
+  const instance = (over: Record<string, unknown> = {}) => ({
+    id: 'web',
+    name: 'web',
+    type: 'VM',
+    status: 'RUNNING',
+    cpu: '4',
+    memory: 8589934592,
+    autostart: false,
+    ...over,
+  });
+
+  /** What the content seam answers a bounded read with. */
+  const tail = (over: Partial<FileTail> = {}): FileTail => ({
+    path: LOG_PATH,
+    lines: ['starting up', 'ready'],
+    truncated: false,
+    ...over,
+  });
+
+  /**
+   * A system with a content reader on it, which `fakeSystem` does not build:
+   * the reader is the seam this tool reads through, and most of these cases
+   * turn on what it answers.
+   */
+  const wired = (
+    responses: Partial<Record<string, unknown>> = {
+      ['vm.query']: [vm()],
+      ['vm.log_file_path']: LOG_PATH,
+    },
+    readTail: (path: string, maxLines: number) => Promise<FileTail> = () => Promise.resolve(tail()),
+  ) => {
+    const { ctx, call, query } = fakeSystem(responses);
+    const reader = vi.fn(readTail);
+    ctx.system.files = { readTail: reader };
+    return { ctx, call, query, reader };
+  };
+
+  /** The same, with one method rejecting instead. */
+  const wiredFailing = (
+    rows: Partial<Record<string, unknown>>,
+    failures: Partial<Record<string, unknown>>,
+  ) => {
+    const { ctx, call, query } = failingSystem(rows, failures);
+    ctx.system.files = { readTail: () => Promise.resolve(tail()) };
+    return { ctx, call, query };
+  };
+
+  const read = async (
+    args: Record<string, unknown> = { vm: 'buildbox' },
+  ): Promise<Record<string, unknown>> =>
+    (await vmLogs.handler(wired().ctx, args)) as Record<string, unknown>;
+
+  it('reports the tail of the log of the VM it was asked for', async () => {
+    expect(await read()).toEqual({
+      source: 'vm',
+      id: 1,
+      name: 'buildbox',
+      log_path: LOG_PATH,
+      log_status: 'READ',
+      requested_lines: 100,
+      lines: ['starting up', 'ready'],
+      truncated: false,
+    });
+  });
+
+  it('matches a VM by its id, written as a number or as text', async () => {
+    const { ctx, call } = wired({ ['vm.query']: [vm({ id: 7 })], ['vm.log_file_path']: LOG_PATH });
+    expect(await vmLogs.handler(ctx, { vm: 7 })).toMatchObject({ id: 7, log_status: 'READ' });
+    expect(await vmLogs.handler(ctx, { vm: '7' })).toMatchObject({ id: 7, log_status: 'READ' });
+    // The path is asked for by id, whichever way the caller named the machine.
+    expect(call).toHaveBeenCalledWith('vm.log_file_path', [7]);
+  });
+
+  it('bounds the lines it asks the reader for, and says which bound it applied', async () => {
+    const { ctx, reader } = wired();
+    expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({ requested_lines: 100 });
+    expect(reader).toHaveBeenCalledWith(LOG_PATH, 100);
+    expect(await vmLogs.handler(ctx, { vm: 'buildbox', lines: 5 })).toMatchObject({
+      requested_lines: 5,
+    });
+    expect(reader).toHaveBeenCalledWith(LOG_PATH, 5);
+  });
+
+  it('refuses a line bound it cannot honour rather than quietly applying another', async () => {
+    // A caller given 100 lines after asking for 1001 cannot tell that from a
+    // log holding 100.
+    for (const lines of [0, -1, 1001, 1.5, '10', true]) {
+      await expect(read({ vm: 'buildbox', lines })).rejects.toThrow(
+        /"lines" must be a whole number between 1 and 1000/,
+      );
+    }
+    // Null and undefined are the argument not being given, which is what the
+    // default is for — as `audit_log_query` reads its own `since`.
+    for (const lines of [null, undefined]) {
+      expect(await read({ vm: 'buildbox', lines })).toMatchObject({ requested_lines: 100 });
+    }
+  });
+
+  it('refuses a vm argument that names no machine', async () => {
+    // `vm` is required, so null is a caller naming nothing rather than a
+    // default to fall back to — there is none.
+    for (const named of ['', 1.5, true, {}, undefined, null]) {
+      await expect(read({ vm: named })).rejects.toThrow(
+        /"vm" must be the name of a virtual machine, or its numeric id/,
+      );
+    }
+  });
+
+  it('reports a VM that does not exist as an error naming it', async () => {
+    const { ctx } = wired({ ['vm.query']: [], ['virt.instance.query']: [] });
+    await expect(vmLogs.handler(ctx, { vm: 'ghost' })).rejects.toThrow(
+      /No libvirt-backed virtual machine matching "ghost" exists on this system$/,
+    );
+  });
+
+  it('says an incus instance has no retrievable log, rather than reporting an empty one', async () => {
+    // The two answers mean different things: only one of them says the machine
+    // has written nothing.
+    const { ctx } = wired({ ['vm.query']: [], ['virt.instance.query']: [instance()] });
+    await expect(vmLogs.handler(ctx, { vm: 'web' })).rejects.toThrow(/is an incus-backed instance/);
+  });
+
+  it('does not read a container as the instance asked about', async () => {
+    // The `type` filter is asked of the middleware and re-checked here: an
+    // unrecognised filter is dropped rather than refused.
+    const { ctx } = wired({
+      ['vm.query']: [],
+      ['virt.instance.query']: [instance({ id: 'plex', name: 'plex', type: 'CONTAINER' })],
+    });
+    await expect(vmLogs.handler(ctx, { vm: 'plex' })).rejects.toThrow(
+      /No libvirt-backed virtual machine matching "plex"/,
+    );
+  });
+
+  it('says the incus stack could not be read rather than that the VM exists nowhere', async () => {
+    const { ctx } = wiredFailing(
+      { ['vm.query']: [] },
+      { ['virt.instance.query']: new Error('virt is not installed') },
+    );
+    await expect(vmLogs.handler(ctx, { vm: 'web' })).rejects.toThrow(
+      /the incus stack could not be read to say whether it holds one: virt is not installed/,
+    );
+  });
+
+  it('reports a stack that could not be listed as that, not as a VM that does not exist', async () => {
+    const { ctx } = wiredFailing({}, { ['vm.query']: new Error('connection reset') });
+    await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+      /could not be listed, so "buildbox" could not be found: connection reset/,
+    );
+  });
+
+  it('refuses to guess between machines the name matches', async () => {
+    const { ctx } = wired({
+      ['vm.query']: [vm({ id: null }), vm({ id: 2 })],
+      ['vm.log_file_path']: LOG_PATH,
+    });
+    await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+      /matches 2 virtual machines on this system — buildbox \(id unknown\), buildbox \(id 2\)/,
+    );
+  });
+
+  it('names an unreadable name in the machines a selector matched', async () => {
+    // One matched by its id and one by a name that is another machine's id, so
+    // asking again by id would not separate them either.
+    const { ctx } = wired({
+      ['vm.query']: [vm({ id: 1, name: null }), vm({ id: 2, name: '1' })],
+      ['vm.log_file_path']: LOG_PATH,
+    });
+    await expect(vmLogs.handler(ctx, { vm: 1 })).rejects.toThrow(
+      /an unnamed VM \(id 1\), 1 \(id 2\)/,
+    );
+  });
+
+  it('refuses a VM whose id the system did not report', async () => {
+    const { ctx } = wired({ ['vm.query']: [vm({ id: null })], ['vm.log_file_path']: LOG_PATH });
+    await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+      /reported no id for the virtual machine matching "buildbox"/,
+    );
+  });
+
+  it('reports a system naming no log file as no log yet, not as an empty one', async () => {
+    for (const path of [null, '']) {
+      const { ctx, reader } = wired({ ['vm.query']: [vm()], ['vm.log_file_path']: path });
+      expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
+        log_path: null,
+        log_status: 'NO_LOG_PATH',
+        lines: [],
+        truncated: false,
+      });
+      // Nothing to read, so nothing is read.
+      expect(reader).not.toHaveBeenCalled();
+    }
+  });
+
+  it('reports a named path with no file behind it as no log yet', async () => {
+    const { ctx } = wired(undefined, () =>
+      Promise.reject(new FileContentError('NOT_FOUND', LOG_PATH, `Could not read "${LOG_PATH}"`)),
+    );
+    expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
+      log_path: LOG_PATH,
+      log_status: 'NO_LOG_FILE',
+      lines: [],
+      truncated: false,
+    });
+  });
+
+  it('raises a log it could not read rather than reporting an empty one', async () => {
+    // Every failure but NOT_FOUND: reporting these as an empty log would say
+    // the VM logged nothing on the strength of a read that never happened.
+    const failures = [
+      new FileContentError('TRANSPORT', LOG_PATH, 'Downloading it failed'),
+      new FileContentError('UNREADABLE', LOG_PATH, 'Permission denied'),
+      new FileContentError('NOT_A_FILE', LOG_PATH, 'It is a directory'),
+      new Error('the reader broke'),
+    ];
+    for (const failure of failures) {
+      const { ctx } = wired(undefined, () => Promise.reject(failure));
+      await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+        new RegExp(`The log of "buildbox" could not be read: ${failure.message}`),
+      );
+    }
+  });
+
+  it('reports a log file path that could not be read', async () => {
+    const { ctx } = wiredFailing(
+      { ['vm.query']: [vm()] },
+      { ['vm.log_file_path']: new Error('no such VM') },
+    );
+    await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+      /The log file path for "buildbox" could not be read: no such VM/,
+    );
+  });
+
+  it('reports a deployment with no content reader rather than an empty log', async () => {
+    const { ctx, query } = fakeSystem({ ['vm.query']: [vm()] });
+    await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
+      /cannot read file content from a system/,
+    );
+    // Said before anything is asked of the system: it is a fact about how the
+    // deployment was assembled rather than about the VM.
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('carries the truncation the reader reported', async () => {
+    const { ctx } = wired(undefined, () =>
+      Promise.resolve(tail({ lines: ['ready'], truncated: true })),
+    );
+    expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
+      lines: ['ready'],
+      truncated: true,
+    });
+  });
+
+  it('reads the log of a VM it has already found without reading the other stack', async () => {
+    const { ctx, query } = wired();
+    await vmLogs.handler(ctx, { vm: 'buildbox' });
+    expect(query).toHaveBeenCalledWith('vm.query');
+    expect(query).not.toHaveBeenCalledWith('virt.instance.query', [['type', '=', 'VM']]);
+  });
+
+  it('carries no field the tool does not name', async () => {
+    const { ctx } = wired({
+      ['vm.query']: [vm({ vnc_password: 'SECRET-VNC-PASSWORD' })],
+      ['vm.log_file_path']: LOG_PATH,
+    });
+    const answer = (await vmLogs.handler(ctx, { vm: 'buildbox' })) as Record<string, unknown>;
+    expect(Object.keys(answer)).toEqual([
+      'source',
+      'id',
+      'name',
+      'log_path',
+      'log_status',
+      'requested_lines',
+      'lines',
+      'truncated',
+    ]);
+    expect(JSON.stringify(answer)).not.toContain('SECRET');
+  });
+
+  it('advertises the same bound its description states', () => {
+    expect(vmLogs.inputSchema).toMatchObject({
+      required: ['vm'],
+      properties: { lines: { minimum: 1, maximum: 1000 } },
+    });
   });
 });
 

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -7919,6 +7919,7 @@ describe('vm_logs', () => {
       name: 'buildbox',
       log_path: LOG_PATH,
       log_status: 'READ',
+      log_error: null,
       requested_lines: 100,
       lines: ['starting up', 'ready'],
       truncated: false,
@@ -8046,6 +8047,7 @@ describe('vm_logs', () => {
       expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
         log_path: null,
         log_status: 'NO_LOG_PATH',
+        log_error: null,
         lines: [],
         truncated: false,
       });
@@ -8054,22 +8056,14 @@ describe('vm_logs', () => {
     }
   });
 
-  it('reports a named path with no file behind it as no log yet', async () => {
-    const { ctx } = wired(undefined, () =>
-      Promise.reject(new FileContentError('NOT_FOUND', LOG_PATH, `Could not read "${LOG_PATH}"`)),
-    );
-    expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
-      log_path: LOG_PATH,
-      log_status: 'NO_LOG_FILE',
-      lines: [],
-      truncated: false,
-    });
-  });
-
-  it('raises a log it could not read rather than reporting an empty one', async () => {
-    // Every failure but NOT_FOUND: reporting these as an empty log would say
-    // the VM logged nothing on the strength of a read that never happened.
+  it('reports a log it could not read as unreadable, never as an empty one', async () => {
+    // Including the absent file this cannot tell from an unreadable one: the
+    // error name that separates them is not carried through to the tool, so
+    // both arrive here and `log_error` is what tells them apart. Reporting
+    // either as `lines: []` under `READ` would say the VM logged nothing on
+    // the strength of a read that never happened.
     const failures = [
+      new FileContentError('NOT_FOUND', LOG_PATH, `Could not read "${LOG_PATH}": ENOENT`),
       new FileContentError('TRANSPORT', LOG_PATH, 'Downloading it failed'),
       new FileContentError('UNREADABLE', LOG_PATH, 'Permission denied'),
       new FileContentError('NOT_A_FILE', LOG_PATH, 'It is a directory'),
@@ -8077,10 +8071,25 @@ describe('vm_logs', () => {
     ];
     for (const failure of failures) {
       const { ctx } = wired(undefined, () => Promise.reject(failure));
-      await expect(vmLogs.handler(ctx, { vm: 'buildbox' })).rejects.toThrow(
-        new RegExp(`The log of "buildbox" could not be read: ${failure.message}`),
-      );
+      expect(await vmLogs.handler(ctx, { vm: 'buildbox' })).toMatchObject({
+        log_path: LOG_PATH,
+        log_status: 'UNREADABLE',
+        log_error: failure.message,
+        lines: [],
+        truncated: false,
+      });
     }
+  });
+
+  it('does not carry the seam\'s cause into a result, where a download URL can be', async () => {
+    // `FileContentError` keeps the adapter's own message — which names the URL
+    // it fetched, token and all — on `cause` rather than in `message`.
+    const failure = new FileContentError('TRANSPORT', LOG_PATH, `Downloading "${LOG_PATH}" failed`, {
+      cause: new Error('request to https://nas.local/_download?auth_token=SECRET-TOKEN failed'),
+    });
+    const { ctx } = wired(undefined, () => Promise.reject(failure));
+    const answer = await vmLogs.handler(ctx, { vm: 'buildbox' });
+    expect(JSON.stringify(answer)).not.toContain('SECRET-TOKEN');
   });
 
   it('reports a log file path that could not be read', async () => {
@@ -8132,6 +8141,7 @@ describe('vm_logs', () => {
       'name',
       'log_path',
       'log_status',
+      'log_error',
       'requested_lines',
       'lines',
       'truncated',

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ApiSurface, ReadOnlyTool } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { FileContentError } from '@/content/file-content';
 
 /**
  * Virtual machines a system runs, with the state each is in and the CPU and
@@ -349,5 +350,332 @@ export const vmsList: ReadOnlyTool = {
       ],
       failures,
     };
+  },
+};
+
+/**
+ * The recent log output of one libvirt-backed virtual machine.
+ *
+ * "The VM will not boot" is unanswerable without its log, and the log is the
+ * one thing `vms_list` deliberately does not carry.
+ *
+ * ONE STACK, NOT TWO. `vms_list` reads both of the stacks TrueNAS runs VMs
+ * under; this reads only the older libvirt-backed one. `vm.log_file_path` is
+ * the only endpoint on the API surface that names a VM's log and there is no
+ * counterpart under `virt.*`, so an incus-backed instance has no retrievable
+ * log here at all. A name matching one of those is an error saying so rather
+ * than an empty log: only one of those two answers means the VM has written
+ * nothing.
+ *
+ * THE CONTENT COMES THROUGH THE FILE SEAM, NOT THE API. `vm.log_file_path`
+ * answers a path and nothing else, and every content-bearing endpoint on this
+ * surface is a job whose payload leaves out of band. `SystemHandle.files` is
+ * how a tool reads bytes (route (a) of #72; `CLAUDE.md` carries the decision).
+ * It is optional, and a deployment that wired none is told so rather than
+ * answered with an empty log.
+ *
+ * A LOG IS UNBOUNDED AND A CONTEXT WINDOW IS NOT, which is why the line count
+ * is a requirement of this tool rather than a refinement. The seam bounds the
+ * bytes it will read, this bounds the lines it will return, and `truncated`
+ * says when the pair of them left something out.
+ *
+ * The audit trail records a tool's arguments and, per system, `ok` or the
+ * error message — never the result (`AuditEvent`). So log content does not
+ * reach it, and nothing thrown here quotes a line of the file: a failure names
+ * the VM and the path, which the caller either supplied or can already see.
+ */
+
+/** Lines returned when the caller names no bound. */
+const DEFAULT_LOG_LINES = 100;
+
+/** The most lines a caller may ask for. */
+const MAX_LOG_LINES = 1000;
+
+/**
+ * How far the read got, for a result that carries no lines.
+ *
+ * Three states rather than one empty list, because "the log was read and holds
+ * nothing", "this VM has no log file" and "the file named does not exist yet"
+ * are different answers to the question the caller asked. A failure to read is
+ * none of them and is an error.
+ */
+type VmLogStatus = 'READ' | 'NO_LOG_PATH' | 'NO_LOG_FILE';
+
+/** One VM's log, in the shape this tool reports it. */
+interface VmLog {
+  source: 'vm';
+  id: number;
+  name: string | null;
+  log_path: string | null;
+  log_status: VmLogStatus;
+  requested_lines: number;
+  lines: string[];
+  truncated: boolean;
+}
+
+/**
+ * The line bound the caller asked for, or the default where they asked for
+ * none.
+ *
+ * Strict, as `audit_log_query` is about its own `since` and for the same
+ * reason: a bound that cannot be read is not a request for the default one. A
+ * caller who asks for 1000 lines and is quietly given 100 has no way to tell
+ * that from a log holding only 100, and a bound above the maximum is a request
+ * this tool cannot honour rather than one it can round down. Null and undefined
+ * are the argument being absent, which is what the default is for.
+ */
+function requestedLines(raw: unknown): number {
+  if (raw == null) return DEFAULT_LOG_LINES;
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1 || raw > MAX_LOG_LINES) {
+    throw new Error(`"lines" must be a whole number between 1 and ${MAX_LOG_LINES}`);
+  }
+  return raw;
+}
+
+/**
+ * The VM the caller named, as text to match on.
+ *
+ * A number is accepted as well as a string because the id of a VM on this stack
+ * IS a number and a caller reading one out of `vms_list` will send it as one;
+ * it is matched as text either way, against both the name and the id, since a
+ * caller has no way to say which of the two they meant.
+ */
+function requestedVm(raw: unknown): string {
+  if (typeof raw === 'number' && Number.isInteger(raw)) return String(raw);
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error('"vm" must be the name of a virtual machine, or its numeric id');
+  }
+  return raw;
+}
+
+/** Whether a row is the one asked for, by name or by id. */
+function matchesVm(row: VmRow, selector: string): boolean {
+  return row.name === selector || (row.id !== null && String(row.id) === selector);
+}
+
+/** How a match is named in a message about several of them. */
+function describeMatch(row: VmRow): string {
+  return `${row.name ?? 'an unnamed VM'} (id ${row.id === null ? 'unknown' : String(row.id)})`;
+}
+
+/**
+ * Every libvirt-backed VM on the system.
+ *
+ * Unlike `vms_list`, a read that fails is fatal here rather than reported
+ * beside an answer: this tool has one question and a list it could not read is
+ * not evidence that the VM asked about does not exist. The message says which
+ * it was, because the two are indistinguishable to a caller who only sees a
+ * name they gave being rejected.
+ */
+async function libvirtVms(system: SystemHandle, selector: string): Promise<VmRow[]> {
+  try {
+    const rows = await firstValueFrom(system.client.api.query('vm.query'));
+    return rows.map(fromVmStack);
+  } catch (reason) {
+    throw new Error(
+      `The virtual machines on this system could not be listed, so "${selector}" could not be ` +
+        `found: ${errorText(reason)}`,
+      { cause: reason },
+    );
+  }
+}
+
+/**
+ * Whether the name belongs to an incus-backed instance instead.
+ *
+ * Read only once the libvirt stack has already answered without a match, so
+ * that the ordinary case costs one query rather than two. Its own failure is
+ * caught and reported in the not-found message rather than raised: not finding
+ * the VM is still the answer, and the failure is what stops that answer being
+ * "it does not exist anywhere".
+ */
+async function incusMatch(
+  system: SystemHandle,
+  selector: string,
+): Promise<Attempt<VmRow | undefined>> {
+  const read = await attempt('virt_instance', () =>
+    firstValueFrom(
+      // Inlined for the reason `vms_list` gives, and re-checked below for the
+      // reason it re-checks: a filter a release does not recognise is dropped
+      // rather than refused, and a container is not a virtual machine.
+      system.client.api.query('virt.instance.query', [['type', '=', 'VM']]),
+    ),
+  );
+  return {
+    value: (read.value ?? [])
+      .filter((instance) => instance.type === 'VM')
+      .map(fromVirtStack)
+      .find((row) => matchesVm(row, selector)),
+    failure: read.failure,
+  };
+}
+
+/** Where the system keeps this VM's log, or null where it names none. */
+async function logFilePath(
+  system: SystemHandle,
+  id: number,
+  selector: string,
+): Promise<string | null> {
+  try {
+    return textOrNull(await firstValueFrom(system.client.api.call('vm.log_file_path', [id])));
+  } catch (reason) {
+    throw new Error(
+      `The log file path for "${selector}" could not be read: ${errorText(reason)}`,
+      { cause: reason },
+    );
+  }
+}
+
+export const vmLogs: ReadOnlyTool = {
+  name: 'vm_logs',
+  description:
+    'The recent log output of one virtual machine — the last lines of the log ' +
+    'file TrueNAS keeps for it. `vm` names the machine: its name, or its ' +
+    'numeric id. ONLY THE OLDER LIBVIRT-BACKED VMs HAVE A LOG HERE, the ones ' +
+    '`vms_list` reports with `source` `vm`, and `source` is always `vm` in ' +
+    'this result for that reason. TrueNAS also runs newer incus-backed ' +
+    'instances — `source` `virt_instance` — and NOTHING ON THIS API CAN ' +
+    'RETRIEVE A LOG FOR ONE, so naming one is an error saying so rather than ' +
+    'an empty log. A name matching no virtual machine at all is an error ' +
+    'naming it, and one matching more than one machine is an error rather ' +
+    'than a guess at which was meant. `lines` is the most lines to return: 100 ' +
+    'by default, 1000 at most, and a value outside that range is an error ' +
+    'rather than a quietly smaller answer. `requested_lines` is the bound ' +
+    'actually applied. The `lines` list is OLDEST FIRST, so the newest line of ' +
+    'the log is the last element. THEY ARE THE LAST LINES OF THE FILE ON A ' +
+    'BEST EFFORT: reaching the end depends on the size the system reports for ' +
+    'the file, and a log being written to while it is read can yield lines ' +
+    'from further forward instead. `truncated` is true whenever what came back ' +
+    'is not the whole log — more lines than the bound, or content skipped to ' +
+    'reach the end — and it does not say WHICH end was missed, so a caller ' +
+    'watching a live problem should read again rather than treat one answer ' +
+    'as final. `log_status` says how far the read got. `READ` is the log file ' +
+    'read, with `lines` holding what it had. `NO_LOG_PATH` is a system that ' +
+    'names no log file for this VM at all, which is usually one that has never ' +
+    'been started. `NO_LOG_FILE` is a system that names a path where no file ' +
+    'exists yet. Under either of those `lines` is empty and `truncated` is ' +
+    'false, and NEITHER IS A FAILURE TO READ — a failure is an error, never an ' +
+    'empty result. Under `READ` an empty `lines` means the file held no whole ' +
+    'line, which is an empty log where `truncated` is false and a single line ' +
+    "longer than the reader's byte ceiling where it is true. `log_path` is " +
+    'where the log file lives on the system, and is null exactly when ' +
+    '`log_status` is `NO_LOG_PATH`. `id` and `name` are the machine this ' +
+    'matched, as `vms_list` reports them, so a name given here can be checked ' +
+    'against the machine it resolved to. This tool reads recorded log output ' +
+    'and nothing else. It is NOT console access — a console is a live socket ' +
+    'and is not in this catalog — it does not report application or container ' +
+    'logs, which belong to `apps_list`, and it does not start, stop or change ' +
+    'a VM. NO field beyond those named here is returned.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      vm: {
+        type: ['string', 'integer'],
+        description:
+          'The virtual machine to read, by name or by numeric id, as ' +
+          '`vms_list` reports them for `source` `vm`.',
+      },
+      lines: {
+        type: 'integer',
+        minimum: 1,
+        maximum: MAX_LOG_LINES,
+        description:
+          `The most log lines to return, newest last. Omitted, ${DEFAULT_LOG_LINES}.`,
+      },
+    },
+    required: ['vm'],
+  },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }, args) {
+    // Both arguments are read before anything is called, so an unreadable one
+    // is an error rather than a system asked a question this tool then throws
+    // the answer to.
+    const wanted = requestedLines(args['lines']);
+    const selector = requestedVm(args['vm']);
+    const files = system.files;
+    // Checked before the first call, because it is a fact about how this
+    // deployment was assembled rather than about the VM asked for — and a
+    // missing reader would otherwise be discovered only after the VM had been
+    // found, which is a slower way to say the same thing.
+    if (files === undefined) {
+      throw new Error(
+        'This deployment cannot read file content from a system, so no VM log can be ' +
+          'retrieved. `vm_logs` reads the log file through the content reader the adapter ' +
+          'supplies when it connects a system; without one there is no way to reach it.',
+      );
+    }
+
+    const matches = (await libvirtVms(system, selector)).filter((row) => matchesVm(row, selector));
+    if (matches.length === 0) {
+      const other = await incusMatch(system, selector);
+      if (other.value !== undefined) {
+        throw new Error(
+          `"${selector}" is an incus-backed instance, and TrueNAS keeps no log this API can ` +
+            'retrieve for that stack. Only the libvirt-backed virtual machines `vms_list` ' +
+            'reports with `source` `vm` have one.',
+        );
+      }
+      throw new Error(
+        `No libvirt-backed virtual machine matching "${selector}" exists on this system` +
+          // Said only where it is true: an incus stack that could not be read
+          // is why "it exists nowhere" is not what was established here.
+          (other.failure === null
+            ? ''
+            : `, and the incus stack could not be read to say whether it holds one: ${other.failure.error}`),
+      );
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `"${selector}" matches ${matches.length} virtual machines on this system — ` +
+          `${matches.map(describeMatch).join(', ')}. Name one of them exactly.`,
+      );
+    }
+    const target = matches[0];
+    // `VmRow.id` spans both stacks and is a string on the other one; on this
+    // one it is a number or nothing at all. Reaching here without one is a
+    // match made on the name alone, and the log can only be asked for by id.
+    const id = target.id;
+    if (typeof id !== 'number') {
+      throw new Error(
+        `The system reported no id for the virtual machine matching "${selector}", and its log ` +
+          'file can only be located by id.',
+      );
+    }
+    /** Every answer this tool gives, so that all three carry the same fields. */
+    const answer = (
+      log_path: string | null,
+      log_status: VmLogStatus,
+      lines: string[],
+      truncated: boolean,
+    ): VmLog => ({
+      source: 'vm',
+      id,
+      name: target.name,
+      log_path,
+      log_status,
+      requested_lines: wanted,
+      lines,
+      truncated,
+    });
+
+    const path = await logFilePath(system, id, selector);
+    if (path === null) return answer(null, 'NO_LOG_PATH', [], false);
+    try {
+      const tail = await files.readTail(path, wanted);
+      return answer(path, 'READ', tail.lines, tail.truncated);
+    } catch (reason) {
+      // A path the system named and no file at it is a VM that has not written
+      // a log yet — an answer about the VM, and the one case here that is not a
+      // failure. Every other reason the read can fail IS one, and is raised:
+      // reporting an unreadable log as an empty one would say the VM logged
+      // nothing on the strength of a read that never happened.
+      if (reason instanceof FileContentError && reason.reason === 'NOT_FOUND') {
+        return answer(path, 'NO_LOG_FILE', [], false);
+      }
+      throw new Error(`The log of "${selector}" could not be read: ${errorText(reason)}`, {
+        cause: reason,
+      });
+    }
   },
 };

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -310,9 +310,10 @@ export const vmsList: ReadOnlyTool = {
     'without any. A stack that is simply absent from a given TrueNAS release ' +
     'appears here as a failure for that reason. This tool reports only virtual ' +
     'machines: incus containers are excluded and applications are ' +
-    "`apps_list`. It does not report a VM's log output, disks, network " +
-    'interfaces, display or passthrough devices, and it does not create, ' +
-    'start, stop or change one. NO field beyond those named here ' +
+    "`apps_list`. A VM's log output is `vm_logs`, which reads one machine on " +
+    'the `vm` stack. This does not report a VM\'s disks, network interfaces, ' +
+    'display or passthrough devices, and it does not create, start, stop or ' +
+    'change one. NO field beyond those named here ' +
     'is returned, whatever a later TrueNAS release adds to either record.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
@@ -566,9 +567,11 @@ export const vmLogs: ReadOnlyTool = {
     'watching a live problem should read again rather than treat one answer ' +
     'as final. `log_status` says how far the read got, and ONLY `READ` MEANS ' +
     'AN EMPTY `lines` IS SOMETHING THE VM DID. `READ` is the log file read, ' +
-    'with `lines` holding what it had; an empty `lines` there means the file ' +
-    'held no whole line, which is an empty log where `truncated` is false and ' +
-    "a single line longer than the reader's byte ceiling where it is true. " +
+    'with `lines` holding what it had; an empty `lines` there means no whole ' +
+    'line was in what was read, which is an empty log where `truncated` is ' +
+    'false and, where it is true, a window that held no line end — a line ' +
+    "longer than the reader's byte ceiling, or a file that changed size while " +
+    'it was being read, among others. ' +
     '`NO_LOG_PATH` is a system that names no log file for this VM at all, ' +
     'which is usually a machine that has never been started. `UNREADABLE` is a ' +
     'log file this tool was told about and could not read, with `log_error` ' +
@@ -590,13 +593,16 @@ export const vmLogs: ReadOnlyTool = {
     'lives. This tool reads recorded log output ' +
     'and nothing else. It is NOT console access — a console is a live socket ' +
     'and is not in this catalog — it does not report application or container ' +
-    'logs, which belong to `apps_list`, and it does not start, stop or change ' +
-    'a VM. NO field beyond those named here is returned.',
+    'logs, WHICH NOTHING IN THIS CATALOG REPORTS, and it does not start, stop ' +
+    'or change a VM. NO field beyond those named here is returned.',
   inputSchema: {
     type: 'object',
     properties: {
       vm: {
-        type: ['string', 'integer'],
+        // `oneOf` rather than a type list, as the catalog's own `systems`
+        // argument spells the same union: an array-valued `type` is valid JSON
+        // Schema and is outside the subset several provider APIs accept.
+        oneOf: [{ type: 'string' }, { type: 'integer' }],
         description:
           'The virtual machine to read, by name or by numeric id, as ' +
           '`vms_list` reports them for `source` `vm`.',
@@ -654,7 +660,8 @@ export const vmLogs: ReadOnlyTool = {
     if (matches.length > 1) {
       throw new Error(
         `"${selector}" matches ${matches.length} virtual machines on this system — ` +
-          `${matches.map(describeMatch).join(', ')}. Name one of them exactly.`,
+          `${matches.map(describeMatch).join(', ')}. Ask again with the id of the one ` +
+          'you mean.',
       );
     }
     const target = matches[0];

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -1,7 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
-import { FileContentError } from '@/content/file-content';
 
 /**
  * Virtual machines a system runs, with the state each is in and the CPU and
@@ -383,6 +382,13 @@ export const vmsList: ReadOnlyTool = {
  * error message — never the result (`AuditEvent`). So log content does not
  * reach it, and nothing thrown here quotes a line of the file: a failure names
  * the VM and the path, which the caller either supplied or can already see.
+ *
+ * `log_error` is the seam's own message and is safe to return for the same
+ * reason. `FileContentError` never quotes the download URL, which carries a
+ * single-use token, and puts the adapter's own message — which can name that
+ * URL — on `cause` instead. `errorText` reads `message` and never `cause`, so
+ * the token cannot arrive in a result through here. A reader of `cause` added
+ * to this file would break that, not merely a test.
  */
 
 /** Lines returned when the caller names no bound. */
@@ -392,14 +398,21 @@ const DEFAULT_LOG_LINES = 100;
 const MAX_LOG_LINES = 1000;
 
 /**
- * How far the read got, for a result that carries no lines.
+ * How far the read got, so that an empty `lines` cannot be read as a VM that
+ * logged nothing when it is a log this tool never saw.
  *
- * Three states rather than one empty list, because "the log was read and holds
- * nothing", "this VM has no log file" and "the file named does not exist yet"
- * are different answers to the question the caller asked. A failure to read is
- * none of them and is an error.
+ * THERE IS NO STATE HERE FOR "THE FILE IS NOT THERE YET", and that is a
+ * property of what reaches this tool rather than a distinction not worth
+ * drawing. `FileContentError` separates an absent path from an unreadable one
+ * on `errname`, and `SystemError.errname` is null for every API failure today —
+ * the client flattens a JSON-RPC error to a plain message before it reaches the
+ * core, and restoring it is an upstream change. So a log file that does not
+ * exist arrives here as indistinguishable from one that could not be opened,
+ * and both are `UNREADABLE` carrying what the system said. Splitting them on
+ * the text of that message would be a guess, and the wrong half of it would
+ * report a permission failure as a machine that has never logged anything.
  */
-type VmLogStatus = 'READ' | 'NO_LOG_PATH' | 'NO_LOG_FILE';
+type VmLogStatus = 'READ' | 'NO_LOG_PATH' | 'UNREADABLE';
 
 /** One VM's log, in the shape this tool reports it. */
 interface VmLog {
@@ -408,6 +421,8 @@ interface VmLog {
   name: string | null;
   log_path: string | null;
   log_status: VmLogStatus;
+  /** What the system said about a log it would not give up, or null. */
+  log_error: string | null;
   requested_lines: number;
   lines: string[];
   truncated: boolean;
@@ -549,19 +564,30 @@ export const vmLogs: ReadOnlyTool = {
     'is not the whole log — more lines than the bound, or content skipped to ' +
     'reach the end — and it does not say WHICH end was missed, so a caller ' +
     'watching a live problem should read again rather than treat one answer ' +
-    'as final. `log_status` says how far the read got. `READ` is the log file ' +
-    'read, with `lines` holding what it had. `NO_LOG_PATH` is a system that ' +
-    'names no log file for this VM at all, which is usually one that has never ' +
-    'been started. `NO_LOG_FILE` is a system that names a path where no file ' +
-    'exists yet. Under either of those `lines` is empty and `truncated` is ' +
-    'false, and NEITHER IS A FAILURE TO READ — a failure is an error, never an ' +
-    'empty result. Under `READ` an empty `lines` means the file held no whole ' +
-    'line, which is an empty log where `truncated` is false and a single line ' +
-    "longer than the reader's byte ceiling where it is true. `log_path` is " +
+    'as final. `log_status` says how far the read got, and ONLY `READ` MEANS ' +
+    'AN EMPTY `lines` IS SOMETHING THE VM DID. `READ` is the log file read, ' +
+    'with `lines` holding what it had; an empty `lines` there means the file ' +
+    'held no whole line, which is an empty log where `truncated` is false and ' +
+    "a single line longer than the reader's byte ceiling where it is true. " +
+    '`NO_LOG_PATH` is a system that names no log file for this VM at all, ' +
+    'which is usually a machine that has never been started. `UNREADABLE` is a ' +
+    'log file this tool was told about and could not read, with `log_error` ' +
+    'carrying what the system said about it. THAT COVERS A FILE THAT IS NOT ' +
+    'THERE YET AS WELL AS ONE THAT COULD NOT BE OPENED, and this API does not ' +
+    'separate the two: the error name that would is not carried through to ' +
+    'this tool, so reading `log_error` is the only way to tell, and a VM that ' +
+    'has simply never logged anything cannot be asserted from this state ' +
+    'alone. `lines` is empty and `truncated` false under both of those states. ' +
+    '`log_error` is null under every state but `UNREADABLE`. `log_path` is ' +
     'where the log file lives on the system, and is null exactly when ' +
-    '`log_status` is `NO_LOG_PATH`. `id` and `name` are the machine this ' +
-    'matched, as `vms_list` reports them, so a name given here can be checked ' +
-    'against the machine it resolved to. This tool reads recorded log output ' +
+    '`log_status` is `NO_LOG_PATH`. `id` is the machine\'s numeric id on this ' +
+    'stack and `name` is the name it is configured under, or null where the ' +
+    'system reported none — both are the machine this matched, as `vms_list` ' +
+    'reports them, so a name given here can be checked against what it ' +
+    'resolved to. A machine that could not be identified at all IS an error ' +
+    'rather than any of these states: no match, several matches, a stack that ' +
+    'could not be listed, or a system that could not be asked where the log ' +
+    'lives. This tool reads recorded log output ' +
     'and nothing else. It is NOT console access — a console is a live socket ' +
     'and is not in this catalog — it does not report application or container ' +
     'logs, which belong to `apps_list`, and it does not start, stop or change ' +
@@ -648,12 +674,14 @@ export const vmLogs: ReadOnlyTool = {
       log_status: VmLogStatus,
       lines: string[],
       truncated: boolean,
+      log_error: string | null = null,
     ): VmLog => ({
       source: 'vm',
       id,
       name: target.name,
       log_path,
       log_status,
+      log_error,
       requested_lines: wanted,
       lines,
       truncated,
@@ -665,17 +693,15 @@ export const vmLogs: ReadOnlyTool = {
       const tail = await files.readTail(path, wanted);
       return answer(path, 'READ', tail.lines, tail.truncated);
     } catch (reason) {
-      // A path the system named and no file at it is a VM that has not written
-      // a log yet — an answer about the VM, and the one case here that is not a
-      // failure. Every other reason the read can fail IS one, and is raised:
-      // reporting an unreadable log as an empty one would say the VM logged
-      // nothing on the strength of a read that never happened.
-      if (reason instanceof FileContentError && reason.reason === 'NOT_FOUND') {
-        return answer(path, 'NO_LOG_FILE', [], false);
-      }
-      throw new Error(`The log of "${selector}" could not be read: ${errorText(reason)}`, {
-        cause: reason,
-      });
+      // Reported rather than raised, because the commonest reason a named log
+      // file will not open is that the VM has not written one yet — which is an
+      // answer about the machine and not a fault. It is not raised as an empty
+      // log either: `log_status` is what stops an empty `lines` here being read
+      // as a VM that logged nothing, since this cannot tell an absent file from
+      // an unreadable one (see `VmLogStatus`). Identifying the machine is the
+      // part that still throws: a system that could not be asked its VMs, or
+      // where its log lives, was never in a position to answer at all.
+      return answer(path, 'UNREADABLE', [], false, errorText(reason));
     }
   },
 };


### PR DESCRIPTION
Adds `vm_logs`, a read-only tool returning the recent log output of one virtual machine. Fixes #36.

## What it does

`vm_logs` takes a machine — `vm`, its name or its numeric id — and an optional `lines` bound, and returns the last lines of the log file TrueNAS keeps for it:

```json
{
  "source": "vm",
  "id": 1,
  "name": "buildbox",
  "log_path": "/var/log/libvirt/qemu/1_buildbox.log",
  "log_status": "READ",
  "log_error": null,
  "requested_lines": 100,
  "lines": ["char device redirected to /dev/pts/3", "…"],
  "truncated": false
}
```

The content comes through the file-content seam #72 landed (`SystemHandle.files`), not through the API: `vm.log_file_path` answers a path and nothing else, and every content-bearing endpoint on this surface is a job whose payload leaves out of band. That was the blocker this ticket was halted on, and the route recorded in `app/CLAUDE.md` is what unblocks it.

## The design notes in the ticket, corrected against the pinned client

Both of the ticket's `(unconfirmed)` notes were checked against `@truenas/api-client` 2.0.0 as installed.

- **`vm.log_file_download` is in the client, and is not usable.** It is a job (`dist/index.d.ts:12088`, `response: null`); the log travels out of band through the download pipe. The ticket said it was absent from the enum; it is present and it is the wrong shape.
- **The retrieval verb is `vm.log_file_path` (`:11159`, `[id] -> string | null`) plus the content seam.** It names where the log lives; the seam reads a bounded window of it. `filesystem.file_tail_follow`, the one endpoint that takes a `tail_lines` bound itself, is still excluded by the client's `EventName` mapping — that is unchanged and is why #72 took the `core.download` route.
- **One stack, not two.** There is no `virt.*` log endpoint on this surface, so an incus-backed instance has no retrievable log at all. Naming one is an error saying so, rather than an empty log — the two mean different things and only one of them says the machine has written nothing. `vms_list` now points at this tool where it says it does not carry log output.

## The three ways to come back with no lines

Kept apart, because they are different answers about the machine:

| `log_status` | means |
|---|---|
| `READ` | the file was read; an empty `lines` is something the VM did (or did not) write |
| `NO_LOG_PATH` | the system names no log file for this VM at all — usually one never started |
| `UNREADABLE` | a log file this tool was told about and could not read, with `log_error` carrying what the system said |

**There is deliberately no "not there yet" state, and that is a limit worth knowing.** `FileContentError` separates an absent path from an unreadable one on `errname`, and `SystemError.errname` is null for every API failure today — the client flattens a JSON-RPC error to a plain message before it reaches the core. So a log file that does not exist and one that would not open arrive here indistinguishable. The first round of this PR had a `NO_LOG_FILE` state keyed on that reason; it was effectively unreachable, and the ordinary case it existed for threw instead of answering. Splitting the two on the text of the message would be a guess whose wrong half reports a permission failure as a machine that has never logged anything. `VmLogStatus` says what would have to change upstream for the distinction to exist.

`UNREADABLE` is returned rather than raised because not-written-yet is the commonest way into it. Identifying the machine still throws: no match, several matches, a stack that could not be listed, or a system that could not be asked where the log lives — none of those was ever in a position to answer.

## Bounding

A log is unbounded and a context window is not, so the bound is a requirement rather than a refinement. `lines` defaults to **100** and stops at **1000**; a value outside that range is an error rather than a quietly smaller answer, since a caller handed 100 lines after asking for 1000 cannot tell that from a log holding 100. The seam bounds the bytes it will read on top of that, and `truncated` says when either bound left something out.

`log_error` is the seam's own message, which never quotes the minted download URL — the adapter's message, which can name it and its single-use token, travels on `cause`, and `errorText` reads `message` only. There is a test asserting a token on `cause` does not reach the result.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test`, `yarn test:coverage` and `yarn build` all pass locally. `src/tools/vms.ts` is at 100% statements and branches; the global floors (branches 96 / statements 97) are unchanged and still met.

Three local review rounds ran the project's own reviewer (`local-review.py`, same rubric and threshold as the required check). Round three returned nothing at or above MEDIUM.

## What I did not change, and why

Three LOW findings from the final round, left for the review here and for a later ticket rather than fixed — each fix is a new diff, and a new diff is unreviewed:

- **`incusMatch` maps `read.value` outside the `attempt()` try** (round-two LOW), so a middleware answering a non-array would escape as a raw `TypeError` rather than the named "incus stack could not be read" failure. `vms_list` has the identical shape three lines away; fixing it here alone would make the two disagree about the same read. Worth doing to both, as one change.
- **"Ask again with the id of the one you mean" cannot resolve every ambiguity it is raised for** — a machine whose id equals another machine's name stays ambiguous under any spelling. The message lists every match with its id, so the caller can see the collision; there is no argument that separates them today.
- **Two test-strength notes**: the id-selector test's `toHaveBeenCalledWith` is satisfied by the numeric call alone, and no test covers `READ` with an empty `lines`. Both are worth adding; neither changes what the tool does.

`app/CLAUDE.md` is unchanged: this introduces no decision a later cycle could not read off the seam #72 already recorded, and nothing in it became false.
