### PR TITLE
feat(tools): add audit_config, the audit settings rather than the audit trail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,14 +135,28 @@ report over a subject the code defines gets a verdict, `UNKNOWN` and all; a
 report over a subject someone else defines gets facts and an `unreadable` list,
 and adding a verdict to the second is asserting a standard nobody supplied.
 
-The other half of the same rule is where a fact's real source is a setting no
-tool in this catalog reports. `fleet_compliance_report` is asked for "whether
-auditing is enabled"; the setting is `audit.config`, no tool reports it, and a
-composite adds no endpoint. So it reports what reading the trail can actually
-establish, under `auditing.recording`, named for the evidence rather than for the
-setting, true only where entries were seen and null everywhere else. **Name the
-field after what was measured, not after the question it was asked** — a
-`recording` that is null is honest, an `enabled` that is null reads as "off".
+The other half of the same rule is where a fact's real source is a setting the
+composite may not read. `fleet_compliance_report` is asked for "whether auditing
+is enabled"; the setting is `audit.config`, and a composite adds no endpoint. So
+it reports what reading the trail can actually establish, under
+`auditing.recording`, named for the evidence rather than for the setting, true
+only where entries were seen and null everywhere else. **Name the field after
+what was measured, not after the question it was asked** — a `recording` that is
+null is honest, an `enabled` that is null reads as "off".
+
+`audit_config` reports that setting directly since #83, and the composite still
+does not read it: the caller is pointed at the tool rather than having its answer
+folded into `recording`, which would make one field mean two things. **A later
+tool answering the question a field was named around does not license renaming
+the field** — `recording` is still what this report measured.
+
+The same rule reaches the new tool, one level down. `audit.config`'s
+`enabled_services` names every service the middleware CAN audit whether or not
+any is switched on — the client declares all three members required — so
+`audit_config` reports it as `services`, and the one positive claim in that
+section is a non-empty `scope`. **A field named for the API field it came from
+inherits that field's promise**, which here is a promise the payload does not
+keep.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `system_update_status`, `audit_log_query`,
+  `system_info`, `system_update_status`, `audit_log_query`, `audit_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
   `vms_list`, `vm_logs`, `alerts_list`, `snapshots_list`, `replication_status`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
   systemInfo,
   updateStatus,
   auditLogQuery,
+  auditConfig,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -263,13 +263,15 @@ export const haStatus: ReadOnlyTool = {
  * and a tool that answered `COMPLIANT` would be asserting one. So this reports
  * facts, names what it could not read, and stops there.
  *
- * The one place that is hard to hold to is auditing. The setting itself —
- * `audit.config`'s `enabled_services` — has no tool in this catalog, and a
- * composite adds no endpoint of its own, so what can be established from here is
- * narrower: the trail was read, and it either held entries or did not. That is
- * reported as what it is, under a field named for the evidence rather than for
- * the setting, because "the trail is empty" and "auditing is off" are the two
- * answers a compliance report must never merge.
+ * The one place that is hard to hold to is auditing. A composite adds no
+ * endpoint of its own, so what can be established from here is narrower than
+ * the question asked: the trail was read, and it either held entries or did
+ * not. That is reported as what it is, under a field named for the evidence
+ * rather than for the setting, because "the trail is empty" and "auditing is
+ * off" are the two answers a compliance report must never merge. `audit_config`
+ * reports the setting itself (#83) and this section is unchanged by it — the
+ * caller is pointed at that tool rather than having its answer folded in, which
+ * would make one field mean two things.
  */
 
 /**
@@ -410,8 +412,11 @@ function auditRead(answer: unknown): AuditRead {
  * report can actually support. Everything else is null, and null is emphatically
  * not "auditing is off" — a system nobody touched inside the window records
  * nothing and looks identical to one that is not auditing at all. The setting
- * that would tell them apart is `audit.config`, which no tool in this catalog
- * reports and which a composite may not reach for itself.
+ * that would tell them apart is `audit.config`. `audit_config` reports it (#83)
+ * and this section still does not read it: a composite adds no endpoint of its
+ * own, and folding a second tool's answer in here would make `recording` mean
+ * two things at once. The caller is pointed at that tool instead, which is what
+ * the description does.
  *
  * True is also WEAKER THAN IT LOOKS on the `MIDDLEWARE` trail, and that is a
  * property of the arrangement rather than of this code: every tool in this
@@ -920,9 +925,9 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
     'nothing and is indistinguishable from a system that is not auditing at ' +
     'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
-    'that setting is `audit.config` on the middleware, no tool in this catalog ' +
-    'reports it, and a null `recording` is a question to put to the system ' +
-    'directly rather than an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
+    'that setting is `audit.config` on the middleware, and `audit_config` is ' +
+    'the tool that reads it. CALL IT ON A NULL `recording` rather than reading ' +
+    'the null as an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
     '`MIDDLEWARE` TRAIL: every tool in this catalog reaches the system through ' +
     'the middleware API, so a call this assistant makes lands in the trail this ' +
     'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,16 +20,17 @@ import {
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
-import { auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
+import { auditConfig, auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-six read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-seven read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(updateStatus);
   catalog.register(auditLogQuery);
+  catalog.register(auditConfig);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -71,6 +72,7 @@ export {
   alertSettings,
   alertsList,
   appsList,
+  auditConfig,
   auditLogQuery,
   certificatesList,
   cloudCredentialsList,

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -193,6 +193,22 @@ export const updateStatus: ReadOnlyTool = {
   },
 };
 
+/** A number the system reported, or null where it reported anything else. */
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * A record the system sent, or null where it sent anything else — an array
+ * included, which is an object and is never one of the keyed payloads this is
+ * used to read.
+ */
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 /**
  * How far back `audit_log_query` reaches when the caller bounds nothing.
  *
@@ -617,6 +633,135 @@ export const auditLogQuery: ReadOnlyTool = {
       // The bound actually applied, so that an empty result is readable against
       // the window it was taken from rather than against an assumed one.
       since: new Date(since).toISOString(),
+    };
+  },
+};
+
+/**
+ * The things the system listed beside one service, as names — or null where it
+ * listed something this tool cannot read as one.
+ *
+ * All-or-nothing rather than per-entry: an entry that could not be read is
+ * dropped from a list only by making the whole list null, because a list
+ * silently missing one share reads as a share that is not audited, which is the
+ * opposite of what is known about it. The same reading `audit_log_query` applies
+ * to a filter it could not check.
+ */
+function scopeNames(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const names: string[] = [];
+  for (const entry of value) {
+    const name = textOrNull(entry);
+    if (name === null) return null;
+    names.push(name);
+  }
+  return names;
+}
+
+/**
+ * What the system is configured to audit, as it reports it, or null where it
+ * sent no configuration this tool could read.
+ *
+ * A service is reported under the name the system spelled it with, so a service
+ * a later TrueNAS release begins auditing is answerable here without a change —
+ * these are values rather than fields, and the allowlist this file keeps is over
+ * the fields of the result.
+ *
+ * Sorted by name, because the middleware sends a keyed object and the order of
+ * its keys means nothing; leaving it alone would make the result differ between
+ * two reads of the same unchanged configuration.
+ */
+function enabledServices(value: unknown): { service: string; scope: string[] | null }[] | null {
+  const services = recordOrNull(value);
+  if (services === null) return null;
+  return Object.keys(services)
+    .filter((name) => name.length > 0)
+    .sort()
+    .map((service) => ({ service, scope: scopeNames(services[service]) }));
+}
+
+/**
+ * What the system is auditing, rather than what it audited.
+ *
+ * The counterpart to `audit_log_query`, and the distinction between them is the
+ * whole point: the trail says what was recorded, and reading it can never
+ * establish that a service is NOT being audited — a service nobody is auditing
+ * and a service nobody has used both record nothing. `fleet_compliance_report`
+ * says exactly that about its own `auditing` section, which is why this tool
+ * exists. The setting is the only place the answer is stated rather than
+ * inferred.
+ *
+ * Reads the configuration and does not change it. `audit.update` is the
+ * mutating counterpart and is not in this catalog.
+ */
+export const auditConfig: ReadOnlyTool = {
+  name: 'audit_config',
+  description:
+    'The audit SETTINGS of a TrueNAS system — what it is configured to audit, ' +
+    'whether audit records are also shipped off the box, how long they are ' +
+    'kept, and how much room the audit dataset has left. This is the ' +
+    'configuration, NOT the trail: for what was actually recorded, and by ' +
+    'whom, that is `audit_log_query`. The two answer different questions and ' +
+    'reading one for the other is the mistake this tool exists to prevent — an ' +
+    'empty trail cannot establish that a service is unaudited, because a ' +
+    'service nobody audits and a service nobody has used both record nothing. ' +
+    '`enabled_services` is what the system lists under its audit ' +
+    'configuration, one entry per service, sorted by name. `service` is the ' +
+    'name as the system spelled it — `MIDDLEWARE` for the API the web UI, the ' +
+    'CLI and this tool all call, `SMB` for file share access, `SUDO` for ' +
+    'commands run as another user, and a name a later TrueNAS release adds is ' +
+    'passed through as the system spelled it. `scope` is what the system ' +
+    'listed beside that service, such as the SMB shares being audited; it is ' +
+    'an empty list where the system listed nothing beside it, and null where ' +
+    'it listed something this tool could not read as names. AN EMPTY `scope` ' +
+    'IS NOT "NOT AUDITED" — (unconfirmed) whether a service listing nothing is ' +
+    'auditing everything or nothing is not established by this read, and only ' +
+    'a non-empty `scope` says which named things are covered. ' +
+    '`enabled_services` ITSELF IS NULL WHERE THE SYSTEM REPORTED NO SERVICE ' +
+    'CONFIGURATION THIS TOOL COULD READ, and an empty list means the system ' +
+    'reported the configuration and listed no services in it — those are ' +
+    'different answers and null is never to be read as the empty one. ' +
+    '`remote_logging_enabled` is whether audit records are also sent to a ' +
+    'remote destination, and it is THREE-VALUED: true, false, or null where ' +
+    'the system reported no value this tool could read. Null is NOT false — ' +
+    'nothing has been established about off-box logging. Where the remote ' +
+    'destination is, and whether it is reachable, are not reported here. ' +
+    '`retention_days` is how many days audit entries are kept before the ' +
+    'system removes them, and is null where the system reported no number this ' +
+    'tool could read. `space_available_bytes` is how much room the audit ' +
+    'dataset has left, in bytes, and is null on the same terms. It does not ' +
+    'say how long that room lasts: that depends on how busy the system is, ' +
+    'which this tool does not read. This tool reads configuration. It does not ' +
+    'change what is audited, how long entries are kept, or anything else — ' +
+    'that is `audit.update`, and it is not in this catalog. A configuration ' +
+    'that could not be read at all is an error naming what the system said, ' +
+    'not a result of nulls.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const config = await firstValueFrom(system.client.api.call('audit.config'));
+    // The payload is read through this guard rather than reached into, because
+    // a system answering the call with something that is not a configuration
+    // would otherwise throw on the first property access — and the error a
+    // caller then sees names a property rather than the read that failed.
+    const settings = recordOrNull(config);
+    if (settings === null) {
+      throw new Error('audit.config did not answer with an audit configuration');
+    }
+    // Named one at a time, so a field a later TrueNAS release adds to the audit
+    // configuration does not appear in this result without a change here.
+    const space = recordOrNull(settings['space']);
+    return {
+      enabled_services: enabledServices(settings['enabled_services']),
+      // Not defaulted to false: a system that reported no value has not been
+      // shown to be keeping its audit records on the box.
+      remote_logging_enabled:
+        typeof settings['remote_logging_enabled'] === 'boolean'
+          ? settings['remote_logging_enabled']
+          : null,
+      retention_days: numberOrNull(settings['retention']),
+      space_available_bytes: space === null ? null : numberOrNull(space['available']),
     };
   },
 };

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -490,10 +490,11 @@ export const auditLogQuery: ReadOnlyTool = {
     'service the system is not auditing records nothing at all and so returns ' +
     'nothing here, which is indistinguishable from a quiet system: this tool ' +
     'reads the trail and cannot say whether a service is being written to it. ' +
-    'A trail that could not be read at all is an error naming what the system ' +
-    'said, not an empty list. This tool reads the audit trail. It does not ' +
-    'change what is audited, how long entries are kept, or anything else — ' +
-    'that is configuration, and it is not in this catalog.',
+    '`audit_config` reads the settings behind that question. A trail that ' +
+    'could not be read at all is an error naming what the system said, not an ' +
+    'empty list. This tool reads the audit trail. It does not change what is ' +
+    'audited, how long entries are kept, or anything else — that is ' +
+    'configuration, and `audit_config` reads it without changing it either.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -659,25 +660,40 @@ function scopeNames(value: unknown): string[] | null {
 }
 
 /**
- * What the system is configured to audit, as it reports it, or null where it
- * sent no configuration this tool could read.
+ * The services the system keeps audit configuration for, with what it listed
+ * beside each — or null where it sent no service configuration this tool could
+ * read.
+ *
+ * This is deliberately NOT read as "the services being audited", and the field
+ * it becomes is not named that way. The pinned client declares `MIDDLEWARE`,
+ * `SMB` and `SUDO` as required members of `enabled_services`, so all three are
+ * present on a system auditing none of them: presence is the middleware
+ * enumerating what it can audit, and it does not establish that any of it is
+ * switched on. Naming the field for the setting would state exactly the
+ * guarantee the read cannot deliver, which is what `app/CLAUDE.md` records as
+ * this repository's most common defect — and what `fleet_compliance_report`
+ * avoided by naming its own field `recording` after the evidence.
  *
  * A service is reported under the name the system spelled it with, so a service
  * a later TrueNAS release begins auditing is answerable here without a change —
  * these are values rather than fields, and the allowlist this file keeps is over
  * the fields of the result.
  *
+ * A name the system sent that this tool cannot read nulls the whole list, on
+ * the same all-or-nothing reading {@link scopeNames} takes of a scope and for
+ * the same reason: a list quietly one service shorter reads as a service the
+ * system does not audit, which is more than the read established.
+ *
  * Sorted by name, because the middleware sends a keyed object and the order of
  * its keys means nothing; leaving it alone would make the result differ between
  * two reads of the same unchanged configuration.
  */
-function enabledServices(value: unknown): { service: string; scope: string[] | null }[] | null {
+function configuredServices(value: unknown): { service: string; scope: string[] | null }[] | null {
   const services = recordOrNull(value);
   if (services === null) return null;
-  return Object.keys(services)
-    .filter((name) => name.length > 0)
-    .sort()
-    .map((service) => ({ service, scope: scopeNames(services[service]) }));
+  const names = Object.keys(services);
+  if (names.some((name) => name.length === 0)) return null;
+  return names.sort().map((service) => ({ service, scope: scopeNames(services[service]) }));
 }
 
 /**
@@ -705,22 +721,26 @@ export const auditConfig: ReadOnlyTool = {
     'reading one for the other is the mistake this tool exists to prevent — an ' +
     'empty trail cannot establish that a service is unaudited, because a ' +
     'service nobody audits and a service nobody has used both record nothing. ' +
-    '`enabled_services` is what the system lists under its audit ' +
-    'configuration, one entry per service, sorted by name. `service` is the ' +
-    'name as the system spelled it — `MIDDLEWARE` for the API the web UI, the ' +
-    'CLI and this tool all call, `SMB` for file share access, `SUDO` for ' +
-    'commands run as another user, and a name a later TrueNAS release adds is ' +
-    'passed through as the system spelled it. `scope` is what the system ' +
-    'listed beside that service, such as the SMB shares being audited; it is ' +
-    'an empty list where the system listed nothing beside it, and null where ' +
-    'it listed something this tool could not read as names. AN EMPTY `scope` ' +
-    'IS NOT "NOT AUDITED" — (unconfirmed) whether a service listing nothing is ' +
-    'auditing everything or nothing is not established by this read, and only ' +
-    'a non-empty `scope` says which named things are covered. ' +
-    '`enabled_services` ITSELF IS NULL WHERE THE SYSTEM REPORTED NO SERVICE ' +
-    'CONFIGURATION THIS TOOL COULD READ, and an empty list means the system ' +
-    'reported the configuration and listed no services in it — those are ' +
-    'different answers and null is never to be read as the empty one. ' +
+    '`services` is one entry per service the system keeps audit configuration ' +
+    'for, sorted by name. `service` is the name as the system spelled it — ' +
+    '`MIDDLEWARE` for the API the web UI, the CLI and this tool all call, ' +
+    '`SMB` for file share access, `SUDO` for commands run as another user, and ' +
+    'a name a later TrueNAS release adds is passed through as the system ' +
+    'spelled it. BEING LISTED HERE IS NOT "THIS SERVICE IS AUDITED": the ' +
+    'system enumerates every service it CAN audit, and reports all of them ' +
+    'whether or not any is switched on, so this tool cannot tell you from this ' +
+    'field alone that a service is being audited. `scope` is what the system ' +
+    'listed beside that service, such as the SMB shares being audited. A ' +
+    'NON-EMPTY `scope` IS THE ONE POSITIVE ANSWER HERE — it names things the ' +
+    'system says it audits for that service. An empty `scope` is the system ' +
+    'listing nothing beside it, and (unconfirmed) that establishes neither ' +
+    'that the service audits everything nor that it audits nothing. `scope` is ' +
+    'null where the system listed something this tool could not read as names, ' +
+    'which is not an empty scope. `services` ITSELF IS NULL WHERE THE SYSTEM ' +
+    'REPORTED NO SERVICE CONFIGURATION THIS TOOL COULD READ, and an empty list ' +
+    'means the system reported the configuration and named no services in it — ' +
+    'those are different answers and null is never to be read as the empty ' +
+    'one. ' +
     '`remote_logging_enabled` is whether audit records are also sent to a ' +
     'remote destination, and it is THREE-VALUED: true, false, or null where ' +
     'the system reported no value this tool could read. Null is NOT false — ' +
@@ -753,7 +773,7 @@ export const auditConfig: ReadOnlyTool = {
     // configuration does not appear in this result without a change here.
     const space = recordOrNull(settings['space']);
     return {
-      enabled_services: enabledServices(settings['enabled_services']),
+      services: configuredServices(settings['enabled_services']),
       // Not defaulted to false: a system that reported no value has not been
       // shown to be keeping its audit records on the box.
       remote_logging_enabled:

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -941,11 +941,11 @@ describe('audit_config', () => {
 
   /** The services of a result, which is what most cases here are about. */
   const services = async (enabled: unknown): Promise<unknown> =>
-    (await read({ enabled_services: enabled }))['enabled_services'];
+    (await read({ enabled_services: enabled }))['services'];
 
   it('reports the settings through named fields and drops the rest', async () => {
     expect(await read()).toEqual({
-      enabled_services: [
+      services: [
         { service: 'MIDDLEWARE', scope: [] },
         { service: 'SMB', scope: ['audited-share'] },
         { service: 'SUDO', scope: [] },
@@ -988,8 +988,23 @@ describe('audit_config', () => {
     expect(await services({ SMB: 'audited-share' })).toEqual([{ service: 'SMB', scope: null }]);
   });
 
-  it('does not report a service the system named with nothing', async () => {
-    expect(await services({ '': [], SMB: [] })).toEqual([{ service: 'SMB', scope: [] }]);
+  it('nulls the whole list rather than dropping a service it could not name', async () => {
+    // The same all-or-nothing reading a scope takes: a list quietly one service
+    // shorter reads as a service the system does not audit.
+    expect(await services({ '': [], SMB: [] })).toBeNull();
+  });
+
+  it('does not claim a listed service is audited', async () => {
+    // The middleware enumerates what it CAN audit — the pinned client declares
+    // all three members required — so presence is not enablement, and the
+    // description says so rather than the field name implying otherwise.
+    const listed = await services({ MIDDLEWARE: [], SMB: [], SUDO: [] });
+    expect(listed).toEqual([
+      { service: 'MIDDLEWARE', scope: [] },
+      { service: 'SMB', scope: [] },
+      { service: 'SUDO', scope: [] },
+    ]);
+    expect(auditConfig.description).toContain('BEING LISTED HERE IS NOT "THIS SERVICE IS AUDITED"');
   });
 
   it('reports remote logging three-valued, and never defaults it to false', async () => {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -8,6 +8,7 @@ import {
   alertSettings,
   alertsList,
   appsList,
+  auditConfig,
   auditLogQuery,
   certificatesList,
   cloudCredentialsList,
@@ -86,11 +87,12 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-seven sketch tools', () => {
+  it('registers the thirty-eight sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
       'audit_log_query',
+      'audit_config',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -126,6 +128,10 @@ describe('createDefaultCatalog', () => {
       'fleet_compliance_report',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises audit_config to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('audit_config');
   });
 
   it('advertises fleet_compliance_report to a read-only credential', () => {
@@ -898,6 +904,140 @@ describe('audit_log_query', () => {
     const { ctx, call, query } = fakeSystem({ ['audit.query']: [entry()] });
     await auditLogQuery.handler(ctx, {});
     expect(call.mock.calls.map((args) => args[0])).toEqual(['audit.query']);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('audit_config', () => {
+  /**
+   * The configuration as `audit.config` sends one, carrying the fields the
+   * pinned client's `AuditEntry` declares — including the several this tool
+   * deliberately does not report, so that the test that they do not survive the
+   * mapping is worth something.
+   */
+  const config = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    retention: 30,
+    reservation: 0,
+    quota: 0,
+    quota_fill_warning: 70,
+    quota_fill_critical: 95,
+    remote_logging_enabled: false,
+    space: {
+      used: 1_000,
+      used_by_dataset: 900,
+      used_by_reservation: 0,
+      used_by_snapshots: 100,
+      available: 4_000_000,
+    },
+    enabled_services: { MIDDLEWARE: [], SMB: ['audited-share'], SUDO: [] },
+    ...over,
+  });
+
+  const read = async (over: Record<string, unknown> = {}): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['audit.config']: config(over) });
+    return (await auditConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  /** The services of a result, which is what most cases here are about. */
+  const services = async (enabled: unknown): Promise<unknown> =>
+    (await read({ enabled_services: enabled }))['enabled_services'];
+
+  it('reports the settings through named fields and drops the rest', async () => {
+    expect(await read()).toEqual({
+      enabled_services: [
+        { service: 'MIDDLEWARE', scope: [] },
+        { service: 'SMB', scope: ['audited-share'] },
+        { service: 'SUDO', scope: [] },
+      ],
+      remote_logging_enabled: false,
+      retention_days: 30,
+      space_available_bytes: 4_000_000,
+    });
+  });
+
+  it('sorts services by name, so an unchanged configuration reads the same twice', async () => {
+    // The middleware sends a keyed object, whose key order says nothing.
+    expect(await services({ SUDO: [], MIDDLEWARE: [], SMB: [] })).toEqual([
+      { service: 'MIDDLEWARE', scope: [] },
+      { service: 'SMB', scope: [] },
+      { service: 'SUDO', scope: [] },
+    ]);
+  });
+
+  it('passes through a service name the pinned client does not know', async () => {
+    // Service names are values rather than fields, so a service a later
+    // TrueNAS release begins auditing is answerable without a change here.
+    expect(await services({ NFS: ['export'] })).toEqual([{ service: 'NFS', scope: ['export'] }]);
+  });
+
+  it('distinguishes a configuration listing no services from one it could not read', async () => {
+    // The distinction the criterion is about: an empty list is an answer, and
+    // null is the absence of one.
+    expect(await services({})).toEqual([]);
+    for (const unreadable of [null, undefined, 'MIDDLEWARE', 42, ['MIDDLEWARE']]) {
+      expect(await services(unreadable)).toBeNull();
+    }
+  });
+
+  it('nulls a whole scope rather than dropping the entry it could not read', async () => {
+    // A list silently missing one share reads as a share that is not audited,
+    // which is the opposite of what is known about it.
+    expect(await services({ SMB: ['kept', 7] })).toEqual([{ service: 'SMB', scope: null }]);
+    expect(await services({ SMB: ['kept', ''] })).toEqual([{ service: 'SMB', scope: null }]);
+    expect(await services({ SMB: 'audited-share' })).toEqual([{ service: 'SMB', scope: null }]);
+  });
+
+  it('does not report a service the system named with nothing', async () => {
+    expect(await services({ '': [], SMB: [] })).toEqual([{ service: 'SMB', scope: [] }]);
+  });
+
+  it('reports remote logging three-valued, and never defaults it to false', async () => {
+    // A system that reported no value has not been shown to be keeping its
+    // audit records on the box.
+    expect((await read({ remote_logging_enabled: true }))['remote_logging_enabled']).toBe(true);
+    expect((await read({ remote_logging_enabled: false }))['remote_logging_enabled']).toBe(false);
+    for (const unreadable of [null, undefined, 'true', 1]) {
+      expect((await read({ remote_logging_enabled: unreadable }))['remote_logging_enabled']).toBe(
+        null,
+      );
+    }
+  });
+
+  it('nulls the retention the system reported no number for', async () => {
+    expect((await read({ retention: 0 }))['retention_days']).toBe(0);
+    for (const unreadable of [null, undefined, '30', Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect((await read({ retention: unreadable }))['retention_days']).toBeNull();
+    }
+  });
+
+  it('nulls the remaining space where the system reported none it could read', async () => {
+    expect((await read({ space: { available: 0 } }))['space_available_bytes']).toBe(0);
+    for (const unreadable of [null, undefined, {}, { available: '4000' }, []]) {
+      expect((await read({ space: unreadable }))['space_available_bytes']).toBeNull();
+    }
+  });
+
+  it('fails rather than answering nulls when the payload is not a configuration', async () => {
+    // Reached into rather than guarded, this would throw naming a property
+    // rather than the read that failed.
+    for (const answer of [null, undefined, 'audit', 7, []]) {
+      const { ctx } = fakeSystem({ ['audit.config']: answer });
+      await expect(auditConfig.handler(ctx, {})).rejects.toThrow(
+        'audit.config did not answer with an audit configuration',
+      );
+    }
+  });
+
+  it('fails rather than answering empty when the configuration could not be read', async () => {
+    const { ctx } = failingSystem({}, { ['audit.config']: new Error('audit dataset not mounted') });
+    await expect(auditConfig.handler(ctx, {})).rejects.toThrow('audit dataset not mounted');
+  });
+
+  it('never mutates: it reads the configuration and nothing else', async () => {
+    const { ctx, call, query } = fakeSystem({ ['audit.config']: config() });
+    await auditConfig.handler(ctx, {});
+    expect(call.mock.calls.map((args) => args[0])).toEqual(['audit.config']);
     expect(query).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Adds `audit_config`, a read-only tool reporting the audit **settings** of a system, beside `auditLogQuery` in `src/tools/system.ts`.

Fixes #83

## Why this is a tool rather than a change inside the composite

`audit_log_query` reads the trail, and reading the trail can never establish that a service is *not* being audited — a service nobody audits and a service nobody has used both record nothing. `fleet_compliance_report` says exactly that about its own `auditing` section, and PR #82 reports `recording` (evidence) rather than `enabled` (setting) for that reason. The setting is where the answer is stated rather than inferred, and a composite adds no endpoint of its own (the #44 decision), so it takes a real tool.

`fleet_compliance_report` is **unchanged** by this. Folding the setting into `recording` would make one field mean two things; the caller is pointed at `audit_config` instead.

## What it reports

`audit.config` — on `DefaultApiDirectory`, so no widening of the supported surface — mapped through four named fields:

| field | |
|---|---|
| `services` | one entry per service the system keeps audit configuration for, sorted by name, each with the `scope` the system listed beside it |
| `remote_logging_enabled` | three-valued — true, false, or null where the system reported no value this tool could read |
| `retention_days` | how long entries are kept; null where unreadable |
| `space_available_bytes` | how much room the audit dataset has left; null where unreadable |

Nothing else of the payload survives the mapping — `id`, `reservation`, `quota`, `quota_fill_warning`, `quota_fill_critical` and the four `space` members beside `available` are all dropped, and a test feeds them in to prove it.

## The one place this answers less than the ticket asked

The ticket's first acceptance criterion is "reports which services the system is auditing". **This read cannot establish that, and the tool does not claim to.**

The pinned client declares `MIDDLEWARE`, `SMB` and `SUDO` as *required* members of `enabled_services`, so all three are present on a system auditing none of them — the field enumerates what the middleware *can* audit. A field called `enabled_services` would therefore promise exactly what the payload does not deliver, which is this repository's most common review finding. The first round of local review flagged it as a MEDIUM and it is fixed rather than argued: the field is `services`, and the description says plainly that being listed is not being audited, and that a **non-empty `scope`** — the SMB shares actually named, for instance — is the one positive answer in the section.

The rest of that criterion is met: `services` is `null` where the system reported no service configuration this tool could read, and `[]` where it reported the configuration and named nothing in it, and those are documented as different answers. `(unconfirmed)` in the description marks what an empty `scope` means — whether such a service audits everything or nothing is not established by this read, and neither reading is asserted.

Anyone who wants the stronger claim needs a second source (`sharing.smb.query` carries a per-share `audit` flag). That is a different ticket and is not attempted here.

## Documentation this change made false

Three descriptions and two JSDoc blocks said no tool in this catalog reports `audit.config`. Each was true when written, and this PR is what makes it false, so each is corrected in place rather than left to contradict the catalog: `audit_log_query`'s closing sentence, `fleet_compliance_report`'s `auditing` paragraph, `fleet.ts`'s two JSDoc blocks, and the #47 decision in `app/CLAUDE.md`.

`app/CLAUDE.md` also gains the rule this ticket produced, since a later cycle would otherwise guess wrong: **a field named for the API field it came from inherits that field's promise**, and a later tool answering the question a field was named around does not license renaming that field.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run locally and pass — every gating job in `.github/workflows/ci.yml`. 806 tests; coverage 99.66 statements / 99.36 branches against floors of 97 / 96.

Two rounds of the project's own reviewer ran here in a separate process (exit 1 then exit 0), so this is the check's own rubric and threshold rather than a subagent's reading of a brief. Round 1 returned three MEDIUMs, all fixed above. Round 2 returned nothing at or above MEDIUM.

## Round 2's LOWs, left unfixed

Reported here rather than acted on, since fixing a LOW makes a new unreviewed diff:

- `system.ts` — `space === null ? null : numberOrNull(space['available'])` could be `numberOrNull(space?.['available'])`, which is the sibling form at `network.ts:351`. Equivalent; the explicit branch reads as the guard it is.
- `system.ts` — `(unconfirmed)` is a repo-internal marker and every other use of it is in a JSDoc rather than in a shipped description. **This one is worth a second opinion**: the marker is load-bearing exactly where it sits — it is what stops a model reading an empty `scope` as an answer — but the reviewer is right that a caller has no way to know what the convention means. A follow-up could spell it out in words instead.
- `tools.spec.ts` — the `does not claim a listed service is audited` case asserts on description prose, so rewording the description fails a test named for mapping behaviour. Deliberate: the description carries the guarantee the field name deliberately does not, and nothing else would catch it being softened. It is brittle in the way the reviewer says.
