### PR TITLE
feat(tools): add fleet_health_rollup, one health verdict per system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,31 @@ section is a non-empty `scope`. **A field named for the API field it came from
 inherits that field's promise**, which here is a promise the payload does not
 keep.
 
+### A fleet-wide tool is still written single-system (#46)
+
+`fleet_health_rollup` answers "which of my systems needs attention" across the
+whole registry, and its handler takes one `SystemHandle` like every other. The
+fleet dimension is the executor's fan-out: it runs a handler once per target,
+labels each result with the system it came from, and reports a call it could not
+run at all as an `ERROR` entry rather than dropping it. **A tool whose name says
+"fleet" is not a reason to reach for the registry or to start its own
+concurrency** — that would duplicate `fanOut` and lose the partial-failure
+reporting that comes with it.
+
+What such a tool owes instead is a row that is worth collecting: small, fixed in
+size regardless of how big the system is, and carrying the system's own name so
+rows stay attributable once flattened. Measured on the bundle, over a registry of
+eight-pool systems: 573 bytes a row against 4,642 for the full
+`system_health_report`, and flat as the system grows.
+
+The second half is what it drops. `fleet_health_rollup` composes
+`system_health_report` — a composite over a composite — and keeps the verdict,
+the counts behind it and the worst three reasons, discarding every section. It
+re-judges nothing: no threshold, band or severity is read a second time, because
+a rollup that scored health its own way would be the drifting second opinion
+composites exist to prevent. **Summarise by dropping fields, never by
+recomputing them**, and point the caller at the composed tool for the detail.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
   `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
   `reporting_app_vm_usage`, `ha_status`, `system_health_report`,
-  `fleet_compliance_report`.
+  `fleet_compliance_report`, `fleet_health_rollup`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,5 +114,6 @@ export {
   haStatus,
   systemHealthReport,
   fleetComplianceReport,
+  fleetHealthRollup,
   createSnapshot,
 } from '@/tools/index';

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -8,7 +8,7 @@ import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 // this one, so there is no cycle.
 import { directoryServicesStatus } from '@/tools/accounts';
 import { certificatesList } from '@/tools/certificates';
-import { systemHealthReport } from '@/tools/reporting';
+import { HEALTH_SECTIONS, systemHealthReport } from '@/tools/reporting';
 import { sharesList } from '@/tools/shares';
 import { auditLogQuery, updateStatus } from '@/tools/system';
 
@@ -1186,13 +1186,6 @@ export const fleetComplianceReport: ReadOnlyTool = {
 const MAX_REASONS = 3;
 
 /**
- * The sections `system_health_report` carries, each of which can come back
- * unread. Named here so `sections_unreadable` is a count of something stated
- * rather than of prose parsed back out of the reasons.
- */
-const HEALTH_SECTIONS = ['pools', 'alerts', 'disks', 'updates'] as const;
-
-/**
  * The severities `system_health_report` states, WORST FIRST. Position is the
  * rank, so there is one place a severity can be added and no map that can
  * disagree with the order.
@@ -1347,6 +1340,9 @@ export const fleetHealthRollup: ReadOnlyTool = {
       reasons_reported: reasons.length,
       reasons: ordered.slice(0, MAX_REASONS),
       reasons_truncated: ordered.length > MAX_REASONS,
+      // The list comes from the report's own file rather than being restated
+      // here: a section added there has to be named in it to compile, so this
+      // count follows rather than drifting quietly one section behind.
       sections_total: HEALTH_SECTIONS.length,
       // Read off each section's own `unavailable` rather than off the reasons,
       // which state the same gap in prose.

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -1,11 +1,14 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
-// `fleet_compliance_report` is composite: it calls these five handlers rather
-// than the API, so that what it reports is by construction what those tools
-// report. None of the four files imports this one, so there is no cycle.
+// Both composites in this file call handlers rather than the API, so that what
+// they report is by construction what those tools report: `fleet_compliance_report`
+// reads five of them, and `fleet_health_rollup` reads `system_health_report`,
+// which is itself a composite over four more. None of the imported files imports
+// this one, so there is no cycle.
 import { directoryServicesStatus } from '@/tools/accounts';
 import { certificatesList } from '@/tools/certificates';
+import { systemHealthReport } from '@/tools/reporting';
 import { sharesList } from '@/tools/shares';
 import { auditLogQuery, updateStatus } from '@/tools/system';
 
@@ -1134,6 +1137,222 @@ export const fleetComplianceReport: ReadOnlyTool = {
         check_error: updates.value?.check_error ?? null,
         version_error: updates.value?.version_error ?? null,
       },
+    };
+  },
+};
+
+/**
+ * `fleet_health_rollup`: which of my systems needs attention, one short answer
+ * each.
+ *
+ * The third composite, and the one that composes another composite: it calls
+ * `system_health_report.handler` and adds no endpoint and no read of its own, so
+ * "healthy" here is by construction what that tool means by it — one
+ * normalization per subject, read through rather than restated.
+ *
+ * **The fleet dimension is the fan-out, not this tool.** Every handler in this
+ * catalog is written single-system and the executor runs it once per target
+ * (`fanOut`), which already returns one labelled result per system and reports a
+ * call it could not run at all as an `ERROR` entry rather than dropping it. So
+ * this is a per-system tool like every other, and a caller asking for `all` systems
+ * gets the registry-wide rollup the name promises. Adding a second concurrency
+ * path here would duplicate that and lose the partial-failure reporting that
+ * comes with it.
+ *
+ * **What it drops is the point.** `system_health_report` already answers one
+ * system thoroughly, at a size that is fine once and expensive ten times over. So
+ * this keeps the verdict, the counts behind it and the worst few reasons, and
+ * drops every section — the pools, the alerts, the devices, the versions. A row
+ * that names something is the cue to call `system_health_report` on THAT system,
+ * which is the round trip the fleet-wide call was avoiding for the other nine.
+ *
+ * **Nothing is re-judged here.** The verdict is passed through as that tool
+ * derived it and no threshold, band or severity is re-read: a rollup that scored
+ * health a second way would be the drifting second opinion composites exist to
+ * avoid. What this file adds is arithmetic over the reasons and a cap on the list.
+ */
+
+/**
+ * How many reasons a row names individually.
+ *
+ * Small on purpose, and smaller than the ten `system_health_report` and
+ * `fleet_compliance_report` each allow: this is read as one row among many, where
+ * three is about what a reader takes in per system before opening the full report
+ * on the one that looks worst. Every count is over EVERY reason, so the cap can
+ * drop the line describing a finding and can never drop the finding — the same
+ * rule both other composites follow, and the whole of why a fixed-size row is
+ * safe to act on.
+ */
+const MAX_REASONS = 3;
+
+/**
+ * The sections `system_health_report` carries, each of which can come back
+ * unread. Named here so `sections_unreadable` is a count of something stated
+ * rather than of prose parsed back out of the reasons.
+ */
+const HEALTH_SECTIONS = ['pools', 'alerts', 'disks', 'updates'] as const;
+
+/**
+ * The severities `system_health_report` states, WORST FIRST. Position is the
+ * rank, so there is one place a severity can be added and no map that can
+ * disagree with the order.
+ */
+const SEVERITIES = ['critical', 'warning', 'unknown'] as const;
+
+/**
+ * Which verdicts mean someone has to look, and which mean nobody does.
+ *
+ * `UNKNOWN` is deliberately absent rather than mapped to either: it is a report
+ * with a hole in it, so it has NOT been established that the system is fine and
+ * it has NOT been established that anything is wrong. A verdict missing from this
+ * map answers null, which is the same reading applied to a verdict a later
+ * release of that tool might add.
+ */
+const ATTENTION = new Map<string | null, boolean>([
+  ['CRITICAL', true],
+  ['WARNING', true],
+  ['OK', false],
+]);
+
+/** One finding, carried forward exactly as `system_health_report` stated it. */
+interface RollupReason {
+  section: string | null;
+  severity: string | null;
+  detail: string | null;
+}
+
+/**
+ * Where a severity sits in {@link SEVERITIES}, or -1 for one this rollup does not
+ * rank.
+ *
+ * -1 sorts a reason FIRST, ahead of `critical`, which is the conservative
+ * direction: a severity this rollup cannot place has not been shown to be
+ * harmless, and putting it where the cap could hide it would be reading an
+ * unrecognised finding as a mild one.
+ */
+function severityRank(severity: unknown): number {
+  return (SEVERITIES as readonly unknown[]).indexOf(severity);
+}
+
+/** How many of `reasons` stand at one severity. Over every reason, never the listed few. */
+function countAt(reasons: RollupReason[], severity: string): number {
+  return reasons.filter((reason) => reason.severity === severity).length;
+}
+
+export const fleetHealthRollup: ReadOnlyTool = {
+  name: 'fleet_health_rollup',
+  description:
+    'One call that answers "which of my TrueNAS systems needs attention": one ' +
+    'health verdict per system, with the worst few reasons behind it and ' +
+    'nothing else. Run it across the fleet and each system answers separately, ' +
+    'as one short row. IT COMPOSES `system_health_report` AND ADDS NOTHING OF ' +
+    'ITS OWN — same verdict, same reasons, same thresholds, nothing re-judged ' +
+    'here — AND IT DELIBERATELY DROPS EVERY SECTION OF THAT REPORT: no pools, no ' +
+    'alerts, no devices, no versions. A ROW NAMING SOMETHING IS THE CUE TO CALL ' +
+    '`system_health_report` ON THAT SYSTEM for the detail; that is the round trip ' +
+    'this call is avoiding for all the systems that named nothing. `system` is ' +
+    'the system this row is about, repeated in the row so that rows collected ' +
+    'from several systems stay attributable one by one. A SYSTEM THAT COULD NOT ' +
+    'BE REACHED IS NEVER SILENTLY ABSENT AND IS ANSWERED HERE RATHER THAN AS A ' +
+    'FAILED CALL: every read beneath it fails, so it comes back as an ordinary ' +
+    'row with `verdict` `UNKNOWN`, `needs_attention` null, `sections_unreadable` ' +
+    'equal to `sections_total`, and a reason per section naming what the system ' +
+    'said. THAT ROW IS NOT A HEALTHY SYSTEM. Separately, the multi-system fan-out ' +
+    'labels every row with the system it came from and reports a system whose ' +
+    'call could not be run at all as a failed result carrying the error, so no ' +
+    'system in the registry is missing from the answer either way. `verdict` is ' +
+    '`system_health_report`\'s own verdict ' +
+    'passed through verbatim: `CRITICAL` where something is already broken, ' +
+    '`WARNING` where something needs attention before it breaks, `UNKNOWN` where ' +
+    'nothing bad was found AND SOMETHING COULD NOT BE ESTABLISHED, and `OK` — ' +
+    'which is the narrow claim that every section was read and none raised ' +
+    'anything. `UNKNOWN` IS NEVER "HEALTHY". `verdict` is null only where that ' +
+    'report named no verdict this rollup could read, which is itself not a ' +
+    'healthy answer. `needs_attention` IS THE FIELD TO SORT AND FILTER A FLEET ' +
+    'ON, so that a system needing work is told from a healthy one by a field ' +
+    'rather than by reading prose: true at `CRITICAL` and `WARNING`, FALSE ONLY ' +
+    'AT `OK`, and NULL AT `UNKNOWN` AND AT ANY VERDICT THIS ROLLUP DOES NOT ' +
+    'RANK. NULL IS NOT FALSE — it is a system whose health was not established, ' +
+    'and treating it as healthy is exactly the fail-open the `UNKNOWN` verdict ' +
+    'exists to prevent. TO ACT ON EVERYTHING NOT CONFIRMED HEALTHY, READ ' +
+    '`needs_attention !== false` RATHER THAN `=== true`. `reason_counts` counts ' +
+    'the findings behind the verdict over EVERY reason: `critical` is something ' +
+    'already broken, `warning` something to fix before it breaks, and `unknown` a ' +
+    'part of the report that could not be established — which is present at every ' +
+    'verdict, so a `CRITICAL` row still says which parts of itself are ' +
+    'incomplete. `unranked` counts findings at a severity this rollup does not ' +
+    'rank; it is 0 against every severity that report states today, and a nonzero ' +
+    'value means it has grown one, NOT that those findings were dropped — they ' +
+    'are in `reasons_reported` and sort FIRST in `reasons`. `reasons_reported` is ' +
+    'how many findings there are in total, and IT IS 0 ONLY WHEN `verdict` IS ' +
+    '`OK`. `reasons` names the worst of them individually, WORST FIRST, each with ' +
+    'the `severity`, the `section` of `system_health_report` that found it — ' +
+    '`pools`, `alerts`, `disks` or `updates` — and the `detail` in words. IT IS ' +
+    `CAPPED AT ${MAX_REASONS} ENTRIES, with \`reasons_truncated\` saying whether ` +
+    'anything was left out, so this list can drop the line describing a finding ' +
+    'and can never drop the finding, which is in the counts either way. ' +
+    '`sections_unreadable` is how many of the `sections_total` sections of ' +
+    '`system_health_report` could not be read at all on this system. IT IS NOT A ' +
+    'COUNT OF FAULTS — it is how much of the report is missing, so a nonzero ' +
+    'value means the verdict rests on an incomplete read, and a value equal to ' +
+    '`sections_total` is what a system that answered nothing at all looks like. ' +
+    'IT IS NOT A ' +
+    'COMPLETE MEASURE OF WHAT IS MISSING: a section can be read and still fail to establish ' +
+    'what it was asked for, which is a finding at `unknown` rather than an ' +
+    'unreadable section, so `reason_counts.unknown` is the field to read for how ' +
+    'much of this verdict is holes. This ' +
+    'tool only reads. It does not scrub, replace a disk, dismiss an alert, free ' +
+    'space or install an update on any system. NO field beyond those named here ' +
+    'is returned, whatever a later TrueNAS release adds to the underlying ' +
+    'responses.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler(ctx) {
+    const report = (await systemHealthReport.handler(ctx, {})) as Record<string, unknown>;
+    const verdict = textOrNull(report['verdict']);
+    // Mapped rather than walked, so a `reasons` that is not a list throws and
+    // fails THIS SYSTEM'S slice of the fan-out — which is reported as a failed
+    // result carrying the error — instead of reading as a system with nothing to
+    // report, which is the one wrong answer a rollup like this can give.
+    const reasons: RollupReason[] = (report['reasons'] as Record<string, unknown>[]).map(
+      (reason) => ({
+        section: textOrNull(reason['section']),
+        severity: textOrNull(reason['severity']),
+        detail: textOrNull(reason['detail']),
+      }),
+    );
+
+    const critical = countAt(reasons, 'critical');
+    const warning = countAt(reasons, 'warning');
+    const unknown = countAt(reasons, 'unknown');
+    // Ordered here rather than in the map, because this ordering is what makes
+    // the cap honest: the reasons that survive it are the worst ones. `sort` is
+    // stable, so reasons at the same severity keep the order the report gave.
+    const ordered = [...reasons].sort((a, b) => severityRank(a.severity) - severityRank(b.severity));
+
+    return {
+      system: ctx.system.name,
+      verdict,
+      needs_attention: ATTENTION.get(verdict) ?? null,
+      reason_counts: {
+        critical,
+        warning,
+        unknown,
+        // By subtraction rather than by a fourth pass, so that this and
+        // `reasons_reported` cannot disagree: every reason is in exactly one of
+        // the four counts however that report spells its severities.
+        unranked: reasons.length - critical - warning - unknown,
+      },
+      reasons_reported: reasons.length,
+      reasons: ordered.slice(0, MAX_REASONS),
+      reasons_truncated: ordered.length > MAX_REASONS,
+      sections_total: HEALTH_SECTIONS.length,
+      // Read off each section's own `unavailable` rather than off the reasons,
+      // which state the same gap in prose.
+      sections_unreadable: HEALTH_SECTIONS.filter(
+        (name) => textOrNull((report[name] as Record<string, unknown>)['unavailable']) !== null,
+      ).length,
     };
   },
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,7 @@ import { iscsiList, nvmeofList } from '@/tools/block';
 import { certificatesList } from '@/tools/certificates';
 import { cloudCredentialsList } from '@/tools/credentials';
 import { disksList } from '@/tools/disks';
-import { fleetComplianceReport, haStatus } from '@/tools/fleet';
+import { fleetComplianceReport, fleetHealthRollup, haStatus } from '@/tools/fleet';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus } from '@/tools/replication';
@@ -24,7 +24,7 @@ import { auditConfig, auditLogQuery, systemInfo, updateStatus } from '@/tools/sy
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-seven read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-eight read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -64,6 +64,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(haStatus);
   catalog.register(systemHealthReport);
   catalog.register(fleetComplianceReport);
+  catalog.register(fleetHealthRollup);
   catalog.register(createSnapshot);
   return catalog;
 }
@@ -81,6 +82,7 @@ export {
   directoryServicesStatus,
   disksList,
   fleetComplianceReport,
+  fleetHealthRollup,
   haStatus,
   iscsiList,
   listDatasets,

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -2219,8 +2219,20 @@ const DEVICE_FAILED = ['FAULTED', 'DEGRADED', 'OFFLINE', 'UNAVAIL', 'REMOVED'];
 /** How severe a finding is. `unknown` is "not established", never "fine". */
 type Severity = 'critical' | 'warning' | 'unknown';
 
-/** The four sections of the report, each backed by exactly one composed tool. */
-type SectionName = 'pools' | 'alerts' | 'disks' | 'updates';
+/**
+ * The sections of the report, each backed by exactly one composed tool and each
+ * carrying an `unavailable` of its own.
+ *
+ * Exported because `fleet_health_rollup` composes this report and counts how many
+ * of its sections could not be read: the list has to be declared once, or a
+ * section added here is one that rollup silently does not know about. {@link
+ * SectionName} is derived from it rather than written beside it, so a section
+ * that raises a reason without being named here does not compile.
+ */
+export const HEALTH_SECTIONS = ['pools', 'alerts', 'disks', 'updates'] as const;
+
+/** One section of the report. */
+type SectionName = (typeof HEALTH_SECTIONS)[number];
 
 /** One thing the report found, and which section found it. */
 interface Reason {

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -18,6 +18,7 @@ import {
   directoryServicesStatus,
   disksList,
   fleetComplianceReport,
+  fleetHealthRollup,
   haStatus,
   iscsiList,
   listDatasets,
@@ -87,7 +88,7 @@ function failingSystem(
 }
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-eight sketch tools', () => {
+  it('registers the thirty-nine sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -126,8 +127,15 @@ describe('createDefaultCatalog', () => {
       'ha_status',
       'system_health_report',
       'fleet_compliance_report',
+      'fleet_health_rollup',
       'snapshots_create',
     ]);
+  });
+
+  it('advertises fleet_health_rollup to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'fleet_health_rollup',
+    );
   });
 
   it('advertises audit_config to a read-only credential', () => {
@@ -11589,5 +11597,185 @@ describe('fleet_compliance_report', () => {
     expect(fleetComplianceReport.mutating).toBe(false);
     expect(fleetComplianceReport.requiredRole).toBe(Role.ReadOnly);
     expect(fleetComplianceReport.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+describe('fleet_health_rollup', () => {
+  /** One leaf of a vdev tree, as `pool.query` nests it under `topology`. */
+  const device = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+    name: 'sda1',
+    type: 'DISK',
+    status: 'ONLINE',
+    disk: 'sda',
+    children: [],
+    ...over,
+  });
+
+  /** One pool as `pool.query` reports it, feeding both pool reads of the health report. */
+  const pool = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+    name: 'tank',
+    status: 'ONLINE',
+    healthy: true,
+    size: 1000,
+    allocated: 100,
+    free: 900,
+    topology: { data: [device()] },
+    ...over,
+  });
+
+  /** One alert as `alert.list` reports it. */
+  const alert = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+    id: '1',
+    klass: 'ZpoolCapacityWarning',
+    level: 'WARNING',
+    formatted: 'tank is filling up',
+    datetime: { $date: 0 },
+    dismissed: false,
+    ...over,
+  });
+
+  /** An `update.status` payload for a system that is already up to date. */
+  const upToDate = (): Record<string, unknown> => ({
+    code: 'NORMAL',
+    error: null,
+    status: { new_version: null, current_version: { train: 'TN-25.04' } },
+  });
+
+  /** Every method the composed health report reads, answering a healthy system. */
+  const healthy = (
+    over: Partial<Record<string, unknown>> = {},
+  ): Partial<Record<string, unknown>> => ({
+    ['pool.query']: [pool()],
+    ['alert.list']: [],
+    ['update.status']: upToDate(),
+    ['system.version']: 'TrueNAS-25.04.0',
+    ...over,
+  });
+
+  /** One system's row, typed loosely: the tool's own contract is an opaque object. */
+  interface Row {
+    system: string;
+    verdict: string | null;
+    needs_attention: boolean | null;
+    reason_counts: { critical: number; warning: number; unknown: number; unranked: number };
+    reasons_reported: number;
+    reasons: { section: string; severity: string; detail: string }[];
+    reasons_truncated: boolean;
+    sections_total: number;
+    sections_unreadable: number;
+  }
+
+  const rollup = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Row> => {
+    const { ctx } = failingSystem(healthy(rows), failures);
+    return (await fleetHealthRollup.handler(ctx, {})) as unknown as Row;
+  };
+
+  it('answers a healthy system with one verdict and no section of the report', async () => {
+    // The whole object, asserted rather than sampled: what this tool is for is
+    // being SMALLER than `system_health_report`, and the way that fails is a
+    // section of that report appearing here.
+    expect(await rollup()).toEqual({
+      system: 'nas',
+      verdict: 'OK',
+      needs_attention: false,
+      reason_counts: { critical: 0, warning: 0, unknown: 0, unranked: 0 },
+      reasons_reported: 0,
+      reasons: [],
+      reasons_truncated: false,
+      sections_total: 4,
+      sections_unreadable: 0,
+    });
+  });
+
+  it('needs attention where something is already broken', async () => {
+    const row = await rollup({ ['pool.query']: [pool({ healthy: false, status: 'DEGRADED' })] });
+    expect(row.verdict).toBe('CRITICAL');
+    expect(row.needs_attention).toBe(true);
+    expect(row.reason_counts).toEqual({ critical: 1, warning: 0, unknown: 0, unranked: 0 });
+  });
+
+  it('needs attention where something needs fixing before it breaks', async () => {
+    const row = await rollup({ ['pool.query']: [pool({ size: 100, allocated: 85 })] });
+    expect(row.verdict).toBe('WARNING');
+    expect(row.needs_attention).toBe(true);
+    expect(row.reason_counts).toEqual({ critical: 0, warning: 1, unknown: 0, unranked: 0 });
+  });
+
+  it('does not answer needs_attention either way where the verdict is UNKNOWN', async () => {
+    const row = await rollup({ ['pool.query']: [pool({ healthy: 'yes' })] });
+    expect(row.verdict).toBe('UNKNOWN');
+    // Null and NOT false: nothing about this system's health was established, and
+    // a fleet filtered on `needs_attention === true` would read it as fine.
+    expect(row.needs_attention).toBeNull();
+    expect(row.reason_counts).toEqual({ critical: 0, warning: 0, unknown: 1, unranked: 0 });
+  });
+
+  it('names the worst reasons first and counts the ones it left out', async () => {
+    const row = await rollup({
+      ['pool.query']: [
+        pool({ name: 'tank', healthy: false, status: 'DEGRADED' }),
+        pool({ name: 'slow', size: 100, allocated: 85 }),
+        pool({ name: 'odd', healthy: 'yes' }),
+      ],
+      ['alert.list']: [alert({ level: 'CRITICAL', formatted: 'a disk failed' })],
+    });
+    expect(row.verdict).toBe('CRITICAL');
+    expect(row.reasons_reported).toBe(4);
+    expect(row.reasons_truncated).toBe(true);
+    // Worst first, and stable within a severity: the pools section's critical
+    // finding stays ahead of the alerts section's, as the report ordered them.
+    expect(row.reasons.map((reason) => [reason.section, reason.severity])).toEqual([
+      ['pools', 'critical'],
+      ['alerts', 'critical'],
+      ['pools', 'warning'],
+    ]);
+    // The `unknown` finding fell off the list and is still in the counts, which
+    // is the whole of why a fixed-size row is safe to act on.
+    expect(row.reason_counts).toEqual({ critical: 2, warning: 1, unknown: 1, unranked: 0 });
+  });
+
+  it('counts a section of the report that could not be read at all', async () => {
+    const row = await rollup({}, { ['alert.list']: new Error('the middleware is not answering') });
+    expect(row.verdict).toBe('UNKNOWN');
+    expect(row.needs_attention).toBeNull();
+    expect(row.sections_unreadable).toBe(1);
+    expect(row.reasons).toEqual([
+      {
+        section: 'alerts',
+        severity: 'unknown',
+        detail:
+          'the alerts section could not be read, so nothing about it is established: the middleware is not answering',
+      },
+    ]);
+  });
+
+  it('answers for a system it could not reach, rather than leaving it out', async () => {
+    const row = await rollup(
+      {},
+      {
+        ['pool.query']: new Error('unreachable'),
+        ['alert.list']: new Error('unreachable'),
+        ['update.status']: new Error('unreachable'),
+        ['system.version']: new Error('unreachable'),
+      },
+    );
+    expect(row.verdict).toBe('UNKNOWN');
+    expect(row.needs_attention).toBeNull();
+    // Every section, and every one of them a finding — so the row says the
+    // verdict rests on nothing rather than looking like a system with no
+    // problems.
+    expect(row.sections_unreadable).toBe(row.sections_total);
+    expect(row.reason_counts).toEqual({ critical: 0, warning: 0, unknown: 4, unranked: 0 });
+    expect(row.reasons_reported).toBe(4);
+    expect(row.reasons_truncated).toBe(true);
+  });
+
+  it('is read-only and takes no arguments', () => {
+    expect(fleetHealthRollup.mutating).toBe(false);
+    expect(fleetHealthRollup.requiredRole).toBe(Role.ReadOnly);
+    expect(fleetHealthRollup.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 });

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -11773,6 +11773,20 @@ describe('fleet_health_rollup', () => {
     expect(row.reasons_truncated).toBe(true);
   });
 
+  it('counts every section the health report actually carries', async () => {
+    const { ctx } = failingSystem(healthy());
+    const report = (await systemHealthReport.handler(ctx, {})) as Record<string, unknown>;
+    // A section of that report is exactly a field carrying an `unavailable` of
+    // its own, which is the contract its own description states. Asserted against
+    // the live report rather than against a list written twice: a fifth section
+    // added there and not reached by this rollup fails here.
+    const sections = Object.values(report).filter(
+      (value) => typeof value === 'object' && value !== null && 'unavailable' in value,
+    );
+    expect(sections.length).toBeGreaterThan(0);
+    expect((await rollup()).sections_total).toBe(sections.length);
+  });
+
   it('is read-only and takes no arguments', () => {
     expect(fleetHealthRollup.mutating).toBe(false);
     expect(fleetHealthRollup.requiredRole).toBe(Role.ReadOnly);


### PR DESCRIPTION
Adds `fleet_health_rollup`: one health verdict per system, so "which of my systems needs attention" is one call and one short answer per system.

Fixes #46

## What it is

A third composite, and the first that composes another composite. It calls `system_health_report.handler` and adds no endpoint and no read of its own, so "healthy" here is by construction what that tool means by it — one normalization per subject, read through rather than restated. **Nothing is re-judged**: no threshold, band or severity is read a second time, because a rollup that scored health its own way would be the drifting second opinion composites exist to prevent.

What it adds is arithmetic over that report's `reasons`, and what it drops is the point: every section — the pools, the alerts, the devices, the versions. A row that names something is the cue to call `system_health_report` on **that** system, which is the round trip the fleet-wide call was avoiding for the other nine.

## The fleet dimension is the fan-out

The handler is written single-system like every other tool in the catalog. The executor's `fanOut` runs it once per target, labels each result with the system it came from, and reports a call it could not run at all as an `ERROR` entry rather than dropping it — so a caller asking for `all` systems gets the registry-wide rollup the name promises. Adding a second concurrency path here would duplicate that and lose the partial-failure reporting that comes with it. The ticket's design note asked for exactly this; recorded as a decision in `CLAUDE.md` so the next fleet-named tool does not reach for the registry.

## The response

```
system                one row, one system, named so rows stay attributable once flattened
verdict               system_health_report's own verdict, verbatim: CRITICAL / WARNING / UNKNOWN / OK
needs_attention       true at CRITICAL and WARNING, FALSE ONLY AT OK, null at UNKNOWN
reason_counts         { critical, warning, unknown, unranked } over EVERY reason
reasons_reported      the total; 0 only when verdict is OK
reasons               the worst 3, worst first: { section, severity, detail }
reasons_truncated     whether anything was left out
sections_total        how many sections that report carries
sections_unreadable   how many of them could not be read at all on this system
```

`needs_attention` is the field the acceptance criterion asks for — a system needing work is told from a healthy one by a field rather than by reading prose. It is three-valued on purpose: **null at `UNKNOWN` is not `false`**, and a fleet filtered on `needs_attention === true` would read a system whose health was never established as fine. To act on everything not confirmed healthy, read `needs_attention !== false`. The description says so where a caller will read it.

**A system that could not be reached is answered here rather than as a failed call.** Every read beneath it fails, so `system_health_report` returns `UNKNOWN` with a reason per section, and the row comes back with `needs_attention` null and `sections_unreadable` equal to `sections_total` — never silently absent, and never reading as healthy. That is measured, not assumed: `it('answers for a system it could not reach, rather than leaving it out')`.

Only the `reasons` list is capped; every count is over every reason, so truncation can drop the line describing a finding and can never drop the finding.

## Measured size

Against the built bundle (`dist/index.cjs`), through `fanOut`, over a ten-system registry — six healthy, two warning, one critical, one unreachable:

| | rollup | full `system_health_report` |
|---|---|---|
| ten-system registry | **3,832 bytes** (383/system) | 7,862 bytes (786/system) |
| one system | 278 bytes | — |
| one hundred systems | 38,311 bytes (383/system) | — |

Growth with system **count** is linear at 383 bytes a system. The property that matters more is growth with system **size**, because that is what the cap fixes: one system with 8 pools, 64 devices and 30 alerts is **573 bytes** rolled up against **4,642** reported in full, and ten of those are 5,741 bytes against 46,431.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test` (816 pass) and `yarn test:coverage` all run clean locally. Coverage is 99.36 branches / 99.66 statements against floors of 96 / 97; `fleet.ts` is 100% statements and 98.25% branches, and the three uncovered branches in it are pre-existing (lines 403, 668, 830, all in `fleet_compliance_report`). The new code adds no uncovered branch. `yarn build` succeeds.

## Rounds

Two local review rounds, both by the project's own reviewer in a separate process (`local-review.py` exit 1 then exit 0 — the same rubric, threshold and parser as the required check, so the clean round is a strong prediction of it).

**Round 1, one MEDIUM, fixed.** `fleet_health_rollup` restated `system_health_report`'s four section names in order to count how many of them could not be read, and that report's own `SectionName` was a hand-written union beside them — so a fifth section added there would have left `sections_total` at 4 and `sections_unreadable` blind to it, silently. `HEALTH_SECTIONS` is now declared once in `reporting.ts` with `SectionName` derived from it, so a section that raises a reason without being named in the list does not compile, and the rollup imports the list. A spec asserts `sections_total` against the sections a live report actually carries, so the two cannot drift even if the derivation is broken later.

**Round 2 returned nothing at MEDIUM or above**, which is where the local loop ends.

## What I did not change, and why

Round 2's four LOWs, left for a reader and a later ticket rather than fixed here — every fix is a new diff, and a new diff is unreviewed:

- **`SEVERITIES` restates `reporting.ts`'s non-exported `Severity` union**, the same drift the MEDIUM fix removed for sections. Fair, and the same remedy would work. It is milder than the section case because a severity added there is *reported* rather than lost: it lands in `reason_counts.unranked`, is inside `reasons_reported`, and sorts **first** in `reasons` so the cap cannot hide it — the section case had no such fallback and undercounted in silence.
- **The unranked-severity path is untested.** It is unreachable through the composed report: `Severity` is a closed union in `reporting.ts`, so exercising it needs a mocked handler rather than a fixture. It is arithmetic (`reasons.length - critical - warning - unknown`) with no branch of its own, which is why it costs no coverage; the description states it is 0 against every severity that report states today rather than implying it has been seen.
- **`sections_unreadable` dereferences `report[name]['unavailable']` unguarded**, so a *renamed* section key would throw rather than fail an assertion. Correct. A throw there fails that system's slice of the fan-out with the error attached rather than reporting the system as healthy, which is the safe direction, and the rename would have to pass `SectionName` — but it is not the same thing as a test.
- **The spec fixtures are duplicated from the `system_health_report` describe block** in the same file and can drift. True; they are `const`s local to each block, and the file's existing convention is that each `describe` carries its own.
