### PR TITLE
feat(tools): add services_status, whether each service is enabled and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `directory_services_status`, `network_interfaces`, `network_config`,
   `certificates_list`, `cloud_credentials_list`, `alert_settings`,
   `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
-  `reporting_app_vm_usage`, `ha_status`, `system_health_report`,
-  `fleet_compliance_report`, `fleet_health_rollup`.
+  `reporting_app_vm_usage`, `services_status`, `ha_status`,
+  `system_health_report`, `fleet_compliance_report`, `fleet_health_rollup`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export {
   reportingDiskIo,
   reportingSpaceTrends,
   reportingAppVmUsage,
+  servicesStatus,
   haStatus,
   systemHealthReport,
   fleetComplianceReport,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the thirty-nine sketch tools', () => {
+  it('registers the forty sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -39,6 +39,7 @@ describe('createDefaultCatalog', () => {
       'reporting_disk_io',
       'reporting_space_trends',
       'reporting_app_vm_usage',
+      'services_status',
       'ha_status',
       'system_health_report',
       'fleet_compliance_report',
@@ -230,6 +231,12 @@ describe('createDefaultCatalog', () => {
   it('advertises network_config to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'network_config',
+    );
+  });
+
+  it('advertises services_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'services_status',
     );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import {
   reportingUtilisation,
   systemHealthReport,
 } from '@/tools/reporting';
+import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
@@ -24,7 +25,7 @@ import { auditConfig, auditLogQuery, systemInfo, updateStatus } from '@/tools/sy
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-eight read-only tools plus one mutating tool. */
+/** The sketch's catalog: thirty-nine read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -61,6 +62,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(reportingDiskIo);
   catalog.register(reportingSpaceTrends);
   catalog.register(reportingAppVmUsage);
+  catalog.register(servicesStatus);
   catalog.register(haStatus);
   catalog.register(systemHealthReport);
   catalog.register(fleetComplianceReport);
@@ -98,6 +100,7 @@ export {
   reportingSpaceTrends,
   reportingUtilisation,
   scrubHistory,
+  servicesStatus,
   shareAccess,
   sharesList,
   snapshotsList,

--- a/src/tools/services.spec.ts
+++ b/src/tools/services.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { fakeSystem } from '@/testing/fake-systems';
+import { servicesStatus } from '@/tools/index';
+
+describe('services_status', () => {
+  /** A service row as `service.query` reports one. */
+  const service = (over: Record<string, unknown> = {}) => ({
+    id: 4,
+    service: 'cifs',
+    enable: true,
+    state: 'RUNNING',
+    pids: [2451, 2452],
+    ...over,
+  });
+
+  const listed = async (rows: unknown[]): Promise<Record<string, unknown>[]> => {
+    const { ctx } = fakeSystem({ ['service.query']: rows });
+    return (await servicesStatus.handler(ctx, {})) as Record<string, unknown>[];
+  };
+
+  /** One service, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([service(over)]))[0];
+
+  it('maps a service to its name, boot setting and run state', async () => {
+    expect(await listed([service()])).toEqual([
+      { service: 'cifs', start_on_boot: true, state: 'RUNNING' },
+    ]);
+  });
+
+  it('reports the middleware name rather than the protocol as a person says it', async () => {
+    // The whole reason the description carries the `cifs`/`iscsitarget`
+    // examples: a caller matching on "SMB" finds nothing, and a remapping here
+    // would be a second vocabulary to keep in step with TrueNAS's own.
+    const rows = await listed([
+      service({ service: 'cifs' }),
+      service({ id: 5, service: 'iscsitarget' }),
+      service({ id: 6, service: 'nfs' }),
+    ]);
+    expect(rows.map((row) => row['service'])).toEqual(['cifs', 'iscsitarget', 'nfs']);
+  });
+
+  it('carries no field the tool does not name, including one a later release adds', async () => {
+    const rows = await listed([service({ ha_propagate: true })]);
+    expect(Object.keys(rows[0])).toEqual(['service', 'start_on_boot', 'state']);
+  });
+
+  it('does not report a service\'s process ids', async () => {
+    const rows = await listed([service({ pids: [2451, 2452] })]);
+    expect(rows[0]).not.toHaveProperty('pids');
+    expect(JSON.stringify(rows)).not.toContain('2451');
+  });
+
+  it('does not report the middleware row id', async () => {
+    const rows = await listed([service({ id: 4 })]);
+    expect(rows[0]).not.toHaveProperty('id');
+  });
+
+  it('keeps the boot setting and the run state apart', async () => {
+    // The mismatch is the finding the tool exists for, so the two fields have
+    // to disagree where the system says they disagree rather than being folded
+    // into one reading.
+    expect(await one({ enable: true, state: 'STOPPED' })).toEqual({
+      service: 'cifs',
+      start_on_boot: true,
+      state: 'STOPPED',
+    });
+    expect(await one({ enable: false, state: 'RUNNING' })).toEqual({
+      service: 'cifs',
+      start_on_boot: false,
+      state: 'RUNNING',
+    });
+  });
+
+  it('reports a state outside the known set as the word the system used', async () => {
+    // `state` is typed `string` rather than a union, so a release that grows a
+    // third word must not have it coerced into one of the two known ones.
+    expect(await one({ state: 'STARTING' })).toMatchObject({ state: 'STARTING' });
+    expect(await one({ state: 'FAILED' })).toMatchObject({ state: 'FAILED' });
+  });
+
+  it('reports a state it could not read as null rather than as stopped', async () => {
+    expect(await one({ state: '' })).toMatchObject({ state: null });
+    expect(await one({ state: null })).toMatchObject({ state: null });
+    expect(await one({ state: 0 })).toMatchObject({ state: null });
+  });
+
+  it('reports a boot setting it could not read as null rather than as false', async () => {
+    expect(await one({ enable: null })).toMatchObject({ start_on_boot: null });
+    expect(await one({ enable: 'true' })).toMatchObject({ start_on_boot: null });
+    expect(await one({ enable: 1 })).toMatchObject({ start_on_boot: null });
+  });
+
+  it('reports a name it could not read as null, so the row matches no protocol', async () => {
+    expect(await one({ service: '' })).toMatchObject({ service: null });
+    expect(await one({ service: null })).toMatchObject({ service: null });
+    expect(await one({ service: 7 })).toMatchObject({ service: null });
+  });
+
+  it('returns nothing for a system that reported no services', async () => {
+    expect(await listed([])).toEqual([]);
+  });
+
+  it('asks for the services', async () => {
+    const { ctx, query } = fakeSystem({ ['service.query']: [] });
+    await servicesStatus.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('service.query');
+  });
+});

--- a/src/tools/services.ts
+++ b/src/tools/services.ts
@@ -1,0 +1,105 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool } from '@/catalog/tool';
+import { booleanOrNull, textOrNull } from '@/tools/common';
+
+/**
+ * Services family: which of the system's services are meant to run, and which
+ * are running.
+ *
+ * Every other tool that touches a served protocol reports the CONFIGURATION and
+ * stops there — `shares_list` says an SMB share exists, `iscsi_list` says a
+ * target and its extents exist, `network_config` says which addresses the box
+ * answers on. None of them can say whether the daemon serving any of it is up,
+ * which is the first thing "why can't I reach my share?" turns on.
+ *
+ * `service.query` answers exactly that and nothing else: one row per service,
+ * carrying whether it starts at boot and what state it is in now. The two are
+ * independent facts and the interesting reading is where they disagree, so they
+ * are reported as two fields and never folded into one verdict — see the
+ * description.
+ *
+ * WHAT THIS FAMILY DELIBERATELY DOES NOT DO:
+ *
+ * - **It does not start, stop or restart anything.** `service.start`,
+ *   `service.stop` and `service.restart` exist and are mutating; no tool here
+ *   is.
+ * - **It does not remap the service names.** The middleware calls SMB `cifs`
+ *   and iSCSI `iscsitarget`, which is not what a person calls them, and the
+ *   description carries those examples so a caller can match. A translation
+ *   table here would be a second vocabulary to keep in step with TrueNAS's
+ *   own, and the allowlist convention is to report what the API reports.
+ * - **It does not read a service's own configuration.** `smb.config`,
+ *   `nfs.config` and `ssh.config` answer a different question and are not
+ *   called.
+ */
+
+/** One service, as this tool reports it. */
+interface ServiceStatus {
+  service: string | null;
+  start_on_boot: boolean | null;
+  state: string | null;
+}
+
+export const servicesStatus: ReadOnlyTool = {
+  name: 'services_status',
+  description:
+    'Every service on a TrueNAS system, whether it is set to start at boot, ' +
+    'and what state it is in right now. This is what says whether the daemon ' +
+    'behind a configured share, export or target is actually up: `shares_list` ' +
+    'and `iscsi_list` report what is configured, and neither reports whether ' +
+    'anything is serving it. `service` IS THE MIDDLEWARE\'S OWN INTERNAL NAME ' +
+    'FOR THE SERVICE, NOT THE NAME THE WEB UI SHOWS — SMB is `cifs` and iSCSI ' +
+    'is `iscsitarget`, and NFS, SSH and the rest read `nfs`, `ssh` and so on. ' +
+    'The names are reported exactly as the system spells them and are not ' +
+    'translated, so match on the internal name rather than on the protocol as ' +
+    'a person would say it. `service` is null where the system reported no ' +
+    'name this tool could read, and such a row cannot be matched to a protocol ' +
+    'from here. `start_on_boot` is the service\'s `enable` setting: true means ' +
+    'the system is configured to start it at boot, false means it is not. IT ' +
+    'IS NOT WHETHER THE SERVICE IS RUNNING. `state` is that — the run state ' +
+    'the system reported, as the word the system itself used. `RUNNING` and ' +
+    '`STOPPED` are the two words seen in practice, but THE SET IS NOT CLOSED: ' +
+    'any other value is reported verbatim rather than coerced into one of ' +
+    'those two, and a word not listed here means the system said something ' +
+    'this tool has no reading of, not that the service is stopped. THE TWO ' +
+    'FIELDS ARE INDEPENDENT AND THE MISMATCH IS THE POINT. `start_on_boot` ' +
+    'true with a `state` that is not `RUNNING` is a service that is supposed ' +
+    'to be up and is not, which is the finding worth acting on; ' +
+    '`start_on_boot` false with `STOPPED` is just a service nobody turned on. ' +
+    'Both fields are null where the system reported no value this tool could ' +
+    'read, which is never the same as a service configured not to start or ' +
+    'one that is not running — a null is a row to look at directly, not an ' +
+    'answer about the service. AN EMPTY LIST IS A SYSTEM THAT REPORTED NO ' +
+    'SERVICES AT ALL, not a failure to read them: a read that fails raises ' +
+    'rather than returning nothing. This tool does not say WHY a service is ' +
+    'not running, does not report its process ids, and does not report its ' +
+    'configuration — `smb.config`, `nfs.config` and the like are a different ' +
+    'question and are not read here. It does not start, stop, restart or ' +
+    'change any service, or change whether one starts at boot. NO field ' +
+    'beyond the three named here is returned, whatever a later TrueNAS ' +
+    'release adds to a service record.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options: a system holds a few dozen services at most,
+    // all three fields reported are part of a service row as it stands, and the
+    // question this answers is about all of them rather than a named one —
+    // there is nothing to bound and no option that changes how they arrive.
+    const services = await firstValueFrom(system.client.api.query('service.query'));
+    return services.map(
+      (service): ServiceStatus => ({
+        service: textOrNull(service.service),
+        start_on_boot: booleanOrNull(service.enable),
+        state: textOrNull(service.state),
+        // `id` is a middleware row id with nothing on the other side of it to
+        // join to, and `pids` is process detail that says nothing a caller
+        // reasoning about availability can use — `state` already carries that.
+        // Both are dropped by being absent from this allowlist rather than by
+        // being removed from a copy, so a field a later release adds cannot
+        // reach a caller without a change here.
+      }),
+    );
+  },
+};


### PR DESCRIPTION
Fixes #92.

One read-only tool over `service.query`, in a new `src/tools/services.ts`.

Not one of the thirty-eight existing read-only tools could say whether the
daemon behind a configured share, export or target is up. `shares_list` reports
that an SMB share exists, `iscsi_list` reports targets and extents; neither can
say anything is serving them, which is what "why can't I reach my share?"
bottoms out at today.

## The method is on the pinned surface

Checked before building, as triage asked. `service.query` is in
`ApiCallDirectoryBase`'s `Pick` list, so it is on `DefaultApiDirectory` — the
client's oldest supported version, which `ApiSurface` still is. `ServiceEntry`
matches the ticket's design note exactly: `id`, `service`, `enable`, `state`,
`pids`, nothing else.

## What the result carries

Three fields, through an allowlist:

- **`service`** — the middleware's own internal name, **not remapped**. SMB is
  `cifs` and iSCSI is `iscsitarget`, so the description carries both examples
  and says outright to match on the internal name. A translation table here
  would be a second vocabulary to keep in step with TrueNAS's own, against the
  allowlist convention of reporting what the API reports.
- **`start_on_boot`** — the row's `enable`, renamed. `enable` sitting beside a
  `state` field reads as "is on" when the field that actually says so is the
  other one; `start_on_boot` is what the setting means and cannot be misread as
  the run state. The description names `enable` as its source so the two can
  still be lined up.
- **`state`** — the run state as the word the system used. Typed `string`
  rather than a union upstream, so a value outside `RUNNING`/`STOPPED` is
  reported verbatim rather than coerced, and the description says the set is
  **not closed** — an unlisted word means the system said something this tool
  has no reading of, not that the service is stopped.

**The two facts stay two fields and are never folded into one verdict.** The
mismatch is the point: `start_on_boot` true with a non-`RUNNING` state is a
service that is supposed to be up and is not; false with `STOPPED` is one
nobody turned on.

`pids` is dropped — process detail with nothing a caller reasoning about
availability can use, which `state` already answers. `id` is dropped too: a
middleware row id with nothing on the other side to join to, unlike
`cloud_credentials_list`'s, which `cloudsync_tasks_list` looks up against.
Both go by being absent from the allowlist rather than removed from a copy, so
a field a later release adds cannot reach a caller without a change to the file
— pinned by a test.

## Nulls

Every field is null where the system reported no value this tool could read,
and the description says that is never the same as a service configured not to
start, one that is not running, or one without a name. An empty list is a
system that reported no services, not a failed read: nothing here catches, so a
rejected query raises.

## Out of scope, as the ticket sets it

No mutating tool (`service.start`/`stop`/`restart` are not called), no
per-protocol configuration (`smb.config`, `nfs.config`, `ssh.config`), and no
`system_health_report` section. That last one is the ticket's named follow-on
and could not have been done earlier: the composite calls handlers rather than
the API (`CLAUDE.md`, #44), so it needed this tool to exist first.

## Registration

Registered after `reporting_app_vm_usage` and before `ha_status` — with the
plain single-subject reads, leaving the composite and fleet block at the end of
the list. `src/tools/index.ts`, its barrel export, `src/index.ts`, the
`createDefaultCatalog` exact-list assertion in `src/tools/index.spec.ts` (now
forty tools, with a read-only advertisement case beside it) and the `README.md`
listing are all updated. Tests are in `src/tools/services.spec.ts`, per the #87
decision that a tool's tests live in the spec named for its module.

No `CLAUDE.md` entry: this tool introduces no decision a later cycle would
guess wrong without — it follows the allowlist, null-meaning and per-module-spec
conventions already recorded there, and nothing it does makes an existing line
false.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test`, `yarn test:coverage` and
`yarn build` all pass locally. 830 tests across 30 files, 12 of them new;
`services.ts` is at 100% statements and branches, and no threshold key in
`vitest.config.ts` was touched (global 99.32% branches / 99.66% statements
against floors of 96 / 97).

**The local review round came back clean — nothing at MEDIUM or above** —
through the same shared reviewer that runs as the required check, in a separate
process.

## What I did not change

Both of the review's LOW findings are real and neither is fixed here, because
the clean round is the exit and every fix is a new unreviewed diff:

- **No test pins that a rejected `service.query` propagates rather than
  returning `[]`.** The description draws that distinction and the code holds it
  — nothing catches — but the guarantee is unobserved rather than merely
  untested elsewhere. Worth a test; it is one a later ticket can add without
  touching the tool.
- **The description does not disambiguate `services_status` from
  `directory_services_status`.** The names are close and answer unrelated
  questions (system daemons versus AD/LDAP), and `block.ts` sets a
  cross-referencing precedent this file does not follow. A one-line pointer in
  each description would settle it.
