### PR TITLE
feat(tools): add system_reboot_info, whether a reboot is pending and why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,24 @@ would report 100% for fixtures and move the global percentages without a line of
 the library being tested any better — the same reason `src/index.ts` is already
 excluded there.
 
+### An unreadable list entry is nulled or kept by which way it moves the summary (#93)
+
+`audit_config`'s `scopeNames` nulls its WHOLE list when one entry cannot be read;
+`system_reboot_info`'s `rebootReasons` KEEPS such an entry, as a pair of nulls.
+Both are the null/empty/unreadable convention below, and they disagree because
+the convention alone does not decide this — what decides it is the direction the
+shorter list moves the answer.
+
+Ask what an entry silently disappearing would make the result say. A scope one
+name shorter says the system does not audit that share, which is more than the
+read established, so the list is nulled to refuse the claim. A reason list one
+entry shorter runs towards EMPTY, and empty is `system_reboot_info`'s one
+positive finding — "nothing is pending" — so the entry stays and still counts
+towards `reboot_required`. **Drop towards a claim and you must null; drop towards
+a fact the tool asserts and you must keep.** Neither answer is the safe default,
+and a tool that copies whichever sibling it read first will land on the wrong one
+about half the time.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
-  `system_info`, `system_update_status`, `audit_log_query`, `audit_config`,
+  `system_info`, `system_update_status`, `system_reboot_info`,
+  `audit_log_query`, `audit_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
   `vms_list`, `vm_logs`, `alerts_list`, `snapshots_list`, `replication_status`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export {
   createDefaultCatalog,
   systemInfo,
   updateStatus,
+  rebootInfo,
   auditLogQuery,
   auditConfig,
   poolStatus,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,10 +3,11 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty sketch tools', () => {
+  it('registers the forty-one sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
+      'system_reboot_info',
       'audit_log_query',
       'audit_config',
       'storage_pool_status',
@@ -237,6 +238,12 @@ describe('createDefaultCatalog', () => {
   it('advertises services_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'services_status',
+    );
+  });
+
+  it('advertises system_reboot_info to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'system_reboot_info',
     );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,15 +21,16 @@ import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
-import { auditConfig, auditLogQuery, systemInfo, updateStatus } from '@/tools/system';
+import { auditConfig, auditLogQuery, rebootInfo, systemInfo, updateStatus } from '@/tools/system';
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: thirty-nine read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
   catalog.register(updateStatus);
+  catalog.register(rebootInfo);
   catalog.register(auditLogQuery);
   catalog.register(auditConfig);
   catalog.register(poolStatus);
@@ -94,6 +95,7 @@ export {
   poolStatus,
   poolTopology,
   quotaReport,
+  rebootInfo,
   replicationStatus,
   reportingAppVmUsage,
   reportingDiskIo,

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeSystem, failingSystem } from '@/testing/fake-systems';
-import { auditConfig, auditLogQuery, updateStatus } from '@/tools/index';
+import { auditConfig, auditLogQuery, rebootInfo, updateStatus } from '@/tools/index';
 
 describe('system_update_status', () => {
   /** `update.status` as the middleware sends it on a system with an update. */
@@ -744,6 +744,132 @@ describe('audit_config', () => {
     const { ctx, call, query } = fakeSystem({ ['audit.config']: config() });
     await auditConfig.handler(ctx, {});
     expect(call.mock.calls.map((args) => args[0])).toEqual(['audit.config']);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('system_reboot_info', () => {
+  /** `system.reboot.info` as the middleware sends it on a system with a reboot pending. */
+  const info = (over: Record<string, unknown> = {}) => ({
+    boot_id: '0f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f',
+    reboot_required_reasons: [
+      { code: 'FIPS', reason: 'FIPS mode was changed and requires a reboot' },
+    ],
+    ...over,
+  });
+
+  // Required rather than defaulted to `info()`: one of the cases below is a
+  // system answering with `undefined`, which a default would swallow.
+  const reported = async (answer: unknown): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['system.reboot.info']: answer });
+    return (await rebootInfo.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  /** The result for a payload differing only in the fields the case is about. */
+  const forInfo = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    reported(info(over));
+
+  it('reports a pending reboot with the code and the text of each reason', async () => {
+    expect(await reported(info())).toEqual({
+      reboot_required: true,
+      reasons: [{ code: 'FIPS', reason: 'FIPS mode was changed and requires a reboot' }],
+      boot_id: '0f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f',
+    });
+  });
+
+  it('reports every reason the system listed, in the order it listed them', async () => {
+    const result = await forInfo({
+      reboot_required_reasons: [
+        { code: 'FIPS', reason: 'FIPS mode was changed and requires a reboot' },
+        { code: 'SED', reason: 'A self-encrypting drive password was set' },
+      ],
+    });
+    expect(result['reasons']).toEqual([
+      { code: 'FIPS', reason: 'FIPS mode was changed and requires a reboot' },
+      { code: 'SED', reason: 'A self-encrypting drive password was set' },
+    ]);
+  });
+
+  it('reports a system with nothing pending as an explicit no', async () => {
+    // The whole point of `reboot_required`: the middleware states this by the
+    // length of a list, and false is a finding rather than an empty result the
+    // caller is left to interpret.
+    expect(await forInfo({ reboot_required_reasons: [] })).toEqual({
+      reboot_required: false,
+      reasons: [],
+      boot_id: '0f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f',
+    });
+  });
+
+  it('keeps "nothing pending" and "could not be read" apart', async () => {
+    // The pair this tool exists to distinguish. Above, false with an empty
+    // list; here, null with a null list — never the same answer.
+    for (const unreadable of [null, undefined, 'FIPS', 7, {}]) {
+      expect(await forInfo({ reboot_required_reasons: unreadable })).toMatchObject({
+        reboot_required: null,
+        reasons: null,
+      });
+    }
+  });
+
+  it('keeps a reason it could not read rather than dropping it towards empty', async () => {
+    // Dropping it would shorten the list towards empty, and empty is this
+    // tool's one positive finding. A reason it cannot read is still a reason.
+    const result = await forInfo({ reboot_required_reasons: ['FIPS', null, 7, []] });
+    expect(result['reasons']).toEqual([
+      { code: null, reason: null },
+      { code: null, reason: null },
+      { code: null, reason: null },
+      { code: null, reason: null },
+    ]);
+    expect(result['reboot_required']).toBe(true);
+  });
+
+  it('reports a code or a text it could not read as null, keeping the other', async () => {
+    const result = await forInfo({
+      reboot_required_reasons: [
+        { code: 'FIPS', reason: '' },
+        { code: null, reason: 'Something changed' },
+        { code: 7, reason: 7 },
+      ],
+    });
+    expect(result['reasons']).toEqual([
+      { code: 'FIPS', reason: null },
+      { code: null, reason: 'Something changed' },
+      { code: null, reason: null },
+    ]);
+  });
+
+  it('reports a boot id it could not read as null', async () => {
+    for (const unreadable of [null, undefined, '', 7]) {
+      expect(await forInfo({ boot_id: unreadable })).toMatchObject({ boot_id: null });
+    }
+  });
+
+  it('carries no field the tool does not name, including one a later release adds', async () => {
+    const result = await forInfo({ other_node: null, reboot_scheduled_at: '2026-08-29T09:00:00Z' });
+    expect(Object.keys(result)).toEqual(['reboot_required', 'reasons', 'boot_id']);
+  });
+
+  it('fails rather than answering nulls when the payload is not reboot information', async () => {
+    // Reached into rather than guarded, this would throw naming a property
+    // rather than the read that failed.
+    for (const answer of [null, undefined, 'rebooting', 7, []]) {
+      await expect(reported(answer)).rejects.toThrow(
+        'system.reboot.info did not answer with reboot information',
+      );
+    }
+  });
+
+  it('fails rather than answering "nothing pending" when the read could not be made', async () => {
+    const { ctx } = failingSystem({}, { ['system.reboot.info']: new Error('connection reset') });
+    await expect(rebootInfo.handler(ctx, {})).rejects.toThrow('connection reset');
+  });
+
+  it('never mutates: it reads the reboot information and nothing else', async () => {
+    const { ctx, call, query } = fakeSystem({ ['system.reboot.info']: info() });
+    await rebootInfo.handler(ctx, {});
+    expect(call.mock.calls.map((args) => args[0])).toEqual(['system.reboot.info']);
     expect(query).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -740,3 +740,130 @@ export const auditConfig: ReadOnlyTool = {
     };
   },
 };
+
+/** One reason the system gave for needing a restart, as this tool reports it. */
+interface RebootReason {
+  code: string | null;
+  reason: string | null;
+}
+
+/**
+ * The reasons the system listed, or null where it reported no list this tool
+ * could read.
+ *
+ * Those are different answers and this tool turns on keeping them apart: an
+ * empty list is the system saying nothing is pending, and no list at all is the
+ * system having said nothing about it.
+ *
+ * An entry that could not be read is kept as a pair of nulls rather than
+ * dropped, which is the opposite of the all-or-nothing reading
+ * {@link scopeNames} takes and is the same argument arriving at the other
+ * answer. There, a list one name shorter understates what is audited and the
+ * whole list is nulled to say so. Here, a list one reason shorter runs towards
+ * EMPTY — and empty is this tool's one positive finding, "nothing is pending".
+ * A reason this tool cannot read is still a reason the system raised, so it
+ * stays and it counts.
+ */
+function rebootReasons(value: unknown): RebootReason[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.map((entry) => {
+    const held = recordOrNull(entry);
+    return {
+      code: held === null ? null : textOrNull(held['code']),
+      reason: held === null ? null : textOrNull(held['reason']),
+    };
+  });
+}
+
+/**
+ * Whether the system is waiting to be restarted, and what made it necessary.
+ *
+ * This is the state a system sits in after an update or a configuration change
+ * that needs a restart — running, but not running what it is configured to run
+ * — and nothing else in this catalog reports it. `system_update_status` answers
+ * whether an update is AVAILABLE, and a system that has already taken one and
+ * not been restarted answers that with an honest "no": it is up to date, and it
+ * is not yet running what it updated to. An assistant summarising such a system
+ * from the tools that existed before this one describes it as current.
+ *
+ * `system.reboot.info` takes no arguments and its payload is already shaped for
+ * a reader — a list of reasons, each carrying a code and prose written for a
+ * person — so there is almost no normalization to do. What is left is the
+ * question of absence, and it is the sharp one here: the middleware's EMPTY
+ * list is the answer on a healthy system, so it has to read as a finding rather
+ * than as a result the caller is left to interpret. Hence `reboot_required`,
+ * derived from the list rather than reported beside it.
+ *
+ * WHAT THIS TOOL DELIBERATELY DOES NOT DO:
+ *
+ * - **It does not reboot anything, or schedule or cancel one.** `system.reboot`
+ *   exists and is mutating; no tool here is.
+ * - **It does not read the other node of an HA pair.**
+ *   `failover.reboot.info` answers the same question about the peer, and
+ *   `ha_status` is the tool that would grow it.
+ */
+export const rebootInfo: ReadOnlyTool = {
+  name: 'system_reboot_info',
+  description:
+    'Whether a TrueNAS system is waiting to be restarted, and what made it ' +
+    'necessary. This is the state a system sits in AFTER an update or a ' +
+    'configuration change that needs a restart — running, but not yet running ' +
+    'what it is configured to run — and NOTHING ELSE IN THIS CATALOG REPORTS ' +
+    'IT: `system_update_status` says whether an update is AVAILABLE, and a ' +
+    'system that has already taken one and not been restarted reports as up to ' +
+    'date, because it is. `reboot_required` is true when the system listed at ' +
+    'least one reason it needs restarting, false when it listed none, and NULL ' +
+    'WHERE THE SYSTEM REPORTED NO LIST OF REASONS THIS TOOL COULD READ. False ' +
+    'is a positive finding — the system was asked and said nothing is pending ' +
+    '— and null is not that: nothing has been established, and a null must ' +
+    'never be read as "no restart needed". `reasons` is one entry per reason, ' +
+    'and is the list `reboot_required` is derived from: AN EMPTY `reasons` IS ' +
+    'THAT SAME POSITIVE FINDING, nothing pending, and a null `reasons` is the ' +
+    'same unreadable answer that makes `reboot_required` null. Each entry ' +
+    'carries `code`, the system\'s own identifier for the reason — a symbol to ' +
+    'match on rather than prose to show — and `reason`, the human-readable ' +
+    'text the system wrote for it, which is what to show and what says why. ' +
+    'Either is null where the system reported no value this tool could read, ' +
+    'and AN ENTRY WHOSE FIELDS ARE BOTH NULL IS STILL A REASON THE SYSTEM ' +
+    'RAISED: it is kept, and it still makes `reboot_required` true, because a ' +
+    'reason this tool cannot read is not a reason that is not there. `boot_id` ' +
+    'IS AN OPAQUE IDENTIFIER FOR THE BOOT THE SYSTEM IS CURRENTLY RUNNING. It ' +
+    'is not a version, a time, or anything to show a person, and it means ' +
+    'nothing on its own — do not display it or reason about its contents. Its ' +
+    'one use is comparing two reads of the same system: a `boot_id` that has ' +
+    'changed between them is a system that restarted in between, and a reason ' +
+    'still listed after it changed is one the restart did not clear. It is ' +
+    'null where the system reported no identifier this tool could read. ' +
+    'Reboot information that could not be read AT ALL is an error naming what ' +
+    'the system said, not a result of nulls. This tool only reports. It does ' +
+    'not restart the system, schedule a restart or cancel one, and it does not ' +
+    'download or apply the update behind a pending restart. It answers about ' +
+    'THIS system only: on a two-node HA pair the other node is asked ' +
+    'separately and is not read here, which is `ha_status`\'s question. NO ' +
+    'field beyond the three named here is returned, whatever a later TrueNAS ' +
+    'release adds to the payload.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const info = await firstValueFrom(system.client.api.call('system.reboot.info'));
+    // Guarded rather than reached into, for the reason `audit_config` gives: a
+    // system answering with something that is not reboot information would
+    // otherwise throw naming a property, and the caller would see the name of a
+    // field rather than the read that failed.
+    const payload = recordOrNull(info);
+    if (payload === null) {
+      throw new Error('system.reboot.info did not answer with reboot information');
+    }
+    const reasons = rebootReasons(payload['reboot_required_reasons']);
+    return {
+      // Derived rather than read: the middleware states the answer by the
+      // length of a list, and a caller should not have to know that. Null where
+      // the list was unreadable, which is the one case that is neither yes nor
+      // no.
+      reboot_required: reasons === null ? null : reasons.length > 0,
+      reasons,
+      boot_id: textOrNull(payload['boot_id']),
+    };
+  },
+};

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -838,8 +838,11 @@ export const rebootInfo: ReadOnlyTool = {
     'the system said, not a result of nulls. This tool only reports. It does ' +
     'not restart the system, schedule a restart or cancel one, and it does not ' +
     'download or apply the update behind a pending restart. It answers about ' +
-    'THIS system only: on a two-node HA pair the other node is asked ' +
-    'separately and is not read here, which is `ha_status`\'s question. NO ' +
+    'THIS system only. On a two-node HA pair, whether the OTHER node is ' +
+    'waiting to be restarted is a separate question and NO TOOL IN THIS ' +
+    'CATALOG ANSWERS IT — `ha_status` reports whether a pair exists, which ' +
+    'node this is and whether a failover would work, and carries no reboot ' +
+    'state for either node. Do not read this result as covering the pair. NO ' +
     'field beyond the three named here is returned, whatever a later TrueNAS ' +
     'release adds to the payload.',
   inputSchema: { type: 'object', properties: {} },


### PR DESCRIPTION
Adds `system_reboot_info`, a read-only tool over `system.reboot.info` reporting
whether a system is waiting to be restarted and what made it necessary.

Fixes #93

## What it answers, and why nothing else did

`system_update_status` says whether an update is *available*. A system that has
already taken one and not been restarted answers that with an honest "no" — it
is up to date, and it is not yet running what it updated to. So an assistant
summarising such a system from the tools that existed before this one describes
it as current, and the one thing about it that is directly actionable is
invisible.

## The decisions

`system.reboot.info` takes no arguments and its payload is already shaped for a
reader — a list of reasons, each with a code and prose written for a person — so
there is almost no normalization here. What the tool is about is absence.

- **`reboot_required` is derived from the list, not reported beside it.** The
  middleware states "nothing is pending" by sending an empty list. That is the
  answer on a healthy system, and it has to read as a finding rather than as an
  empty result the caller is left to interpret.
- **It is three-valued.** `null` where the system reported no list this tool
  could read — never to be read as "no restart needed". False is the positive
  finding; null is nothing established.
- **An unreadable reason is kept, as a pair of nulls, not dropped.**
  `audit_config`'s `scopeNames` nulls its *whole* list in the same situation.
  Both follow the null/empty/unreadable convention and they land on opposite
  answers, because what decides it is which way a silently shorter list moves
  the result: a scope one name shorter claims a share is unaudited, and a reason
  list one entry shorter runs towards *empty*, which is this tool's one positive
  finding. Such an entry still makes `reboot_required` true — a reason this tool
  cannot read is not a reason that is not there.
- **`boot_id` is kept and described as opaque.** It means nothing on its own;
  its one use is comparing two reads of the same system, where a changed
  `boot_id` says the system restarted in between and a reason still listed after
  that is one the restart did not clear.
- **An unreadable payload raises.** Same reading `audit_config` takes: an error
  naming the read that failed, not a result of nulls that looks like a system
  with nothing pending.

`CLAUDE.md` gains a `## Decisions` entry for the null-or-keep rule, since neither
call site implies it and a tool copying whichever sibling it read first would
land on the wrong one about half the time.

`system.reboot.info` was confirmed present in the pinned client's
`ApiCallDirectoryBase` — the oldest supported surface — before anything was
built, per the triage note. Its response is `RebootInfo`, fully typed, and is
still read through `common.ts`'s guards: a declared type is a claim about what
the middleware sends, not the value received.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all run
clean locally. 842 tests pass; global coverage is 99.66% statements / 99.32%
branches against floors of 97 / 96, so no floor in `vitest.config.ts` moved.

## Review

Two rounds of the project's own reviewer ran locally — the same script, rubric
and threshold as the required check, in a separate process.

- **Round 1, one MEDIUM, fixed.** The description said the peer node of an HA
  pair "is `ha_status`'s question", which reads as a pointer to where the answer
  is. It is not: `ha_status` carries no reboot state for either node. The
  description now says outright that no tool in this catalog answers it, names
  what `ha_status` *does* report, and tells the caller not to read this result as
  covering the pair.
- **Round 2 came back clean** — nothing at MEDIUM or above.

### What I did not change

Two LOWs, left deliberately so that fixing them does not start another review
round. Both are worth a later look.

- **`CLAUDE.md`'s new null-or-keep rule is framed as binary and omits a third
  route** that `ha_status` already uses: drop the entry, derive the summary from
  the full *count* rather than the kept list, and name the shortfall in a
  separate `reasons_error`. That is a genuinely better answer where a count is
  available separately from the list — it is not here, since
  `reboot_required_reasons` is the only thing the payload carries. The rule as
  written is true of both sites it names; it is less complete than it could be.
- **The malformed-payload error names the method and the read, not the
  payload**, while the description promises an error "naming what the system
  said". Worth noting that this is the wording `audit_config` already uses for
  the same throw, so tightening it is a change to a convention rather than to
  this tool, and belongs in its own ticket.
