### PR TITLE
feat(tools): report pending uncommitted network changes from network_config

### DIFF
--- a/src/tools/network.spec.ts
+++ b/src/tools/network.spec.ts
@@ -441,25 +441,31 @@ describe('network_config', () => {
   });
 
   /**
-   * The three reads, canned. `config` and `summary` are spread over their
+   * The four reads, canned. `config` and `summary` are spread over their
    * defaults so a test naming one field keeps the rest; passing `null` for the
    * summary is how a test says the system answered with nothing this tool can
    * read, which is a different case from a summary missing one field.
+   *
+   * `pending` defaults to `false` — the settled system every other test in this
+   * block is about — so that a test reading a gateway is not also asserting
+   * that its fixture is provisional.
    */
   const read = async (
     config: Record<string, unknown> = {},
     summary: Record<string, unknown> | null = {},
     routes: unknown = [route()],
+    pending: unknown = false,
   ): Promise<Record<string, unknown>> => {
     const { ctx } = fakeSystem({
       ['network.configuration.config']: { ...CONFIG, ...config },
       ['network.general.summary']: summary === null ? null : { ...SUMMARY, ...summary },
       ['staticroute.query']: routes,
+      ['interface.has_pending_changes']: pending,
     });
     return (await networkConfig.handler(ctx, {})) as Record<string, unknown>;
   };
 
-  /** The same three reads, with the named ones rejecting instead. */
+  /** The same four reads, with the named ones rejecting instead. */
   const readFailing = async (
     failures: Partial<Record<string, unknown>>,
   ): Promise<Record<string, unknown>> => {
@@ -468,6 +474,7 @@ describe('network_config', () => {
         ['network.configuration.config']: CONFIG,
         ['network.general.summary']: SUMMARY,
         ['staticroute.query']: [route()],
+        ['interface.has_pending_changes']: false,
       },
       failures,
     );
@@ -476,6 +483,7 @@ describe('network_config', () => {
 
   it('reports the hostname, DNS, gateways and static routes from both sides', async () => {
     expect(await read()).toEqual({
+      changes_pending: false,
       hostname: 'nas',
       domain: 'example.com',
       search_domains: ['lab.example.com'],
@@ -527,6 +535,7 @@ describe('network_config', () => {
       { future_field: 'added by a later release' },
     );
     expect(Object.keys(result)).toEqual([
+      'changes_pending',
       'hostname',
       'domain',
       'search_domains',
@@ -640,17 +649,19 @@ describe('network_config', () => {
     });
   });
 
-  it('reports both failures where both supplementary reads fail', async () => {
+  it('names every supplementary read that failed', async () => {
     const result = await readFailing({
       ['network.general.summary']: new Error('summary refused'),
       ['staticroute.query']: new Error('routes refused'),
+      ['interface.has_pending_changes']: new Error('pending refused'),
     });
     expect(result['failures']).toEqual([
       { source: 'effective_values', error: 'summary refused' },
       { source: 'static_routes', error: 'routes refused' },
+      { source: 'changes_pending', error: 'pending refused' },
     ]);
     // And the configured side is still answered in full, which is the whole
-    // point of not letting either failure take the tool down.
+    // point of not letting any of them take the tool down.
     expect(result).toMatchObject({ hostname: 'nas', domain: 'example.com' });
   });
 
@@ -773,15 +784,58 @@ describe('network_config', () => {
     });
   });
 
-  it('asks for the configuration, the summary and the static routes', async () => {
+  it('reports a system with uncommitted network changes as having them pending', async () => {
+    expect(await read({}, {}, [route()], true)).toMatchObject({
+      changes_pending: true,
+      failures: [],
+    });
+  });
+
+  it('names a pending-changes read that failed, and reports it as unread', async () => {
+    // Null rather than false: a system whose commit state could not be read is
+    // not a system with nothing pending, and reading it as one is what would
+    // have a caller describe a configuration that reverts in minutes as
+    // settled.
+    expect(
+      await readFailing({ ['interface.has_pending_changes']: new Error('pending refused') }),
+    ).toMatchObject({
+      changes_pending: null,
+      failures: [{ source: 'changes_pending', error: 'pending refused' }],
+    });
+  });
+
+  it('answers the rest of the configuration where only the pending read failed', async () => {
+    const result = await readFailing({
+      ['interface.has_pending_changes']: new Error('pending refused'),
+    });
+    expect(result).toMatchObject({
+      hostname: 'nas',
+      domain: 'example.com',
+      ipv4_gateway: { configured: '192.168.1.1', in_effect: '192.168.1.1', source: 'STATIC' },
+      static_routes: [{ destination: '10.0.0.0/8', gateway: '192.168.1.254' }],
+    });
+  });
+
+  it('reports a pending state sent as something other than a boolean as unread', async () => {
+    // The read completed, so there is no failure to name — it answered a shape
+    // this tool cannot read, and null says that the same way the other reads do.
+    expect(await read({}, {}, [route()], 'yes')).toMatchObject({
+      changes_pending: null,
+      failures: [],
+    });
+  });
+
+  it('asks for the configuration, the summary, the static routes and the pending state', async () => {
     const { ctx, call, query } = fakeSystem({
       ['network.configuration.config']: CONFIG,
       ['network.general.summary']: SUMMARY,
       ['staticroute.query']: [],
+      ['interface.has_pending_changes']: false,
     });
     await networkConfig.handler(ctx, {});
     expect(call).toHaveBeenCalledWith('network.configuration.config');
     expect(call).toHaveBeenCalledWith('network.general.summary');
+    expect(call).toHaveBeenCalledWith('interface.has_pending_changes');
     expect(query).toHaveBeenCalledWith('staticroute.query');
   });
 });

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -362,13 +362,20 @@ export const networkInterfaces: ReadOnlyTool = {
  * and nothing configured, and a system whose configuration has not been applied
  * has the reverse.
  *
- * The fourth read is what says whether the answer is settled at all. TrueNAS
- * applies a network change behind a commit-and-confirm timer, so an uncommitted
- * change REVERTS on its own if nobody confirms it — and a caller told only what
- * is configured will describe a configuration that will not exist in a few
- * minutes. `interface.has_pending_changes` answers that yes/no for the SYSTEM
- * and names no interface, so this reports it as one field over the whole result
- * rather than per gateway or per nameserver.
+ * The fourth read is what says whether the answer is settled at all. A network
+ * change on TrueNAS is saved before it is applied, and applying it starts a
+ * rollback timer that puts it back unless somebody confirms it — so a pending
+ * change is one that either has not taken effect or is about to be undone, and
+ * a caller told only what is configured will describe a configuration that will
+ * not exist in a few minutes.
+ *
+ * `interface.has_pending_changes` answers yes/no for the SYSTEM and takes no
+ * argument, so this reports it as one field over the whole result rather than
+ * per gateway or per nameserver. It is also the whole of what it answers: which
+ * of the two states above a pending change is in is `interface.checkin_waiting`
+ * and is a second read this tool does not make, so the description promises
+ * neither it nor how long is left — the pair either would need is what makes
+ * that a tool of its own rather than a field here.
  *
  * That comparison is what distinguishes an inherited value from a configured
  * one, rather than a field on the configuration saying so. The client declares
@@ -605,12 +612,17 @@ export const networkConfig: ReadOnlyTool = {
     'themselves, their links and their addresses, and neither tool reports ' +
     'the other. `changes_pending` is whether this system has NETWORK CHANGES ' +
     'THAT HAVE NOT BEEN COMMITTED: true means everything else reported here ' +
-    'is PROVISIONAL and REVERTS ON ITS OWN unless it is confirmed, false ' +
-    'means none is pending and what is reported is what the system is ' +
-    'keeping, and NULL MEANS THE READ DID NOT COMPLETE — a null here is never ' +
-    '"none pending". It answers for the SYSTEM, and does not say WHICH ' +
-    'INTERFACE a pending change is on, WHAT the change is, or HOW LONG is ' +
-    'left before it reverts. Wherever the system can say both, a value is reported from ' +
+    'is PROVISIONAL — a pending change has NOT been permanently applied, and ' +
+    'ONCE IT IS APPLIED IT REVERTS ON ITS OWN unless it is confirmed within ' +
+    "the system's rollback window. False means none is pending and what is " +
+    'reported is what the system is keeping. NULL MEANS THE COMMIT STATE ' +
+    'COULD NOT BE READ — either the read did not complete, in which case ' +
+    '`failures` names `changes_pending`, or it completed and answered ' +
+    'something other than a yes/no, in which case it does not; A NULL IS ' +
+    'NEVER "none pending" either way. It answers for the SYSTEM, and does not ' +
+    'say WHICH INTERFACE a pending change is on, WHAT the change is, WHETHER ' +
+    'it has been applied yet, or HOW LONG is left before it reverts. ' +
+    'Wherever the system can say both, a value is reported from ' +
     'BOTH SIDES: what is CONFIGURED on this system, and what is IN EFFECT ' +
     'right now. The two differ in both directions — a system addressed by ' +
     'DHCP has a gateway and nameservers in effect with nothing configured, ' +
@@ -672,7 +684,7 @@ export const networkConfig: ReadOnlyTool = {
   async handler({ system }) {
     // Every read is issued before any is awaited, so none waits on another.
     // Only the configuration is allowed to fail the tool: it is the answer,
-    // and the other two sharpen it.
+    // and the other three qualify it.
     const [config, summary, routes, pending] = await Promise.all([
       firstValueFrom(system.client.api.call('network.configuration.config')),
       attempt('effective_values', () =>

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -2,7 +2,14 @@ import type { CallResponse } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, ReadOnlyTool } from '@/catalog/tool';
-import { errorText, numberOrNull, recordOrNull, textList, textOrNull } from '@/tools/common';
+import {
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  textList,
+  textOrNull,
+} from '@/tools/common';
 
 /**
  * Networking family. Two tools split it by what is being asked about:
@@ -345,14 +352,23 @@ export const networkInterfaces: ReadOnlyTool = {
 /**
  * The settings over the interfaces: hostname, DNS, gateways and static routes.
  *
- * Three reads, and only the first is the answer. `network.configuration.config`
+ * Four reads, and only the first is the answer. `network.configuration.config`
  * holds what is CONFIGURED on this system; `network.general.summary` holds the
  * default routes and nameservers actually IN EFFECT; `staticroute.query` holds
- * the routes configured by hand. The first two are the same facts read from two
+ * the routes configured by hand; `interface.has_pending_changes` says whether
+ * any of it is uncommitted. The first two are the same facts read from two
  * sides, and the difference between them is the question this tool exists to
  * answer: a system addressed by DHCP has a gateway and nameservers in effect
  * and nothing configured, and a system whose configuration has not been applied
  * has the reverse.
+ *
+ * The fourth read is what says whether the answer is settled at all. TrueNAS
+ * applies a network change behind a commit-and-confirm timer, so an uncommitted
+ * change REVERTS on its own if nobody confirms it — and a caller told only what
+ * is configured will describe a configuration that will not exist in a few
+ * minutes. `interface.has_pending_changes` answers that yes/no for the SYSTEM
+ * and names no interface, so this reports it as one field over the whole result
+ * rather than per gateway or per nameserver.
  *
  * That comparison is what distinguishes an inherited value from a configured
  * one, rather than a field on the configuration saying so. The client declares
@@ -373,7 +389,7 @@ export const networkInterfaces: ReadOnlyTool = {
 
 /** One read that did not complete, and why. */
 interface ConfigFailure {
-  source: 'effective_values' | 'static_routes';
+  source: 'effective_values' | 'static_routes' | 'changes_pending';
   error: string;
 }
 
@@ -587,7 +603,14 @@ export const networkConfig: ReadOnlyTool = {
     'and the routes configured by hand. These are the settings OVER the ' +
     'interfaces; `network_interfaces` is what reports the interfaces ' +
     'themselves, their links and their addresses, and neither tool reports ' +
-    'the other. Wherever the system can say both, a value is reported from ' +
+    'the other. `changes_pending` is whether this system has NETWORK CHANGES ' +
+    'THAT HAVE NOT BEEN COMMITTED: true means everything else reported here ' +
+    'is PROVISIONAL and REVERTS ON ITS OWN unless it is confirmed, false ' +
+    'means none is pending and what is reported is what the system is ' +
+    'keeping, and NULL MEANS THE READ DID NOT COMPLETE — a null here is never ' +
+    '"none pending". It answers for the SYSTEM, and does not say WHICH ' +
+    'INTERFACE a pending change is on, WHAT the change is, or HOW LONG is ' +
+    'left before it reverts. Wherever the system can say both, a value is reported from ' +
     'BOTH SIDES: what is CONFIGURED on this system, and what is IN EFFECT ' +
     'right now. The two differ in both directions — a system addressed by ' +
     'DHCP has a gateway and nameservers in effect with nothing configured, ' +
@@ -636,7 +659,8 @@ export const networkConfig: ReadOnlyTool = {
     'ABSENT — when it names `effective_values`, every `in_effect` is null and ' +
     'no value can be reported as `AUTOMATIC`, so a `STATIC` gateway or ' +
     'nameserver is still correct there while the absence of one is not ' +
-    'evidence of anything. This tool reports settings as they are: it does ' +
+    'evidence of anything, and when it names `changes_pending`, nothing can ' +
+    'be said about whether these settings are provisional. This tool reports settings as they are: it does ' +
     'not change any network setting, and IT DOES NOT TEST whether a name ' +
     'resolves, a gateway answers or a host is reachable — a nameserver ' +
     'reported here is one the system is configured to use, not one confirmed ' +
@@ -649,20 +673,31 @@ export const networkConfig: ReadOnlyTool = {
     // Every read is issued before any is awaited, so none waits on another.
     // Only the configuration is allowed to fail the tool: it is the answer,
     // and the other two sharpen it.
-    const [config, summary, routes] = await Promise.all([
+    const [config, summary, routes, pending] = await Promise.all([
       firstValueFrom(system.client.api.call('network.configuration.config')),
       attempt('effective_values', () =>
         firstValueFrom(system.client.api.call('network.general.summary')),
       ),
       attempt('static_routes', () => firstValueFrom(system.client.api.query('staticroute.query'))),
+      attempt('changes_pending', () =>
+        firstValueFrom(system.client.api.call('interface.has_pending_changes')),
+      ),
     ]);
 
     const effective = effectiveValues(summary.value);
     const failures: ConfigFailure[] = [];
     if (summary.failure !== null) failures.push(summary.failure);
     if (routes.failure !== null) failures.push(routes.failure);
+    if (pending.failure !== null) failures.push(pending.failure);
 
     return {
+      // First, because it qualifies every other field rather than sitting
+      // beside them: a pending change makes the whole configuration below
+      // provisional. Read through a guard like everything else here — the
+      // client declares a bare boolean, and a response that is not one leaves
+      // this null rather than reporting a system as settled on the strength of
+      // a shape this tool could not read.
+      changes_pending: booleanOrNull(pending.value),
       hostname: localHostname(config),
       domain: textOrNull(config['domain']),
       search_domains: textList(config['domains']),

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -356,26 +356,34 @@ export const networkInterfaces: ReadOnlyTool = {
  * holds what is CONFIGURED on this system; `network.general.summary` holds the
  * default routes and nameservers actually IN EFFECT; `staticroute.query` holds
  * the routes configured by hand; `interface.has_pending_changes` says whether
- * any of it is uncommitted. The first two are the same facts read from two
- * sides, and the difference between them is the question this tool exists to
- * answer: a system addressed by DHCP has a gateway and nameservers in effect
- * and nothing configured, and a system whose configuration has not been applied
- * has the reverse.
+ * an INTERFACE change is waiting to be committed. The first two are the same
+ * facts read from two sides, and the difference between them is the question
+ * this tool exists to answer: a system addressed by DHCP has a gateway and
+ * nameservers in effect and nothing configured, and a system whose
+ * configuration has not been applied has the reverse.
  *
- * The fourth read is what says whether the answer is settled at all. A network
- * change on TrueNAS is saved before it is applied, and applying it starts a
- * rollback timer that puts it back unless somebody confirms it — so a pending
- * change is one that either has not taken effect or is about to be undone, and
- * a caller told only what is configured will describe a configuration that will
- * not exist in a few minutes.
+ * The fourth read is the one whose subject is not this tool's, and the scope is
+ * the whole of why it is a warning rather than a verdict. An interface change on
+ * TrueNAS is saved before it is applied, and applying it starts a rollback timer
+ * that puts it back unless somebody confirms it — so a pending change is one
+ * that either has not taken effect or is about to be undone. What
+ * `interface.has_pending_changes` answers over is the staging area that
+ * `interface.create/update/delete` fill and `interface.checkin` clears:
+ * interfaces, aliases, bridges, VLANs and link aggregations, which is the
+ * subject of `network_interfaces`. Nothing reported HERE is staged that way —
+ * `network.configuration.config` and `staticroute.query` take effect on update
+ * — so a true is NOT a claim that the hostname, DNS, gateways or static routes
+ * beside it are provisional. It is worth reporting anyway because the
+ * `in_effect` side of this result is read off the running system, and rolling an
+ * interface change back moves which route and nameservers that is.
  *
- * `interface.has_pending_changes` answers yes/no for the SYSTEM and takes no
- * argument, so this reports it as one field over the whole result rather than
- * per gateway or per nameserver. It is also the whole of what it answers: which
- * of the two states above a pending change is in is `interface.checkin_waiting`
- * and is a second read this tool does not make, so the description promises
- * neither it nor how long is left — the pair either would need is what makes
- * that a tool of its own rather than a field here.
+ * It answers yes/no for the SYSTEM and takes no argument, so this reports it as
+ * one field over the whole result rather than per gateway or per nameserver. It
+ * is also the whole of what it answers: which of the two states above a pending
+ * change is in is `interface.checkin_waiting` and is a second read this tool
+ * does not make, so the description promises neither it nor how long is left —
+ * the pair either would need is what makes that a tool of its own rather than a
+ * field here.
  *
  * That comparison is what distinguishes an inherited value from a configured
  * one, rather than a field on the configuration saying so. The client declares
@@ -610,12 +618,19 @@ export const networkConfig: ReadOnlyTool = {
     'and the routes configured by hand. These are the settings OVER the ' +
     'interfaces; `network_interfaces` is what reports the interfaces ' +
     'themselves, their links and their addresses, and neither tool reports ' +
-    'the other. `changes_pending` is whether this system has NETWORK CHANGES ' +
-    'THAT HAVE NOT BEEN COMMITTED: true means everything else reported here ' +
-    'is PROVISIONAL — a pending change has NOT been permanently applied, and ' +
-    'ONCE IT IS APPLIED IT REVERTS ON ITS OWN unless it is confirmed within ' +
-    "the system's rollback window. False means none is pending and what is " +
-    'reported is what the system is keeping. NULL MEANS THE COMMIT STATE ' +
+    'the other. `changes_pending` is whether this system has an INTERFACE ' +
+    'CHANGE THAT HAS NOT BEEN COMMITTED — a change to an interface, an alias, ' +
+    'a bridge, a VLAN or a link aggregation, WHICH IS WHAT `network_interfaces` ' +
+    'REPORTS AND NOT WHAT THIS TOOL DOES. True means one is pending: it has ' +
+    'NOT been permanently applied, and ONCE IT IS APPLIED IT REVERTS ON ITS ' +
+    "OWN unless it is confirmed within the system's rollback window. IT SAYS " +
+    'NOTHING ABOUT WHETHER THE HOSTNAME, DOMAIN, DNS SERVERS, CONFIGURED ' +
+    'GATEWAYS OR STATIC ROUTES REPORTED HERE ARE COMMITTED — those are not ' +
+    'staged behind a commit, so a true MUST NOT be read as making them ' +
+    'provisional. What a pending interface change can move is the `in_effect` ' +
+    'side of this result, since rolling one back changes which default route ' +
+    'and nameservers the system is using. False means no interface change is ' +
+    'pending. NULL MEANS THE COMMIT STATE ' +
     'COULD NOT BE READ — either the read did not complete, in which case ' +
     '`failures` names `changes_pending`, or it completed and answered ' +
     'something other than a yes/no, in which case it does not; A NULL IS ' +
@@ -672,7 +687,8 @@ export const networkConfig: ReadOnlyTool = {
     'no value can be reported as `AUTOMATIC`, so a `STATIC` gateway or ' +
     'nameserver is still correct there while the absence of one is not ' +
     'evidence of anything, and when it names `changes_pending`, nothing can ' +
-    'be said about whether these settings are provisional. This tool reports settings as they are: it does ' +
+    'be said about whether an interface change is waiting to be committed. ' +
+    'This tool reports settings as they are: it does ' +
     'not change any network setting, and IT DOES NOT TEST whether a name ' +
     'resolves, a gateway answers or a host is reachable — a nameserver ' +
     'reported here is one the system is configured to use, not one confirmed ' +
@@ -703,12 +719,14 @@ export const networkConfig: ReadOnlyTool = {
     if (pending.failure !== null) failures.push(pending.failure);
 
     return {
-      // First, because it qualifies every other field rather than sitting
-      // beside them: a pending change makes the whole configuration below
-      // provisional. Read through a guard like everything else here — the
-      // client declares a bare boolean, and a response that is not one leaves
-      // this null rather than reporting a system as settled on the strength of
-      // a shape this tool could not read.
+      // First, because it is the caveat over the reading rather than one more
+      // setting: a pending interface change can move the `in_effect` side of
+      // everything below. It does not make the configured side provisional —
+      // see the description, and the block comment above for what the staging
+      // area it answers over actually holds. Read through a guard like
+      // everything else here — the client declares a bare boolean, and a
+      // response that is not one leaves this null rather than reporting a
+      // system as settled on the strength of a shape this tool could not read.
       changes_pending: booleanOrNull(pending.value),
       hostname: localHostname(config),
       domain: textOrNull(config['domain']),


### PR DESCRIPTION
Fixes #94

`network_config` reported what is configured and what is in effect with no indication of whether the interface layer under it is settled. An interface change on TrueNAS is saved before it is applied, and applying it starts a rollback timer that puts it back unless somebody confirms it — so a caller reading the settled and the provisional case as the same thing describes a state that may not exist in a few minutes.

## What changed

`interface.has_pending_changes` is a fourth read in `networkConfig`'s handler, issued alongside `network.general.summary` and `staticroute.query` through the same `attempt()` wrapper those two already use. It surfaces as one new field:

- **`changes_pending`** — `true` where the system has an uncommitted interface change, `false` where it has none, `null` where the commit state could not be read.
- A read that **rejects** leaves the field `null` and is named in the existing `failures` list as `changes_pending`. It does not stop the rest of the tool answering.
- A read that **completes and answers something other than a boolean** also leaves the field `null` and is *not* named in `failures` — the same split the description already states for `static_routes` and the effective side. `booleanOrNull` is the guard; the client declares a bare `boolean`, and a declaration is not a value received.
- `null` is never "none pending". That is the one wrong reading here that does real harm, and it is what the three-valued field exists to prevent.

The field is first in the result because it is the caveat over the reading rather than one more setting.

No new tool name, no catalog registration, no change to `createDefaultCatalog`'s exact-list assertion in `index.spec.ts` — this ticket adds a field to a tool that already exists.

`interface.has_pending_changes` is on `DefaultApiDirectory` (via `ApiCallDirectory$7`), so no widening of the API surface was needed. It takes no parameters and returns a bare boolean.

## What the description promises, and what it deliberately does not

**The field is scoped to interface changes, and the description says so.** `interface.has_pending_changes` answers over the staging area that `interface.create/update/delete` fill and `interface.checkin` clears — interfaces, aliases, bridges, VLANs and link aggregations, which is `network_interfaces`' subject rather than this tool's. Every field `network_config` returns comes from elsewhere: `network.configuration.config` for the hostname, domain, search domains, configured gateways and `STATIC` nameservers, and `staticroute.query` for the routes.

So the description states outright that a `true` makes no claim about whether *those* settings are committed, and keeps the warning that does hold: a pending interface change can move the **`in_effect`** side of this result, because rolling one back changes which default route and nameservers the system is using.

This replaces an earlier wording that said a `true` meant "everything else reported here is PROVISIONAL" and a `false` meant the reported settings were "what the system is keeping" — both over-broad in the same direction, and both flagged MEDIUM by review round 2. Add an uncommitted VLAN and the first was wrong about the hostname, DNS, gateways and static routes beside it.

Two earlier MEDIUM findings, from round 1, are also fixed:

- **The null case names both readings.** It first said only "the read did not complete", which the tool's own spec contradicts.
- **The revert claim is not unconditional.** `interface.has_pending_changes` is true both for a change that has been saved and not applied and for one applied and awaiting confirmation; only the second is on a rollback timer. Telling the two apart is `interface.checkin_waiting`, a second read this tool does not make, so the description says a pending change has not been permanently applied and reverts once applied unless confirmed — and says outright that it does not report which of the two states a change is in, nor how long is left.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all run locally and pass. `network.ts` at 100% statements/branches/functions/lines; no coverage floor in `vitest.config.ts` moved.

Local review ran the project's own reviewer in a separate process (`local-review.py`, exit 0 on round 3), so this is the same rubric, threshold and parser the required check applies.

## What I did not change, and why

Round 3 came back clean at MEDIUM and above with three LOW findings. Per the developer rules a clean round ends the work, so these are recorded rather than fixed — the first is the one worth a reviewer's judgement:

1. **The scoping claim above is sourced from the client's method surface, not from middleware source I can read.** `interface.has_pending_changes` sits in the client's directory beside `interface.checkin`, `interface.commit`, `interface.rollback`, `interface.cancel_rollback` and `interface.save_network_config` — the commit-and-confirm machinery — while `network.configuration.update` and `staticroute.*` sit outside it. That is the evidence for saying it does not cover the hostname, DNS, gateway and static-route settings. If a TrueNAS rollback in fact also reverts the `network.configuration` datastore, the description's "MUST NOT be read as making them provisional" would be too strong in the opposite direction. Someone with the middleware in front of them can settle it in a minute; I could not.
2. **`network_interfaces` — the tool that reports the interfaces a pending change is actually on — gains no pending indicator.** Out of scope by the ticket's own wording: "Reporting *which* interfaces have pending changes... would need a different source and is not filed." Worth a ticket if the per-interface answer is wanted, and the scoping above makes it a more useful one than it looked at filing time.
3. **A demonstrative in the block comment above `networkConfig`.** "That comparison is what distinguishes an inherited value from a configured one" now sits two paragraphs after the comparison it names, because the `changes_pending` explanation was inserted between them. It still reads correctly on a careful read; it no longer reads correctly on a skim.
