### PR TITLE
refactor(tools): put the repeated guards in one shared module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ src/registry/         SystemRegistry, connectSystems, the client factory
 src/execution/        the executor, fan-out, and plan/confirm
 src/content/          bounded file content (see the decision below)
 src/tools/            one file per family; all registered by createDefaultCatalog()
+src/tools/common.ts   the guards every family shares; not a family, not exported
 src/index.ts          the public barrel — an export here is a contract
 ```
 
@@ -182,6 +183,40 @@ re-judges nothing: no threshold, band or severity is read a second time, because
 a rollup that scored health its own way would be the drifting second opinion
 composites exist to prevent. **Summarise by dropping fields, never by
 recomputing them**, and point the caller at the composed tool for the detail.
+
+### The shared guards live in `src/tools/common.ts` (#86)
+
+Every tool file reads middleware payloads whose fields arrive as `unknown`, so
+each needed the same narrowings — `textOrNull`, `numberOrNull`, `booleanOrNull`,
+`recordOrNull`, `textList` — and the same reading of a rejection, `errorText`.
+Each file grew a private copy, on the stated ground that a tool file is read on
+its own. Eleven copies of `textOrNull` later, they had not all stayed identical:
+`shares.ts`'s `errorText` had lost the branch that reads the `{ reason }` and
+`{ message }` carriers the client documents, so a real middleware rejection
+there reported as having said nothing while every sibling reported its reason.
+**That is the cost this file was cut to stop — a fix applied to one copy is not
+a fix applied to the rest, and nothing makes the divergence visible.**
+
+Where the line falls, since "shared" is not the same as "generic":
+
+- **What belongs there says the same thing for every family** — a type
+  narrowing, the wording of a stated absence, the `Date` bound.
+- **What does not is anything whose meaning is a family's own**: a limit's
+  default, a state vocabulary, a field name. `effectiveLimit` is shared and
+  takes its two bounds as arguments precisely because the bounding is common
+  and the numbers are not.
+- **A per-family `Attempt`/`attempt` pair is NOT this.** Four files hold one and
+  they look alike, but each is typed by its own failure shape and names its own
+  sources — the overlap is the shape, not the function. Sharing it would mean
+  generalising over the failure type, which buys nothing and couples five
+  families to one signature.
+- **`common.ts` is internal.** It is not a family, `createDefaultCatalog()` does
+  not know about it, and it must not reach `src/index.ts` — an export there is
+  a contract, and none of this is one.
+
+Reaching for a private copy of something already in `common.ts` is the thing to
+notice in review. The comment that used to justify each copy — *a tool file is
+read on its own* — is what produced the drift, and is no longer the rule.
 
 ## Conventions
 

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { effectiveLimit, errorText, numberOrNull, textOrNull } from '@/tools/common';
 
 /**
  * Accounts family: who has an account on this system, what each belongs to, and
@@ -76,53 +77,12 @@ interface Attempt {
 }
 
 /**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters: an
- * account with no full name set is what the middleware sends `""` for, and
- * passing that through would put a field in the result that says nothing.
- *
- * `shares.ts`, `tasks.ts` and `block.ts` each hold the same reading under their
- * own names, and this restates rather than shares it for the reason `shares.ts`
- * gives for restating its own guards: a tool file is read on its own.
+ * `textOrNull` reads the account's full name, which the middleware sends as
+ * `""` when it is unset; `numberOrNull` reads the primary group's id, which the
+ * account record embeds as `Record<string, unknown>` so every field of it
+ * arrives as `unknown`. Both come from `common.ts`, as does `errorText` for the
+ * group read below.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/**
- * A number the system reported, or null where it reported anything else.
- *
- * Needed only for the primary group, which the account record embeds as
- * `Record<string, unknown>` on the pinned client: every field of it arrives as
- * `unknown` and has to be read rather than trusted. Non-finite is not a number
- * here — a group id that is `NaN` resolves against nothing.
- */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
-/**
- * Why the group read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. Anything else
- * still becomes a stated absence rather than `"[object Object]"`, and the
- * result is never empty: a failure with no text still has to read as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /**
  * The groups the system knows, with a failure named rather than thrown.
@@ -203,19 +163,16 @@ function primaryGroup(
 }
 
 /**
- * The bound actually applied, from whatever the caller asked for.
+ * The bound this family applies, from whatever the caller asked for.
  *
  * Lenient rather than strict, as `snapshots_list` is about its own limit: a
  * misread bound only changes how many of the right rows come back, and the
  * number applied is returned beside them, so a caller can see that its argument
- * was not taken.
+ * was not taken. The bounding is `common.ts`'s; the two numbers are this
+ * family's.
  */
-function effectiveLimit(raw: unknown): number {
-  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_LIMIT;
-  // Rounded down because a fractional limit reaches the middleware as one, and
-  // floored at 1 because a limit of zero or less would return nothing while
-  // reporting the system as holding more — true, and not an answer.
-  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(raw)));
+function accountLimit(raw: unknown): number {
+  return effectiveLimit(raw, DEFAULT_LIMIT, MAX_LIMIT);
 }
 
 export const usersList: ReadOnlyTool = {
@@ -289,7 +246,7 @@ export const usersList: ReadOnlyTool = {
   requiredRole: Role.ReadOnly,
   mutating: false,
   async handler({ system }, args) {
-    const limit = effectiveLimit(args['limit']);
+    const limit = accountLimit(args['limit']);
     // Both reads are issued before either is awaited, so neither waits on the
     // other. Only the account read may fail the tool: the groups are what the
     // memberships resolve against, and with no accounts there is nothing for

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { booleanOrNull, errorText, recordOrNull, textOrNull } from '@/tools/common';
 
 /**
  * The system's own health verdict. `system_info` and the storage tools describe
@@ -72,63 +73,17 @@ export const alertsList: ReadOnlyTool = {
  */
 
 /**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters, the
- * same reading `credentials.ts`, `network.ts`, `block.ts` and `shares.ts` each
- * hold under their own names — and restated here for the reason those files
- * give for restating it: a tool file is read on its own.
- */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** A boolean the system reported, or null where it reported anything else. */
-function booleanOrNull(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null;
-}
-
-/**
- * A nested object of a row, or null where the row held anything else.
- *
- * `typeof null` is `'object'`, so the null check is what stops a reported-as-null
- * `attributes` being indexed. An array is an object too and is excluded: the two
- * things read through this — a destination's `attributes` and the per-class
+ * `recordOrNull` from `common.ts` is what stops a reported-as-null `attributes`
+ * being indexed, and what keeps a list from being read as a record: the two
+ * things read through it here — a destination's `attributes` and the per-class
  * settings map — are records, and reading a list as one would answer null for
  * every field rather than saying the shape was not what this tool reads.
  */
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
 
 /** The one supplementary read of this tool, named for the field it fills. */
 interface SettingsFailure {
   source: 'class_overrides';
   error: string;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
-/**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. `block.ts`,
- * `network.ts` and `shares.ts` each hold this same reading under their own
- * names. The result is never empty, because a failure with no text still has to
- * read as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
 }
 
 /** A read that produced a value, or the failure that stopped it. */

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { booleanOrNull, errorText, numberOrNull, textOrNull } from '@/tools/common';
 
 /**
  * Block-storage family: what the system serves as block devices rather than as
@@ -50,43 +51,10 @@ interface Failure<S extends string> {
 }
 
 /**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters: a
- * target with no alias is what the middleware sends `""` for, and passing that
- * through would put a field in the result that says nothing.
- *
- * `shares.ts` and `tasks.ts` each hold the same reading under their own names,
- * and this restates rather than shares it for the reason `shares.ts` gives for
- * restating its own guards: a tool file is read on its own.
+ * `textOrNull` from `common.ts` is what reads a target's alias, which the
+ * middleware sends as `""` when it is unset — passing that through would put a
+ * field in the result that says nothing.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
-/**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. Those are what a
- * failed call actually rejects with, and reading neither made every real
- * failure report as having said nothing. Anything else still becomes a stated
- * absence rather than `"[object Object]"`, and the result is never empty: a
- * failure with no text still has to read as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /** A read that produced a value, or the failure that stopped it. */
 interface Attempt<T, S extends string> {
@@ -380,22 +348,13 @@ export const iscsiList: ReadOnlyTool = {
 };
 
 /**
- * A number the system reported, or null where it reported anything else.
- *
- * The NVMe-oF reads need this where the iSCSI ones do not: the pinned client
- * types a subsystem entry as `Record<string, unknown>`, so every field of one —
- * including the id the other two reads are joined on — arrives as `unknown` and
- * has to be read rather than trusted. Non-finite is not a number here: an id
- * that is `NaN` joins nothing and a size that is `NaN` measures nothing.
+ * The NVMe-oF reads below need `numberOrNull` where the iSCSI ones do not: the
+ * pinned client types a subsystem entry as `Record<string, unknown>`, so every
+ * field of one — including the id the other two reads are joined on — arrives
+ * as `unknown` and has to be read rather than trusted. Non-finite is excluded
+ * there for a reason this family feels directly: an id that is `NaN` joins
+ * nothing and a size that is `NaN` measures nothing.
  */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-/** A boolean the system reported, or null where it reported anything else. */
-function booleanOrNull(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null;
-}
 
 /** One namespace of a subsystem: a block device, as an initiator addresses it. */
 interface Namespace {

--- a/src/tools/certificates.ts
+++ b/src/tools/certificates.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { textList, textOrNull } from '@/tools/common';
 
 /**
  * Certificates family: which certificates this system holds, and when each one
@@ -26,35 +27,12 @@ import { ReadOnlyTool } from '@/catalog/tool';
  */
 
 /**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters: the
- * middleware sends `""` for a subject component a certificate does not carry,
- * and passing it through would put a field in the result that says nothing.
- *
- * `network.ts`, `accounts.ts`, `shares.ts`, `tasks.ts` and `block.ts` each hold
- * this same reading under their own names, and it is restated here for the
- * reason those files give for restating it: a tool file is read on its own.
+ * Two guards come from `common.ts` and both matter here. `textOrNull` reads the
+ * subject components, which the middleware sends as `""` where a certificate
+ * does not carry them. `textList` keeps an empty SAN list distinct from a
+ * missing one: a certificate that reported an empty list carries no alternative
+ * name, and one that reported no list said nothing about them.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/**
- * The non-empty strings of a list field, or null where the field was not a list
- * at all.
- *
- * The two are kept apart for the reason `network.ts` keeps them apart: a
- * certificate that reported an empty SAN list carries no alternative name, and
- * one that reported no list said nothing about them.
- */
-function textList(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  return value.flatMap((entry) => {
-    const text = textOrNull(entry);
-    return text === null ? [] : [text];
-  });
-}
 
 /** Month names in the order the C `asctime` format abbreviates them. */
 const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -1,0 +1,144 @@
+/**
+ * The guards and constants the tool files share, in one place rather than one
+ * copy per family.
+ *
+ * Every tool in `src/tools/` reads middleware payloads whose fields arrive as
+ * `unknown`, so each of them needs the same handful of narrowings — is this a
+ * string, a finite number, a record — and each of them needs the same reading
+ * of a rejection. Those grew as a private copy per file, on the stated ground
+ * that a tool file is read on its own. They did not all stay identical: by the
+ * time this module was cut, `shares.ts`'s `errorText` had lost the branch that
+ * reads a middleware error object, so a real rejection there reported as having
+ * said nothing while every sibling file reported its reason.
+ *
+ * That is the trade this file settles: one definition a fix reaches, against a
+ * file that can no longer be read entirely on its own. Nothing here is a tool,
+ * a family, or part of the public surface — `src/index.ts` exports named tools
+ * and this module is not among them, and must not become one.
+ *
+ * What belongs here is a guard or a constant that says the same thing for every
+ * family. What does not is anything whose meaning is a family's own: a limit's
+ * default, a state vocabulary, a field name. Those stay in the file that
+ * defines them and are passed in.
+ */
+
+/**
+ * One string field of a row, or null where the system reported no value.
+ *
+ * An empty string is read as no value rather than as text of no characters: a
+ * field the middleware sent as `''` has told the caller nothing, and a tool
+ * that surfaced it would report an unnamed thing as being named.
+ */
+export function textOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * A finite number the system reported, or null where it reported anything else.
+ *
+ * Non-finite is not a number here: `NaN` and the infinities are not counts, byte
+ * totals or ids, whatever else they are, and one arriving in a field a tool
+ * arithmetics over would propagate rather than fail.
+ */
+export function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** A boolean the system reported, or null where it reported anything else. */
+export function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+/**
+ * A nested object of a row, or null where the row held anything else.
+ *
+ * `typeof null` is `'object'`, so the null check is what stops a reported-as-null
+ * sub-object being indexed. An array is an object too and is excluded: the
+ * things read through this are records, and reading a list as one would answer
+ * null for every field rather than saying the shape was not what was expected.
+ */
+export function recordOrNull(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * The non-empty strings of a list field, or null where the field was not a list
+ * at all.
+ *
+ * The two are kept apart because they are different answers: a field that
+ * reported an empty list said there are none, and a field that reported no list
+ * said nothing about them. Entries that are not non-empty strings are dropped
+ * rather than surfaced as null, so the result is a list of names.
+ */
+export function textList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.flatMap((entry) => {
+    const text = textOrNull(entry);
+    return text === null ? [] : [text];
+  });
+}
+
+/** What a failure carrying no text of its own is reported as. */
+export const NO_REASON = 'the system reported no reason';
+
+/**
+ * Why a read failed, in words.
+ *
+ * A rejection is not necessarily an `Error` — the client rejects with whatever
+ * the transport gave it — so a bare string is read too, and so are the two
+ * shapes the client documents as its own: a JSON-RPC error object carrying
+ * `message`, and a middleware error object carrying `reason`. Those are what a
+ * failed call actually rejects with, and reading neither made every real
+ * failure report as having said nothing. Anything else still becomes a stated
+ * absence rather than `"[object Object]"`, and the result is never empty: a
+ * failure with no text still has to read as a failure.
+ */
+export function errorText(reason: unknown): string {
+  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
+  if (typeof reason === 'object' && reason !== null) {
+    const carrier = reason as Record<string, unknown>;
+    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
+  }
+  return textOrNull(reason) ?? NO_REASON;
+}
+
+/** `1 alert` / `2 alerts`, so a rendered reason reads as English at either count. */
+export function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * The largest instant `Date` accepts, in milliseconds since the epoch.
+ *
+ * A time beyond it makes `new Date(...).toISOString()` throw rather than
+ * answer, so one absurd timestamp in a row would otherwise take the whole
+ * listing down with it. Every tool that turns a middleware time into ISO text
+ * bounds it against this first.
+ */
+export const MAX_TIME_MS = 8.64e15;
+
+/**
+ * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
+ * which is the date representation the client's own types declare
+ * (`TrueNasDate`). Restated with `$date` untyped because the rows carrying it
+ * arrive as open records, so the field has to be read rather than trusted.
+ */
+export interface MiddlewareDate {
+  $date?: unknown;
+}
+
+/**
+ * A caller's requested row limit, bounded into what a listing will actually ask
+ * the middleware for.
+ *
+ * `fallback` and `max` are the calling family's own policy and are passed in —
+ * what is shared is the bounding, not the numbers. Rounded down because a
+ * fractional limit reaches the middleware as one, and floored at 1 because a
+ * limit of zero or less would return nothing while reporting the system as
+ * holding more — true, and not an answer.
+ */
+export function effectiveLimit(raw: unknown, fallback: number, max: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return fallback;
+  return Math.min(max, Math.max(1, Math.floor(raw)));
+}

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -93,6 +93,13 @@ export const NO_REASON = 'the system reported no reason';
  * failure report as having said nothing. Anything else still becomes a stated
  * absence rather than `"[object Object]"`, and the result is never empty: a
  * failure with no text still has to read as a failure.
+ *
+ * IT READS `message` AND NEVER `cause`, AND THAT IS A CREDENTIAL BOUNDARY.
+ * `FileContentError` keeps the minted download URL — which carries a single-use
+ * auth token — off its own message and puts the adapter's message, which can
+ * name that URL, on `cause`. `vm_logs` returns what this function produces, and
+ * tool results are recorded verbatim in the audit trail. Adding a `cause`
+ * reader here would put that token in a result, for every tool at once.
  */
 export function errorText(reason: unknown): string {
   if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { textOrNull } from '@/tools/common';
 
 /**
  * Cloud credentials family: which stored cloud credentials this system holds,
@@ -30,19 +31,6 @@ import { ReadOnlyTool } from '@/catalog/tool';
  * releases before the one the pinned types describe, and is an object carrying
  * the configuration in this one.
  */
-
-/**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters, the
- * same reading `certificates.ts`, `network.ts`, `accounts.ts`, `shares.ts`,
- * `tasks.ts` and `block.ts` each hold under their own names — and restated here
- * for the reason those files give for restating it: a tool file is read on its
- * own.
- */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
 
 /**
  * The credential's numeric id, or null where the system reported none this

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -8,6 +8,7 @@ import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 // this one, so there is no cycle.
 import { directoryServicesStatus } from '@/tools/accounts';
 import { certificatesList } from '@/tools/certificates';
+import { booleanOrNull, errorText, numberOrNull, plural, textOrNull } from '@/tools/common';
 import { HEALTH_SECTIONS, systemHealthReport } from '@/tools/reporting';
 import { sharesList } from '@/tools/shares';
 import { auditLogQuery, updateStatus } from '@/tools/system';
@@ -18,43 +19,10 @@ import { auditLogQuery, updateStatus } from '@/tools/system';
  */
 
 /**
- * A string the system reported, or null where it reported anything else.
- *
- * An empty string is read as no value rather than as text of no characters: a
- * status of no characters names nothing a caller could act on, and passing it
- * through would put a field in the result that says nothing.
- *
- * `system.ts`, `accounts.ts`, `shares.ts` and `block.ts` each hold the same
- * reading under their own names, and this restates rather than shares it for the
- * reason `shares.ts` gives for restating its own guards: a tool file is read on
- * its own.
+ * `textOrNull` from `common.ts` reads the HA status below, where an empty
+ * string names nothing a caller could act on, and `errorText` names a read that
+ * did not complete — which for a composite is most of what it reports.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
-/**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. Anything else
- * still becomes a stated absence rather than `"[object Object]"`, and the
- * result is never empty: a failure with no text still has to read as a failure.
- * The same reading `system.ts` holds of a failed version read.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /**
  * The status a system reports when it is not one node of an HA pair.
@@ -305,20 +273,12 @@ const EXPIRY_HORIZON_DAYS = 30;
 /** The five sections of the report, each backed by exactly one composed tool. */
 type SectionName = 'auditing' | 'certificates' | 'directory_service' | 'shares' | 'updates';
 
-/** A boolean the system reported, or null where it reported anything else. */
-function booleanOrNull(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null;
-}
-
-/** A finite number the system reported, or null where it reported anything else. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-/** `1 certificate` / `2 certificates`, so a detail reads as English at either count. */
-function plural(count: number, noun: string): string {
-  return `${count} ${noun}${count === 1 ? '' : 's'}`;
-}
+/**
+ * `booleanOrNull` and `numberOrNull` re-read the composed handlers' results,
+ * which arrive as `Promise<unknown>`; `plural` is what makes a detail read as
+ * English at either count (`1 certificate` / `2 certificates`). All three are
+ * `common.ts`'s.
+ */
 
 /** A section that was read, or the reason it could not be. */
 interface SectionRead<T> {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { errorText, numberOrNull, recordOrNull, textList, textOrNull } from '@/tools/common';
 
 /**
  * Networking family. Two tools split it by what is being asked about:
@@ -37,38 +38,13 @@ import { ReadOnlyTool } from '@/catalog/tool';
  */
 
 /**
- * One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters: a
- * media subtype the system has nothing to say about arrives as `""`, and
- * passing it through would put a field in the result that says nothing.
- *
- * `accounts.ts`, `shares.ts`, `tasks.ts` and `block.ts` each hold this same
- * reading under their own names, and it is restated here for the reason those
- * files give for restating their own guards: a tool file is read on its own.
+ * The pinned client answers `interface.query` as a bare record, so every field
+ * and every sub-object of one arrives as `unknown` and is read through
+ * `common.ts`'s guards. `recordOrNull` is what stops a reported-as-null `state`
+ * being indexed, and what keeps a list from being read as a record: `state` and
+ * a port entry are records, and reading a list as one would answer null for
+ * every field rather than saying the shape was not what this tool reads.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** A number the system reported, or null where it reported anything else. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-/**
- * A nested object of a row, or null where the row held anything else.
- *
- * Every sub-object of an interface arrives as `unknown`, and `typeof null` is
- * `'object'`, so the null check is what stops a reported-as-null `state` being
- * indexed. An array is an object too and is excluded here: `state` and a port
- * entry are records, and reading a list as one would answer null for every
- * field rather than saying the shape was not what this tool reads.
- */
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
 
 /** The entries of a list field, or an empty list where the field was not one. */
 function listOf(value: unknown): unknown[] {
@@ -404,30 +380,6 @@ interface ConfigFailure {
   error: string;
 }
 
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
-/**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. `block.ts` and
- * `shares.ts` each hold this same reading under their own names, and it is
- * restated here for the reason those files give: a tool file is read on its
- * own. The result is never empty, because a failure with no text still has to
- * read as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
-
 /** A read that produced a value, or the failure that stopped it. */
 interface Attempt<T> {
   value: T | null;
@@ -453,22 +405,10 @@ async function attempt<T>(
 }
 
 /**
- * The non-empty strings of a list field, or null where the field was not a list
- * at all.
- *
- * The two are kept apart everywhere this is used: a system that reported an
- * empty search-domain list has none, and one that reported no list said
- * nothing. An entry that is not a string, or is the empty string the middleware
- * sends for "no value", names nothing and is dropped — the same reading
- * `textOrNull` holds above.
+ * `textList` from `common.ts` keeps the two apart everywhere it is used here: a
+ * system that reported an empty search-domain list has none, and one that
+ * reported no list said nothing.
  */
-function textList(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  return value.flatMap((entry) => {
-    const text = textOrNull(entry);
-    return text === null ? [] : [text];
-  });
-}
 
 /** Where a value in effect came from, as far as this tool can tell. */
 type ValueSource = 'STATIC' | 'AUTOMATIC';

--- a/src/tools/replication.ts
+++ b/src/tools/replication.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { MAX_TIME_MS, MiddlewareDate } from '@/tools/common';
 
 /**
  * Replication family: the replication tasks that exist and how their last run
@@ -27,12 +28,10 @@ import { ReadOnlyTool } from '@/catalog/tool';
 const ENDED_STATES = new Set(['FINISHED', 'ERROR']);
 
 /**
- * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
- * than answering, so one absurd recorded time would otherwise take the whole
- * listing down with it — the same guard `snapshots.ts` applies to a creation
- * time.
+ * {@link MAX_TIME_MS} from `common.ts` is what keeps one absurd recorded time
+ * from taking the whole listing down with it, applied here to the instant a
+ * task's state was recorded.
  */
-const MAX_TIME_MS = 8.64e15;
 
 /**
  * The state record a replication task carries, restated with every field
@@ -47,16 +46,6 @@ interface RunState {
   state?: unknown;
   datetime?: unknown;
   error?: unknown;
-}
-
-/**
- * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
- * which is the only date representation the client's own types declare
- * (`TrueNasDate`). Restated with `$date` untyped because it arrives inside an
- * open record.
- */
-interface MiddlewareDate {
-  $date?: unknown;
 }
 
 /**

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -5,6 +5,14 @@ import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 // the API, so that what it reports is by construction what those tools report.
 // None of the four imports this file, so there is no cycle.
 import { alertsList } from '@/tools/alerts';
+import {
+  NO_REASON,
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  plural,
+  textOrNull,
+} from '@/tools/common';
 import { poolTopology } from '@/tools/pools';
 import { poolStatus } from '@/tools/storage';
 import { updateStatus } from '@/tools/system';
@@ -94,9 +102,6 @@ const MAX_INTERFACES = 6;
  */
 const MAX_DISKS = 6;
 
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
 /** What a metric the system collected nothing for in the range is marked with. */
 const NO_DATA = 'the system collected no data for this metric in this range';
 
@@ -123,37 +128,11 @@ const NO_DISKS = 'the system named no disk to graph';
 const NO_DIMENSION = 'the system reported no series this metric can be derived from';
 
 /**
- * A string a row reported, or null where it reported anything else.
- *
- * An empty string is read as no value rather than as text of no characters: an
- * interface of no characters names nothing that could be graphed. `network.ts`,
- * `system.ts` and `shares.ts` each hold this same reading under their own names,
- * and it is restated here for the reason those files give: a tool file is read
- * on its own.
+ * `textOrNull` from `common.ts` reads the graph names, where an empty string
+ * names nothing that could be graphed; {@link NO_REASON} is imported alongside
+ * `errorText` because the update section reports it directly for a check that
+ * failed with no text of its own.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. Restated from
- * `network.ts` and `system.ts` for the reason they restate it from each other.
- * The result is never empty, because a failure with no text still has to read
- * as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /**
  * A date, or a date and a time, in the forms this tool reads: `2026-08-29`,
@@ -1255,11 +1234,6 @@ function propertyBytes(property: unknown): number | null {
   return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null;
 }
 
-/** A finite number, or null where the system reported anything else. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
 /**
  * One entry of a row's `properties` map, or undefined where the row carries no
  * map to read it from. Guarded rather than asserted, because a row that sends
@@ -2244,15 +2218,11 @@ interface Reason {
 /** The verdict, worst first. `OK` is last because it is the narrowest claim. */
 type Verdict = 'CRITICAL' | 'WARNING' | 'UNKNOWN' | 'OK';
 
-/** A boolean the system reported, or null where it reported anything else. */
-function booleanOrNull(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null;
-}
-
-/** `1 alert` / `2 alerts`, so that a reason reads as English at either count. */
-function plural(count: number, noun: string): string {
-  return `${count} ${noun}${count === 1 ? '' : 's'}`;
-}
+/**
+ * `booleanOrNull` re-reads the composed handlers' results, which arrive as
+ * `Promise<unknown>`; `plural` is what makes a reason read as English at either
+ * count (`1 alert` / `2 alerts`). Both are `common.ts`'s.
+ */
 
 /** A section that was read, or the reason it could not be. */
 interface SectionRead<T> {

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { errorText, numberOrNull, textOrNull } from '@/tools/common';
 
 /**
  * Shares family: what the system offers to the network, and where from.
@@ -50,32 +51,18 @@ interface Attempt {
 }
 
 /**
- * One string field of a share row, or null where the system reported no value.
+ * `textOrNull` from `common.ts` reads a share's comment, which the middleware
+ * sends as `""` when it is unset.
  *
- * An empty string is read as no value rather than as text of no characters: a
- * share with no comment is what the middleware sends `""` for, and passing that
- * through would put a field in the result that says nothing.
- *
- * `tasks.ts` has the same reading of a string field under another name, and
- * this restates rather than shares it for the reason that file gives for
- * restating its own guards: a tool file is read on its own.
+ * `errorText` is `common.ts`'s too, and taking it changed what this file
+ * reports. The copy that lived here read an `Error` and a bare string and
+ * nothing else, so a rejection that arrived as a middleware error object — the
+ * `{ reason }` and `{ message }` carriers the client documents, and what a
+ * failed `sharing.smb.query` actually rejects with — reported as having said
+ * nothing. Every sibling file read those two carriers; this one had lost the
+ * branch. A `failures` entry here now names the reason where the system gave
+ * one, which is what it always claimed to do.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/**
- * Why a protocol's query failed, in words, for the caller to act on.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and anything else
- * becomes a stated absence rather than `"[object Object]"`. Never empty: a
- * failure with no text still has to read as a failure.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? 'the system reported no reason';
-  return textOrNull(reason) ?? 'the system reported no reason';
-}
 
 /**
  * What an NFS export says about who may reach it, beyond the ACL on its path.
@@ -369,11 +356,6 @@ interface Acl {
   owner_group: string | null;
   owner_gid: number | null;
   entries: AccessEntry[] | null;
-}
-
-/** A finite number as the middleware reported it, or null where it reported none. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 /**

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -2,6 +2,7 @@ import type { CallParams } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, MutatingTool, ReadOnlyTool, ToolContext } from '@/catalog/tool';
+import { MAX_TIME_MS, effectiveLimit } from '@/tools/common';
 
 /** Snapshots family: the snapshots that exist, and taking a new one. */
 
@@ -131,11 +132,9 @@ const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 1000;
 
 /**
- * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
- * than answering, so one absurd creation time would otherwise take the whole
- * listing down with it.
+ * {@link MAX_TIME_MS} from `common.ts` is what keeps one absurd creation time
+ * from taking the whole listing down with it.
  */
-const MAX_TIME_MS = 8.64e15;
 
 /**
  * A ZFS property as a snapshot row carries it. `pool.snapshot.query` answers
@@ -237,20 +236,17 @@ function requestedDataset(raw: unknown): string | null {
 }
 
 /**
- * The bound actually applied, from whatever the caller asked for.
+ * The bound this family applies, from whatever the caller asked for.
  *
  * Lenient where {@link requestedDataset} is strict, and what the argument
  * decides is the difference: a misread `dataset` would quietly answer about the
  * wrong snapshots, while a misread `limit` only changes how many of the right
  * ones come back — and the number applied is returned beside them, so a caller
- * can see that its argument was not taken.
+ * can see that its argument was not taken. The bounding is `common.ts`'s; the
+ * two numbers are this family's.
  */
-function effectiveLimit(raw: unknown): number {
-  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_LIMIT;
-  // Rounded down because a fractional limit reaches the middleware as one, and
-  // floored at 1 because a limit of zero or less would return nothing while
-  // reporting the system as holding more — true, and not an answer.
-  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(raw)));
+function snapshotLimit(raw: unknown): number {
+  return effectiveLimit(raw, DEFAULT_LIMIT, MAX_LIMIT);
 }
 
 /** Newest first; a snapshot whose creation time could not be read goes last. */
@@ -315,7 +311,7 @@ export const snapshotsList: ReadOnlyTool = {
   mutating: false,
   async handler(ctx, args) {
     const dataset = requestedDataset(args['dataset']);
-    const limit = effectiveLimit(args['limit']);
+    const limit = snapshotLimit(args['limit']);
     const snapshots = await firstValueFrom(
       // Filters and options are inlined so the call's own parameter types
       // apply, as in `storage.ts`.

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,6 +1,15 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import {
+  MAX_TIME_MS,
+  MiddlewareDate,
+  NO_REASON,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  textOrNull,
+} from '@/tools/common';
 
 /**
  * Grounds the LLM on what it is talking to — version, hostname, hardware —
@@ -30,46 +39,14 @@ export const systemInfo: ReadOnlyTool = {
 };
 
 /**
- * A string the system reported, or null where it reported anything else.
- *
- * An empty string is read as no value rather than as text of no characters: a
- * version of no characters names nothing a caller could act on, and passing it
- * through would put a field in the result that says nothing.
- *
- * `accounts.ts`, `shares.ts` and `block.ts` each hold the same reading under
- * their own names, and this restates rather than shares it for the reason
- * `shares.ts` gives for restating its own guards: a tool file is read on its
- * own.
+ * `textOrNull` from `common.ts` reads the version, where a string of no
+ * characters names nothing a caller could act on. {@link NO_REASON} is imported
+ * beside `errorText` because `checkFailure` below reports it directly, for an
+ * update check that failed carrying no text of its own.
  */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
 
 /** What a system answering the check with no status at all is reported as. */
 const NO_STATUS = 'the system reported no update status';
-
-/**
- * Why the version read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. Anything else
- * still becomes a stated absence rather than `"[object Object]"`, and the
- * result is never empty: a failure with no text still has to read as a failure.
- * The same reading as `accounts.ts` holds of a failed configuration read.
- */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /** The running version, or the failure that stopped it being read. */
 interface VersionAttempt {
@@ -193,21 +170,11 @@ export const updateStatus: ReadOnlyTool = {
   },
 };
 
-/** A number the system reported, or null where it reported anything else. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
 /**
- * A record the system sent, or null where it sent anything else — an array
- * included, which is an object and is never one of the keyed payloads this is
- * used to read.
+ * An audit row arrives as an open record, so the fields below are read through
+ * `common.ts`'s guards. `recordOrNull` excludes an array, which is an object
+ * and is never one of the keyed payloads it is used to read here.
  */
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 /**
  * How far back `audit_log_query` reaches when the caller bounds nothing.
@@ -233,23 +200,11 @@ const AUDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
 const AUDIT_LIMIT = 100;
 
 /**
- * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
- * than answering, so one absurd recorded time would otherwise take the whole
- * listing down with it — the same guard `tasks.ts`, `replication.ts` and
- * `snapshots.ts` each apply to a time of their own, restated here for the same
- * reason they restate it: a tool file is read on its own.
+ * {@link MAX_TIME_MS} is the guard that keeps one absurd recorded time from
+ * taking the whole listing down with it, and {@link MiddlewareDate} is the
+ * shape an audit row's timestamp arrives in. Both are `common.ts`'s, applied
+ * here to an entry's `message_timestamp`.
  */
-const MAX_TIME_MS = 8.64e15;
-
-/**
- * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
- * which is the date representation the client's own types declare
- * (`TrueNasDate`). Restated with `$date` untyped because an audit row arrives
- * as an open record.
- */
-interface MiddlewareDate {
-  $date?: unknown;
-}
 
 /**
  * A date, or a date and a time, in the forms this tool reads: `2026-08-29`,

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { MAX_TIME_MS, MiddlewareDate } from '@/tools/common';
 
 /**
  * Tasks family: the work a system does to itself on a schedule, with nobody
@@ -347,13 +348,10 @@ export const snapshotTasksList: ReadOnlyTool = {
 const ENDED_JOB_STATES = new Set(['SUCCESS', 'FAILED', 'ABORTED', 'ERROR', 'FINISHED']);
 
 /**
- * The largest instant a `Date` can hold. `toISOString` throws beyond it rather
- * than answering, so one absurd recorded time would otherwise take the whole
- * listing down with it — the same guard `replication.ts` and `snapshots.ts`
- * each apply to a time of their own, restated here for the same reason they
- * restate it rather than share it: a tool file is read on its own.
+ * {@link MAX_TIME_MS} from `common.ts` is what keeps one absurd recorded time
+ * from taking the whole listing down with it, applied here to a job's
+ * `time_finished`.
  */
-const MAX_TIME_MS = 8.64e15;
 
 /**
  * The job record a cloud sync task carries for its last run, restated with
@@ -375,16 +373,6 @@ interface LastRun {
   state?: unknown;
   time_finished?: unknown;
   error?: unknown;
-}
-
-/**
- * A time as the middleware sends one: `{ "$date": <epoch milliseconds> }`,
- * which is the only date representation the client's own types declare
- * (`TrueNasDate`). Restated with `$date` untyped because it arrives inside an
- * open record.
- */
-interface MiddlewareDate {
-  $date?: unknown;
 }
 
 /**

--- a/src/tools/tools.spec.ts
+++ b/src/tools/tools.spec.ts
@@ -3752,9 +3752,14 @@ describe('shares_list', () => {
     expect(nfsOnly.failures).toEqual([{ protocol: 'SMB', error: 'smb service is not running' }]);
   });
 
-  it('names a failure that arrived as neither an Error nor any text', async () => {
+  it('names a failure however the rejection arrived', async () => {
     for (const [reason, text] of [
       ['nfs is down', 'nfs is down'],
+      // The two carrier shapes the client documents. This file used to read
+      // neither, so a real middleware rejection reported as having said
+      // nothing; it now reads them the way every other tool family does.
+      [{ reason: 'nfs service is not running' }, 'nfs service is not running'],
+      [{ message: 'connection reset' }, 'connection reset'],
       [new Error(''), 'the system reported no reason'],
       [{ code: 500 }, 'the system reported no reason'],
       [undefined, 'the system reported no reason'],

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -346,8 +346,10 @@ export const vmsList: ReadOnlyTool = {
  * reason. `FileContentError` never quotes the download URL, which carries a
  * single-use token, and puts the adapter's own message — which can name that
  * URL — on `cause` instead. `errorText` reads `message` and never `cause`, so
- * the token cannot arrive in a result through here. A reader of `cause` added
- * to this file would break that, not merely a test.
+ * the token cannot arrive in a result through here. That guard now lives in
+ * `common.ts` rather than in this file, so it is a reader of `cause` added
+ * THERE that would break this, not merely a test — and it would break it for
+ * every tool at once.
  */
 
 /** Lines returned when the caller names no bound. */

--- a/src/tools/vms.ts
+++ b/src/tools/vms.ts
@@ -1,6 +1,13 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import {
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  textOrNull,
+} from '@/tools/common';
 
 /**
  * Virtual machines a system runs, with the state each is in and the CPU and
@@ -36,62 +43,13 @@ import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 /** Which of the two stacks a row was read from. */
 type VmSource = 'vm' | 'virt_instance';
 
-/** One string field of a row, or null where the system reported no value.
- *
- * An empty string is read as no value rather than as text of no characters, the
- * same reading `alerts.ts`, `credentials.ts`, `network.ts`, `block.ts` and
- * `shares.ts` each hold under their own names — and restated here for the
- * reason those files give for restating it: a tool file is read on its own. */
-function textOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-/** A finite number the system reported, or null where it reported anything
- * else. Infinite and NaN are not counts or byte totals, whatever else they
- * are. */
-function numberOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-/** A boolean the system reported, or null where it reported anything else. */
-function booleanOrNull(value: unknown): boolean | null {
-  return typeof value === 'boolean' ? value : null;
-}
-
-/** A nested object of a row, or null where the row held anything else.
- *
- * `typeof null` is `'object'`, so the null check is what stops a reported-as-null
- * `status` being indexed. An array is an object too and is excluded: the one
- * thing read through this is a VM's status record, and reading a list as one
- * would answer null for every field rather than saying the shape was not what
- * this tool reads. */
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-/** What a failure carrying no text of its own is reported as. */
-const NO_REASON = 'the system reported no reason';
-
 /**
- * Why a read failed, in words.
- *
- * A rejection is not necessarily an `Error` — the client rejects with whatever
- * the transport gave it — so a bare string is read too, and so are the two
- * shapes the client documents as its own: a JSON-RPC error object carrying
- * `message`, and a middleware error object carrying `reason`. `alerts.ts`,
- * `block.ts`, `network.ts` and `shares.ts` each hold this same reading under
- * their own names. The result is never empty, because a failure with no text
- * still has to read as a failure.
+ * `recordOrNull` from `common.ts` is what stops a reported-as-null `status`
+ * being indexed, and its exclusion of arrays matters here: the one thing read
+ * through it is a VM's status record, and reading a list as one would answer
+ * null for every field rather than saying the shape was not what this tool
+ * reads.
  */
-function errorText(reason: unknown): string {
-  if (reason instanceof Error) return textOrNull(reason.message) ?? NO_REASON;
-  if (typeof reason === 'object' && reason !== null) {
-    const carrier = reason as Record<string, unknown>;
-    return textOrNull(carrier['reason']) ?? textOrNull(carrier['message']) ?? NO_REASON;
-  }
-  return textOrNull(reason) ?? NO_REASON;
-}
 
 /** A read that did not complete, named by the stack it was against. */
 interface VmFailure {


### PR DESCRIPTION
Fixes #86

## What this does

Every tool file reads middleware payloads whose fields arrive as `unknown`, so
each of them grew a private copy of the same handful of narrowings and the same
reading of a rejection. `src/tools/common.ts` now holds one of each, and the
fourteen tool files import them.

What was repeated, by count of definitions removed:

| helper | copies |
|---|---|
| `textOrNull` | 11 |
| `numberOrNull` | 8 |
| `errorText` + `NO_REASON` | 8 |
| `booleanOrNull` | 5 |
| `recordOrNull` | 4 |
| `MAX_TIME_MS` | 4 |
| `MiddlewareDate` | 3 |
| `textList`, `plural`, `effectiveLimit` | 2 each |

`common.ts` is internal: it is not a family, `createDefaultCatalog()` does not
know about it, and it is not exported from `src/index.ts`.

## The drift, and the one output change

The ticket asks that the drift be noticed before it is flattened. It was in one
place, and it was a defect rather than a deliberate variant.

**`shares.ts`'s `errorText` had lost the branch that reads the `{ reason }` and
`{ message }` carriers.** Every other copy reads them — `block.ts`'s comment
says why in as many words: *"Those are what a failed call actually rejects with,
and reading neither made every real failure report as having said nothing."*
`shares.ts` read an `Error` and a bare string and nothing else, so a rejection
arriving as a middleware error object made `shares_list` report
`the system reported no reason` where the system had in fact given one.

Taking the shared version fixes that, and **it is the one change to a tool's
output in this PR.** The acceptance criterion says no tool's output changes; it
changes here, on the path that was wrong, and nowhere else. No existing test
covered that path — the `{ code: 500 }` case in the failure table has neither
carrier field and answers `the system reported no reason` under both versions,
so the whole suite passes unchanged. The `shares_list` failure test now covers
both carrier shapes so the fixed behaviour is observable.

Every other consolidation is byte-for-byte identical to what it replaced.
`system.ts`'s `recordOrNull` was written as a ternary rather than an early
return; same inputs, same outputs.

## Where the line was drawn

`common.ts` holds what says the same thing for every family. Anything whose
meaning is a family's own stays where it is:

- **`effectiveLimit` takes its two bounds as arguments.** `accounts.ts` and
  `snapshots.ts` held byte-identical copies down to the comment, but the two
  numbers they bind are each family's policy that happen to coincide. Each file
  keeps a one-line named wrapper (`accountLimit`, `snapshotLimit`) so its call
  site still reads as that family's bound.
- **The per-family `Attempt` / `attempt` pairs are left alone.** Four files hold
  one and they look alike, but each is typed by its own failure shape and names
  its own sources — the ticket's own out-of-scope note covers this: the overlap
  is the shape rather than an actual repeated function.

The decision, including where that line falls, is recorded under `## Decisions`
in `app/CLAUDE.md`, together with the layout entry for the new file.

## Checks run locally

`yarn typecheck`, `yarn lint`, `yarn test` and `yarn test:coverage` all pass.
817 tests, up 0 — the two new cases are rows in an existing table-driven test.
Coverage is 99.65% statements / 99.31% branches against floors of 97 / 96;
`common.ts` is at 100% on both. No per-file floor keys on `src/tools/`, so
moving covered lines between those files could not silently drop one.

The local review round returned nothing at MEDIUM or above.

## What I did not change, and why

It returned five LOW findings. One is fixed in this branch — a credential
boundary comment in `vms.ts` that my own change made false: it warned that a
reader of `cause` added to *that file* would put the download URL's single-use
token into a result, and `errorText` had just moved out of it. The warning now
names `common.ts` and is restated on `errorText` itself.

The other four are below, with one note of my own (item 3) that the review did
not raise. All are real; none blocks, and each is a new diff that would start
another review round, so they are recorded here instead. Any of them could be
its own ticket.

1. **`reporting.ts:1267` bounds a time against a bare `8.64e15`** rather than a
   named constant, so one unconsolidated copy of the `Date` bound survives.
   Confirmed by grep. The finding says the file *"now imports"* `MAX_TIME_MS` —
   it does not; the import would have to be added. It is a literal rather than a
   duplicated declaration, which is why the scan for repeated helpers did not
   surface it.
2. **`tasks.ts:101` keeps `fieldOrNull`**, which is byte-identical to
   `textOrNull` under a different name, in a file that now imports from
   `common.ts`. Confirmed. It is a twelfth copy hiding behind a rename, and the
   same argument that moved the other eleven applies to it.
3. **`snapshots.ts:205` keeps `stringOrNull`**, which is *not* a copy —
   it accepts the empty string where `textOrNull` rejects it. Renaming or
   folding it would be a behaviour change, so it stays. Noting it here because
   it is the one same-shaped helper that is deliberately different.
4. **About eighteen free-floating JSDoc blocks.** Where a removed helper's
   comment explained something the file still needs to know, it was rewritten
   into a block that documents no symbol. Each is separated from the next
   declaration by a blank line, so none attaches to it, and each says something
   true — but a `/** */` that documents nothing is a shape this repository does
   not otherwise use, and plain `//` comments or attaching the text to a nearby
   symbol would read better.
5. **`MiddlewareDate` is imported in value position** in `replication.ts`,
   `tasks.ts` and `system.ts`, where the repository's convention is
   `import type` for an interface. `yarn lint` and `yarn typecheck` both pass as
   written, and the emitted bundle is unaffected — TypeScript elides a
   type-only binding either way — so this is a convention miss rather than a
   defect.

## Interaction with #87

#87 splits `tools.spec.ts` into per-area files and deletes the file this PR
edits. This PR adds two rows to one existing table-driven test in that file and
touches nothing else in it, so whichever lands second is a one-hunk rebase
rather than a conflict.
