### PR TITLE
chore(deps): update @truenas/api-client to 4.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,11 +188,43 @@ a rollup that scored health its own way would be the drifting second opinion
 composites exist to prevent. **Summarise by dropping fields, never by
 recomputing them**, and point the caller at the composed tool for the detail.
 
+### Name a payload type off the call, never off the entity (#91)
+
+`@truenas/api-client` 4.x declares a concrete interface for payloads 2.x typed
+as `Record<string, unknown>` — `network.configuration.config`, `disk.query`,
+`interface.query`, `nvmet.subsys.query` and `pool.dataset.query` among them. A
+tool that now needs to name one of those payloads has two routes, and only one
+of them survives the next regeneration:
+
+- **Derive it from the method**, through the client's own `QueryEntity` and
+  `CallResponse` over `ApiSurface` — `QueryEntity<ApiSurface['call'],
+  'nvmet.subsys.query'>`, `CallResponse<ApiSurface, 'network.configuration.config'>`.
+  This is what `block.ts` and `network.ts` do, and it is the same move
+  `snapshots.ts` already made for arguments with `CallParams`.
+- **Do not import the generated entity by name.** The generator suffixes a
+  colliding interface `$1`/`$2`/`$N`, and the suffix a type carries in one
+  release is not the one it carries in the next: `AppEntry$1` became
+  `AppEntry$2` across this bump, and `ReplicationEntry.transport`'s enum was
+  renamed `Transport` → `ReplicationCountEligibleManualSnapshotsTransport` with
+  identical members. Importing either name would have broken on a rename that
+  changed nothing.
+
+**A declared type is a claim about what the middleware sends, not the value
+received, so it does not retire a guard.** Every field named through one of
+these aliases is still read through `common.ts` — the bump did not delete a
+single `textOrNull`. Where a type says a field is required and the code falls
+back anyway, the fallback is the load-bearing half: `network.ts`'s
+`hostname_local` is declared `string` and is an extend rather than a stored
+field, so a release that does not add it still answers.
+
 ### The shared guards live in `src/tools/common.ts` (#86)
 
-Every tool file reads middleware payloads whose fields arrive as `unknown`, so
-each needed the same narrowings — `textOrNull`, `numberOrNull`, `booleanOrNull`,
-`recordOrNull`, `textList` — and the same reading of a rejection, `errorText`.
+Every tool file reads middleware payloads whose declared shape it does not take
+as given, so each needed the same narrowings — `textOrNull`, `numberOrNull`,
+`booleanOrNull`, `recordOrNull`, `textList` — and the same reading of a
+rejection, `errorText`. The pinned client left many of those payloads as
+`unknown` outright; 4.x declares nearly all of them, which changed what the
+compiler knows and not what a system sends (#91).
 Each file grew a private copy, on the stated ground that a tool file is read on
 its own. Eleven copies of `textOrNull` later, they had not all stayed identical:
 `shares.ts`'s `errorText` had lost the branch that reads the `{ reason }` and

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@truenas/api-client": "^2.0.0",
+    "@truenas/api-client": "^4.0.0",
     "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
-    "@truenas/api-client": "^2.0.0",
+    "@truenas/api-client": "^4.0.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.18.0",

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -1,6 +1,7 @@
+import type { QueryEntity } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
 import { booleanOrNull, errorText, numberOrNull, textOrNull } from '@/tools/common';
 
 /**
@@ -523,6 +524,9 @@ interface Read<T> {
   reason: unknown;
 }
 
+/** One NVMe-oF subsystem, as the API surface in use types a row of it. */
+type SubsystemRow = QueryEntity<ApiSurface['call'], 'nvmet.subsys.query'>;
+
 /**
  * The subsystems, with a rejection kept as it arrived rather than reduced to
  * text.
@@ -532,11 +536,14 @@ interface Read<T> {
  * rejection it is, and `attempt` has already thrown that away by the time its
  * caller sees a `Failure`.
  *
- * The rows are `Record<string, unknown>[]` because that is how the pinned
- * client types a subsystem entry — untyped, unlike the namespace and join rows
- * beside it — rather than because this widens anything.
+ * The rows are named off the call through the client's own `QueryEntity` rather
+ * than by importing the generated entity: the surface decides which version's
+ * shape that is, and a regeneration that renames the interface does not reach
+ * this file. It is a claim about what the middleware sends and not one this
+ * tool acts on — every field below is still read through a guard, because a
+ * declared type is not a received value.
  */
-function readSubsystems(system: SystemHandle): Promise<Read<Record<string, unknown>[]>> {
+function readSubsystems(system: SystemHandle): Promise<Read<SubsystemRow[]>> {
   return firstValueFrom(system.client.api.query('nvmet.subsys.query')).then(
     (rows) => ({ rows, reason: null }),
     (reason: unknown) => ({ rows: null, reason }),

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -349,12 +349,12 @@ export const iscsiList: ReadOnlyTool = {
 };
 
 /**
- * The NVMe-oF reads below need `numberOrNull` where the iSCSI ones do not: the
- * pinned client types a subsystem entry as `Record<string, unknown>`, so every
- * field of one — including the id the other two reads are joined on — arrives
- * as `unknown` and has to be read rather than trusted. Non-finite is excluded
- * there for a reason this family feels directly: an id that is `NaN` joins
- * nothing and a size that is `NaN` measures nothing.
+ * The NVMe-oF reads below need `numberOrNull` where the iSCSI ones do not: a
+ * subsystem's id is what the other two reads are joined on, and the client
+ * declaring it `number` is a claim about what the middleware sends rather than
+ * about the value received, so it is read rather than trusted. Non-finite is
+ * excluded there for a reason this family feels directly: an id that is `NaN`
+ * joins nothing and a size that is `NaN` measures nothing.
  */
 
 /** One namespace of a subsystem: a block device, as an initiator addresses it. */

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -2,11 +2,16 @@
  * The guards and constants the tool files share, in one place rather than one
  * copy per family.
  *
- * Every tool in `src/tools/` reads middleware payloads whose fields arrive as
- * `unknown`, so each of them needs the same handful of narrowings — is this a
- * string, a finite number, a record — and each of them needs the same reading
- * of a rejection. Those grew as a private copy per file, on the stated ground
- * that a tool file is read on its own. They did not all stay identical: by the
+ * Every tool in `src/tools/` reads middleware payloads whose declared shape it
+ * does not take as given, so each of them needs the same handful of narrowings
+ * — is this a string, a finite number, a record — and each of them needs the
+ * same reading of a rejection. The pinned client typed many of these payloads
+ * as `unknown` outright; `@truenas/api-client` 4.x declares nearly all of them,
+ * which changed what the compiler knows and not what a system sends, so nothing
+ * below was retired by the bump.
+ *
+ * Those narrowings grew as a private copy per file, on the stated ground that a
+ * tool file is read on its own. They did not all stay identical: by the
  * time this module was cut, `shares.ts`'s `errorText` had lost the branch that
  * reads a middleware error object, so a real rejection there reported as having
  * said nothing while every sibling file reported its reason.

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -21,13 +21,11 @@ import { errorText, numberOrNull, recordOrNull, textList, textOrNull } from '@/t
  * the two things the catalog wants here (interface state, and the VLANs and
  * bridges above it) are one tool rather than two reads of the same rows.
  *
- * The pinned client types the query response as `Record<string, unknown>`
- * (`InterfaceEntry` is a bare record), so every field is read rather than
- * trusted, the way `storage.ts` reads a ZFS property. The field NAMES below come
- * from the client's own `InterfaceEntryInput` and `InterfaceEntryState`
- * declarations, which describe this same record on the create and event sides;
- * they are strong evidence and not a guarantee about the query response, and a
- * name that turns out wrong costs a null rather than a wrong value.
+ * Every field is read rather than trusted, the way `storage.ts` reads a ZFS
+ * property. The client declares `InterfaceEntry` and the field NAMES below
+ * agree with it, but a declaration is a claim about what the middleware sends
+ * rather than about the value received — strong evidence and not a guarantee,
+ * and a name that turns out wrong costs a null rather than a wrong value.
  *
  * The mapping is an allowlist rather than a trim, as in `pools.ts`. A raw
  * interface row carries the whole `state` sub-object — supported media lists,
@@ -39,12 +37,12 @@ import { errorText, numberOrNull, recordOrNull, textList, textOrNull } from '@/t
  */
 
 /**
- * The pinned client answers `interface.query` as a bare record, so every field
- * and every sub-object of one arrives as `unknown` and is read through
- * `common.ts`'s guards. `recordOrNull` is what stops a reported-as-null `state`
- * being indexed, and what keeps a list from being read as a record: `state` and
- * a port entry are records, and reading a list as one would answer null for
- * every field rather than saying the shape was not what this tool reads.
+ * Every field of an `interface.query` row, and every sub-object of one, is read
+ * through `common.ts`'s guards rather than off the client's declaration.
+ * `recordOrNull` is what stops a reported-as-null `state` being indexed, and
+ * what keeps a list from being read as a record: `state` and a port entry are
+ * records, and reading a list as one would answer null for every field rather
+ * than saying the shape was not what this tool reads.
  */
 
 /** The entries of a list field, or an empty list where the field was not one. */
@@ -357,18 +355,16 @@ export const networkInterfaces: ReadOnlyTool = {
  * has the reverse.
  *
  * That comparison is what distinguishes an inherited value from a configured
- * one, rather than a field on the configuration saying so. The client types the
- * configuration response as a bare `Record<string, unknown>` — nothing about it
- * is guaranteed by the types — while `NetworkGeneralSummaryResult` IS typed,
- * with `default_routes` and `nameservers` on it. So the effective side is the
- * grounded half and the configured side is read defensively, field by field,
- * the way an interface row is read above. Most configured field NAMES come from
- * the client's own `NetWorkConfigurationUpdate`, which describes this same
- * record on the update side: strong evidence rather than a guarantee, and a
- * name that turns out wrong costs a null rather than a wrong value. The
- * exception is `hostname_local`, which the middleware adds when it READS the
- * record and so cannot appear on an update type — see `localHostname`, which
- * is why that one is read with a fallback rather than on its own.
+ * one, rather than a field on the configuration saying so. The client declares
+ * both sides — `NetworkConfiguration` here and `NetworkGeneralSummaryResult`
+ * for the summary — and neither declaration is what either side is read
+ * through: the configured side is read defensively, field by field, the way an
+ * interface row is read above, and a name that turns out wrong costs a null
+ * rather than a wrong value. `hostname_local` is the field that most needs
+ * that. The middleware adds it when it READS the record rather than storing it,
+ * so a release that does not add it still answers with the field that was
+ * correct before HA — see `localHostname`, which is why that one is read with a
+ * fallback rather than on its own, whatever the type says it is.
  *
  * Only the configuration read can fail the tool. A system whose configuration
  * read and whose routes did not still has most of an answer, and `failures` is

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -1,6 +1,7 @@
+import type { CallResponse } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool } from '@/catalog/tool';
 import { errorText, numberOrNull, recordOrNull, textList, textOrNull } from '@/tools/common';
 
 /**
@@ -473,6 +474,19 @@ function gatewayReport(
   };
 }
 
+/**
+ * The system-wide network settings, as the API surface in use types the
+ * `network.configuration.config` response.
+ *
+ * Named off the call through the client's own `CallResponse` rather than by
+ * importing the generated entity, so the surface decides which version's shape
+ * this is and a regeneration that renames the interface does not reach this
+ * file. It says what the middleware is declared to send, which is not what this
+ * tool acts on: every field below is still read through a guard, and
+ * `localHostname` still falls back for the same reason it always did.
+ */
+type NetworkConfiguration = CallResponse<ApiSurface, 'network.configuration.config'>;
+
 /** One DNS server, and what this tool can say about where it came from. */
 interface NameserverReport {
   address: string;
@@ -493,13 +507,13 @@ interface NameserverReport {
  * not report as one that is definitely unused.
  */
 function nameserverReports(
-  config: Record<string, unknown>,
+  config: NetworkConfiguration,
   effective: string[] | null,
 ): NameserverReport[] {
   // Three numbered fields rather than a list: that is the shape the middleware
   // holds them in, and a server configured in the third slot with the second
   // left empty is ordinary.
-  const configured = ['nameserver1', 'nameserver2', 'nameserver3'].flatMap((key) => {
+  const configured = (['nameserver1', 'nameserver2', 'nameserver3'] as const).flatMap((key) => {
     const address = textOrNull(config[key]);
     return address === null ? [] : [address];
   });
@@ -566,7 +580,7 @@ function staticRouteRows(routes: unknown): StaticRouteRow[] | null {
  * could not read it from, still has the field that was correct before HA — and
  * on a single-node system the two are the same value anyway.
  */
-function localHostname(config: Record<string, unknown>): string | null {
+function localHostname(config: NetworkConfiguration): string | null {
   return textOrNull(config['hostname_local']) ?? textOrNull(config['hostname']);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,12 +796,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@truenas/api-client@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@truenas/api-client@npm:2.0.0"
+"@truenas/api-client@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@truenas/api-client@npm:4.0.1"
   peerDependencies:
     rxjs: ^7.8.0
-  checksum: 10c0/32e484524ff31af5cd1d17285901f948a68ea9095aad075dde0dd9af7ea2430383d78ad48b7ccf1ea08abeb1a6c3acf726ed35834723d197138533f54ca6817e
+  checksum: 10c0/2a923b5dee53e139d4bfe36afc1c416e0fba0d7ac6b24a5cd7a00525493d5ee2ef49e75462c5833c56cb243bf0fb88f551525170b1eb7e8d57916c9e915667c6
   languageName: node
   linkType: hard
 
@@ -810,7 +810,7 @@ __metadata:
   resolution: "@truenas/mcp-base@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.18.0"
-    "@truenas/api-client": "npm:^2.0.0"
+    "@truenas/api-client": "npm:^4.0.0"
     "@types/node": "npm:^22.0.0"
     "@vitest/coverage-v8": "npm:^3.0.0"
     eslint: "npm:^9.18.0"
@@ -821,7 +821,7 @@ __metadata:
     typescript-eslint: "npm:^8.20.0"
     vitest: "npm:^3.0.0"
   peerDependencies:
-    "@truenas/api-client": ^2.0.0
+    "@truenas/api-client": ^4.0.0
     rxjs: ^7.8.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fixes #91.

`package.json` asked for `^2.0.0` in both `peerDependencies` and
`devDependencies` and `yarn.lock` resolved 2.0.0, two majors behind the
published 4.0.1. Both ranges now name `^4.0.0`, the lockfile resolves 4.0.1,
and the installed tree matches it.

## What the regeneration actually changed

The ticket's design note says the risk is entirely in entity shapes rather
than in method availability, and that the tools re-stating a payload shape
locally would not raise a compile error. That needed measuring rather than
compiling, so I measured it: for each of the 46 middleware methods `src/tools/`
calls, I resolved the entity or response type the v25.10.0 call directory names
in 2.0.0 and in 4.0.1 and compared them field by field, expanding nested types
and stripping the `$N` suffixes the generator adds on a name collision (a
textual diff of the two `.d.ts` files is 6,643 lines and almost all of it is
that renumbering).

**No method the tools call is absent from 4.0.1, and no field a tool reads was
removed or retyped.** What changed:

- **The dump-api `Record` fix (`0647d28`) is nearly all of it.** Payloads 2.0.0
  typed as `Record<string, unknown>` are now concrete interfaces —
  `network.configuration.config`, `interface.query`, `disk.query`,
  `nvmet.subsys.query`, `pool.dataset.query`, `pool.snapshot.query`,
  `staticroute.query`, `alertclasses.config` and
  `network.general.summary`'s IP sub-object among them. Type-level only; the
  fields are the ones the tools were already reading. Of the 46 methods, 39
  now resolve to a declared object type and the remaining 7 answer a scalar —
  nothing the tools call is still opaque.
- **Six entities gained a `description` field** — `CloudSyncEntry`,
  `CoreGetJobsItem`, `CoreGetJobsItemProgress`, `StaticRouteEntry`,
  `UpdateDownloadProgress` and `VMEntry`. The mapping is an allowlist rather
  than a trim, so none of them can reach a tool result without a change to a
  tool file. That is the convention doing its job, not an omission.
- **`ReplicationEntry.transport`'s enum was renamed** `Transport` →
  `ReplicationCountEligibleManualSnapshotsTransport`, with identical members
  (`SSH`, `SSH+NETCAT`, `LOCAL`).

`DefaultApiDirectory` is `ApiDirectoryV25_10_0` in both releases, so `ApiSurface`
in `src/catalog/tool.ts` is unchanged and no method appeared or disappeared
under it.

## The three type errors, and how they are fixed

All three were the same one: a concrete interface has no index signature, so it
is not assignable to `Record<string, unknown>`. `block.ts` typed
`readSubsystems`' rows that way and `network.ts` passed the configuration
payload to two helpers typed that way.

Both now name the payload **off the call** — `QueryEntity<ApiSurface['call'],
'nvmet.subsys.query'>` and `CallResponse<ApiSurface,
'network.configuration.config'>` — rather than by importing the generated
entity. That is the same move `snapshots.ts` already made for arguments with
`CallParams`, and it is the one that survives the next regeneration: `AppEntry$1`
became `AppEntry$2` across this bump and the `transport` enum was renamed
outright, so an imported entity name would have broken on a rename that changed
nothing.

**No guard was removed and no tool output changed.** A declared type is a claim
about what the middleware sends, not the value received, so every field is still
read through `common.ts`. The one place this matters concretely is
`network.ts`'s `hostname_local`: 4.x declares it `string` and required, and it
is a read-side extend rather than a stored field, so `localHostname`'s fallback
to `hostname` is still load-bearing.

A second commit corrects three header comments in those two files that argued
from the old typing — most substantially `network_config`'s, which reasoned
that the configured side was the untyped half against a typed
`network.general.summary`. Both sides are typed now, so that asymmetry no
longer exists even though the defensive read stays. Comment text only.

`CLAUDE.md` gets a `## Decisions` entry for the off-the-call naming rule, since
eleven tool tickets follow this one and the obvious move — importing the entity
— is the one that breaks. Its `#86` entry and `common.ts`'s header both opened
by saying every payload field arrives as `unknown`, which this bump makes false;
both now say the thing that is still true, that the declared shape is not taken
as given.

## Verification

`yarn install && yarn lint && yarn typecheck && yarn test && yarn test:coverage`
all pass locally, plus `yarn build`. 817 tests, 29 files, no test's expected
values changed and no threshold key in `vitest.config.ts` touched (global
99.32% branches / 99.65% statements against floors of 96 / 97).

The local review round came back clean — nothing at MEDIUM or above — through
the same shared reviewer that runs as the required check.

## What I did not change

- **Eight untouched tool files carry the same now-stale claim** about the
  pinned client leaving payloads untyped (the review raised this as a LOW,
  citing `storage.ts`, `snapshots.ts`, `reporting.ts`, `accounts.ts`,
  `tasks.ts`, `replication.ts`, `disks.ts` and `certificates.ts`). It is real
  and this bump is what made it stale, but it is comment debt in files this
  diff does not otherwise touch, and rewriting eight more headers here would
  bury a dependency bump under prose. Worth its own ticket; the substance of
  the correction is already recorded in `CLAUDE.md` for whoever takes it.
- **`ApiSurface` is not widened.** Out of scope per the ticket and per the
  `CLAUDE.md` convention: it is a decision about the minimum supported TrueNAS
  version.
- **The connection fixes the bump picks up** (WebSocket close 1008 treated as
  terminal, CORS failure distinguished from an unreachable host) are behaviour
  inside the client and are not exercised by anything here.

One thing the ticket says that I could not reproduce: it reports the installed
`node_modules/@truenas/api-client` at 1.0.1 against a lockfile resolving 2.0.0.
The tree read 2.0.0 before I touched it, matching the lockfile. Either
something installed in between or the reading was of a different checkout —
noting it because the ticket gives it as half the reason for `priority:high`.
