### PR TITLE
fix(tools): order fleet_compliance_report certificates worst-first before capping

### DIFF
--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -451,7 +451,7 @@ interface CertificateRead {
   expired: number;
   expiring_soon: number;
   expiry_unknown: number;
-  /** Every certificate that is not comfortably valid, in the order reported. */
+  /** Every certificate that is not comfortably valid, worst first — see {@link certificateRank}. */
   notable: CertificateEntry[];
 }
 
@@ -485,6 +485,29 @@ function certificateState(
   return days <= EXPIRY_HORIZON_DAYS ? 'expiring_soon' : 'valid';
 }
 
+/**
+ * Where a certificate sorts. Already expired first, then one whose expiry this
+ * report could not read, then one expiring inside the horizon.
+ *
+ * The same job {@link exposureRank} does for shares: the ordering is what makes
+ * the cap below honest, so what survives it is the worst of what was found
+ * rather than whichever ones the system happened to list first. An already
+ * lapsed certificate takes the web UI and every API client down now, where one
+ * expiring soon has not broken anything yet; an expiry that would not read sorts
+ * between them for the reason it is counted separately — it is not shown to be
+ * fine, and it is the one an auditor most wants to look at by hand.
+ *
+ * It ranks off {@link certificateState} rather than off the fields directly, so
+ * the order of the list and the counts beside it can never disagree about where
+ * a certificate stands — including where the system's own `expired` verdict
+ * contradicts the day count, which that function settles and this one inherits.
+ */
+function certificateRank(entry: CertificateEntry): number {
+  const state = certificateState(entry.days_until_expiry, entry.expired);
+  if (state === 'expired') return 0;
+  return state === 'unknown' ? 1 : 2;
+}
+
 /** What `certificates_list` reported, read back through this report's guards. */
 function certificateRead(answer: unknown): CertificateRead {
   const rows = (answer as Record<string, unknown>[]).map((row) => ({
@@ -513,6 +536,11 @@ function certificateRead(answer: unknown): CertificateRead {
     else read.expiry_unknown += 1;
     read.notable.push(row);
   }
+  // Sorted after the walk rather than during it, so the counts are taken over
+  // every certificate in the order the system reported them and only the list
+  // is reordered. `sort` is stable, so certificates at the same rank keep that
+  // order.
+  read.notable.sort((a, b) => certificateRank(a) - certificateRank(b));
   return read;
 }
 
@@ -972,7 +1000,11 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'taken from; it is fixed rather than an argument, so that one system\'s ' +
     'report can be compared with another\'s. `entries` lists the certificates ' +
     'in those three ' +
-    'categories individually and lists no comfortably-valid one, each with its ' +
+    'categories individually and lists no comfortably-valid one, ALREADY-' +
+    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
+    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
+    'found; certificates in the same category keep the order the system listed ' +
+    'them in, which is not an ordering by date. Each entry carries its ' +
     '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
     '`days_until_expiry` — negative where it has already expired, by that many ' +
     'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -11161,6 +11161,9 @@ describe('fleet_compliance_report', () => {
         cert({ name: 'just-outside', until: inDays(31) }),
       ],
     });
+    // Listed worst first — expired, then the expiry that would not read, then
+    // the two expiring soon in the order the system reported them — rather than
+    // in the order above, so that the cap drops the least alarming lines.
     expect(result.certificates).toEqual({
       unavailable: null,
       reported: 6,
@@ -11169,20 +11172,6 @@ describe('fleet_compliance_report', () => {
       expiry_unknown: 1,
       expiring_within_days: 30,
       entries: [
-        {
-          name: 'boundary',
-          common_name: 'truenas.local',
-          not_after: inDays(30),
-          days_until_expiry: 30,
-          expired: false,
-        },
-        {
-          name: 'soon',
-          common_name: 'truenas.local',
-          not_after: inDays(5),
-          days_until_expiry: 5,
-          expired: false,
-        },
         {
           name: 'gone',
           common_name: 'truenas.local',
@@ -11195,6 +11184,20 @@ describe('fleet_compliance_report', () => {
           common_name: 'truenas.local',
           not_after: 'the ides of March',
           days_until_expiry: null,
+          expired: false,
+        },
+        {
+          name: 'boundary',
+          common_name: 'truenas.local',
+          not_after: inDays(30),
+          days_until_expiry: 30,
+          expired: false,
+        },
+        {
+          name: 'soon',
+          common_name: 'truenas.local',
+          not_after: inDays(5),
+          days_until_expiry: 5,
           expired: false,
         },
       ],
@@ -11262,6 +11265,37 @@ describe('fleet_compliance_report', () => {
     expect(result.certificates['expiring_soon']).toBe(12);
     expect(result.certificates['entries']).toHaveLength(10);
     expect(result.certificates['truncated']).toBe(true);
+  });
+
+  it('keeps every expired certificate through a cap that drops expiring-soon ones', async () => {
+    const result = await report({
+      // The three that matter are reported LAST, so listing in reported order
+      // would cap them out and leave a report whose entries name only
+      // certificates that have not broken anything yet.
+      ['certificate.query']: [
+        ...Array.from({ length: 12 }, (_, index) =>
+          cert({ name: `expiring-${index}`, until: inDays(1) }),
+        ),
+        cert({ name: 'lapsed', until: inDays(-3) }),
+        cert({ name: 'unreadable', until: 'the ides of March' }),
+        // Ranked on the system's own verdict, not on the 200 days beside it —
+        // the same disagreement the counts are settled on.
+        cert({ name: 'disputed', until: inDays(200), expired: true }),
+      ],
+    });
+    const entries = result.certificates['entries'] as { name: string }[];
+    expect(entries.map((entry) => entry.name).slice(0, 3)).toEqual([
+      'lapsed',
+      'disputed',
+      'unreadable',
+    ]);
+    expect(entries).toHaveLength(10);
+    expect(result.certificates['truncated']).toBe(true);
+    // The ordering moved lines, not facts: every count is still over all 15.
+    expect(result.certificates['reported']).toBe(15);
+    expect(result.certificates['expired']).toBe(2);
+    expect(result.certificates['expiring_soon']).toBe(12);
+    expect(result.certificates['expiry_unknown']).toBe(1);
   });
 
   it('reports where identities come from, with no bind credential', async () => {


### PR DESCRIPTION
Fixes #84.

## What was wrong

`fleet_compliance_report`'s `certificates.entries` was capped at ten in the
order the system reported, so on a system holding more than ten notable
certificates an already-expired one could be dropped from the list while an
expiring-soon one was kept. `shares.entries` in the same file already sorts by
`exposureRank` before capping and has no such gap, so one report treated its two
truncated lists differently.

The counts were never affected — `expired`, `expiring_soon` and
`expiry_unknown` are computed over every certificate, which is the convention
`app/CLAUDE.md` states ("a cap can drop the line describing a finding; it must
never drop the finding"). This is about which ten lines survive.

## What changed

- **`certificateRank`** (`src/tools/fleet.ts`) sorts `CertificateRead.notable`
  expired → expiry-unknown → expiring-soon, the same shape `exposureRank` gives
  shares. It ranks through `certificateState` rather than off the fields
  directly, so the list order and the counts beside it cannot disagree about
  where a certificate stands — including where the system's own `expired`
  verdict contradicts the day count, which `certificateState` already settles.
- **The sort runs after the walk, not during it**, so every count is still taken
  over every certificate; only the list is reordered. `sort` is stable, so
  certificates in the same category keep the order the system listed them in.
- **The tool `description` states the ordering**, as it already did for
  `shares.entries`, and says explicitly that the within-category order is the
  system's rather than an ordering by date.

## Tests

- The existing `counts certificates by expiry and lists only the ones that are
  not comfortably valid` case now asserts the worst-first order.
- New: `keeps every expired certificate through a cap that drops expiring-soon
  ones` — twelve expiring-soon certificates reported first, then an expired one,
  an unreadable expiry and one the system itself calls expired despite 200 days
  on its date. All three lead the capped list, and the four counts are still
  over all fifteen.

`yarn typecheck`, `yarn lint` and `yarn test:coverage` all pass locally: 817
tests, global coverage 99.66 statements / 99.37 branches against floors of
97 / 96. `src/tools/fleet.ts` has no per-file floor in `vitest.config.ts`.

## Review

The local review round ran the project's own shared reviewer (exit 0, the
check's actual verdict, not a subagent fallback) and found nothing at or above
MEDIUM. It raised two LOWs, left unfixed because the round that raised them was
the clean one:

- **No tiebreak inside `expiring_soon`** (`fleet.ts:505`): the cap can still
  drop a certificate expiring tomorrow while keeping one expiring in 30 days.
  Deliberate — the ticket asked for ordering by state, the description now says
  the within-category order is the system's and not an ordering by date, and
  sorting on `days_until_expiry` would mean choosing what to do with the nulls
  and with a day count the system's own verdict contradicts. Worth a follow-up
  ticket if a day-count tiebreak is wanted.
- **`certificateRank`'s JSDoc names three states, four can reach it**
  (`fleet.ts:508`): `'valid'` would rank 2 alongside `'expiring_soon'`. Not
  reachable — `certificateRead` filters valid certificates out before anything
  is pushed to `notable`, which is the only list sorted — so this is about the
  doc's completeness rather than behaviour.
