### PR TITLE
feat(tools): add boot_pool_status, the health of the boot device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,35 @@ a fact the tool asserts and you must keep.** Neither answer is the safe default,
 and a tool that copies whichever sibling it read first will land on the wrong one
 about half the time.
 
+### The boot pool is a separate read, and its scan record is unreported (#95)
+
+`pool.query` — which `storage_pool_status`, `storage_pool_topology` and
+`storage_scrub_history` all read — **does not list the boot pool**. The device
+the system runs from has its own verb, `boot.get_state`, and `boot_pool_status`
+(`src/tools/boot.ts`) is the only tool that reads it. A tool answering a question
+about "every pool" from `pool.query` is answering about the data pools, and its
+description has to say so — `boot_pool_status`'s says it from the other side,
+and the three above still read as covering every pool.
+
+`boot.get_state` carries `scan` and `expand` as open records, and this tool
+reports **neither**, in any form. The alternative was to reuse `pools.ts`'s
+`ScanRecord` reading, and the reason not to is where the line in `common.ts`
+falls: the *shape* of a ZFS scan record is common, but everything that reading
+does with it — `SCRUB` vs `RESILVER`, `NEVER_SCRUBBED`, `UNKNOWN` — is a
+vocabulary decided for data pools and is that family's own. Copying it into a
+second family is the drift `common.ts` was cut to stop; moving it there would
+move the vocabulary with it. So the boot pool's scrub outcome is a gap, it is
+named as one in the tool's description, and closing it means promoting the
+reading deliberately rather than as a side effect of this tool.
+
+**Two independent reads are two sections, each with its own `unavailable`.**
+`boot.get_state` and `boot.environment.query` fail separately, so neither may
+fail the tool — the same seam `system_health_report` and `fleet_compliance_report`
+use, and the reason `boot.ts` catches rather than throws. A section that could
+not be read still carries every field it promises, as nulls: `undefined`
+serializes to no key at all, and a caller would otherwise get a shape it was
+never told about.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_info`, `system_update_status`, `system_reboot_info`,
   `audit_log_query`, `audit_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
+  `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
   `vms_list`, `vm_logs`, `alerts_list`, `snapshots_list`, `replication_status`,
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `tasks_recent_runs`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export {
   poolStatus,
   poolTopology,
   scrubHistory,
+  bootPoolStatus,
   listDatasets,
   quotaReport,
   disksList,

--- a/src/tools/boot.spec.ts
+++ b/src/tools/boot.spec.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { bootPoolStatus } from '@/tools/index';
+
+describe('boot_pool_status', () => {
+  /** A `boot.get_state` payload, healthy and complete unless overridden. */
+  const state = (over: Record<string, unknown> = {}) => ({
+    name: 'boot-pool',
+    status: 'ONLINE',
+    path: '/',
+    scan: { function: 'SCRUB', state: 'FINISHED', errors: 0 },
+    expand: null,
+    is_upgraded: true,
+    healthy: true,
+    warning: false,
+    status_code: null,
+    status_detail: null,
+    size: 240_057_409_536,
+    allocated: 12_884_901_888,
+    free: 227_172_507_648,
+    freeing: 0,
+    ...over,
+  });
+
+  /** One `boot.environment.query` row. */
+  const environment = (over: Record<string, unknown> = {}) => ({
+    id: '25.10.0',
+    dataset: 'boot-pool/ROOT/25.10.0',
+    active: true,
+    activated: true,
+    created: '2026-08-01T10:00:00',
+    used_bytes: 3_221_225_472,
+    used: '3 GiB',
+    keep: false,
+    can_activate: true,
+    ...over,
+  });
+
+  const reported = async (
+    poolState: unknown,
+    environments: unknown = [environment()],
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({
+      ['boot.get_state']: poolState,
+      ['boot.environment.query']: environments,
+    });
+    return (await bootPoolStatus.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  const pool = async (over: Record<string, unknown> = {}) =>
+    (await reported(state(over)))['pool'] as Record<string, unknown>;
+
+  const entries = async (rows: unknown) =>
+    ((await reported(state(), rows))['environments'] as Record<string, unknown>)[
+      'entries'
+    ] as Record<string, unknown>[];
+
+  it('is read-only and requires no arguments', () => {
+    expect(bootPoolStatus.mutating).toBe(false);
+    expect(bootPoolStatus.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('reports the boot pool, its health and its space', async () => {
+    expect(await pool()).toEqual({
+      unavailable: null,
+      name: 'boot-pool',
+      status: 'ONLINE',
+      healthy: true,
+      warning: false,
+      status_code: null,
+      status_detail: null,
+      features_current: true,
+      size_bytes: 240_057_409_536,
+      allocated_bytes: 12_884_901_888,
+      free_bytes: 227_172_507_648,
+    });
+  });
+
+  it('never reports the scan or expansion record, in any form', async () => {
+    const section = await pool();
+    expect(section['scan']).toBeUndefined();
+    expect(section['expand']).toBeUndefined();
+    expect(JSON.stringify(section)).not.toContain('SCRUB');
+  });
+
+  it('reports healthy and warning independently, so a healthy pool can warn', async () => {
+    expect(await pool({ healthy: true, warning: true })).toMatchObject({
+      healthy: true,
+      warning: true,
+    });
+  });
+
+  it('reports an unhealthy pool with the code and detail the system gave', async () => {
+    expect(
+      await pool({
+        status: 'DEGRADED',
+        healthy: false,
+        warning: true,
+        status_code: 'FAULTED_DEV',
+        status_detail: 'One or more devices has been taken offline.',
+      }),
+    ).toMatchObject({
+      status: 'DEGRADED',
+      healthy: false,
+      warning: true,
+      status_code: 'FAULTED_DEV',
+      status_detail: 'One or more devices has been taken offline.',
+    });
+  });
+
+  it('passes a status it does not recognise through as the system spelled it', async () => {
+    expect(await pool({ status: 'SUSPENDED' })).toMatchObject({ status: 'SUSPENDED' });
+  });
+
+  it('reports healthy and warning as null where the system reported no boolean', async () => {
+    expect(await pool({ healthy: 'yes', warning: null })).toMatchObject({
+      healthy: null,
+      warning: null,
+    });
+  });
+
+  it('reports a pool behind on features as false, not as unreported', async () => {
+    expect(await pool({ is_upgraded: false })).toMatchObject({ features_current: false });
+  });
+
+  it('distinguishes a pool that did not report its upgrade state from one that is behind', async () => {
+    // Deleted rather than set to undefined: `is_upgraded` is optional in the
+    // payload, and a system that is not on a version that reports it sends no
+    // key at all.
+    const withoutUpgradeState: Record<string, unknown> = { ...state() };
+    delete withoutUpgradeState['is_upgraded'];
+    const section = (await reported(withoutUpgradeState))['pool'] as Record<string, unknown>;
+    expect(section['features_current']).toBeNull();
+    expect(section['features_current']).not.toBe(false);
+  });
+
+  it('reports a size the system did not send as null', async () => {
+    expect(await pool({ size: null, allocated: 'lots', free: undefined })).toMatchObject({
+      size_bytes: null,
+      allocated_bytes: null,
+      free_bytes: null,
+    });
+  });
+
+  it('reports the environments, naming which is active and which boots next', async () => {
+    expect(await entries([environment(), environment({ id: '25.04.1', active: false, activated: false })]))
+      .toEqual([
+        {
+          name: '25.10.0',
+          active: true,
+          active_on_reboot: true,
+          size_bytes: 3_221_225_472,
+          created_at: '2026-08-01T10:00:00',
+        },
+        {
+          name: '25.04.1',
+          active: false,
+          active_on_reboot: false,
+          size_bytes: 3_221_225_472,
+          created_at: '2026-08-01T10:00:00',
+        },
+      ]);
+  });
+
+  it('keeps active and active_on_reboot apart on an environment activated but not booted', async () => {
+    expect(await entries([environment({ active: false, activated: true })])).toEqual([
+      expect.objectContaining({ active: false, active_on_reboot: true }),
+    ]);
+  });
+
+  it('reports an environment field the system did not send as null', async () => {
+    expect(
+      await entries([environment({ id: '', active: 1, used_bytes: null, created: null })]),
+    ).toEqual([{ name: null, active: null, active_on_reboot: true, size_bytes: null, created_at: null }]);
+  });
+
+  it('keeps an entry it cannot read at all, as a row of nulls', async () => {
+    expect(await entries([environment(), 'not an environment'])).toEqual([
+      expect.objectContaining({ name: '25.10.0' }),
+      { name: null, active: null, active_on_reboot: null, size_bytes: null, created_at: null },
+    ]);
+  });
+
+  it('reports a system holding no boot environments as an empty list, not as unread', async () => {
+    const section = (await reported(state(), []))['environments'] as Record<string, unknown>;
+    expect(section).toEqual({ unavailable: null, entries: [] });
+  });
+
+  it('reports the environments as unread where the system answered with no list', async () => {
+    const section = (await reported(state(), { id: '25.10.0' }))['environments'] as Record<
+      string,
+      unknown
+    >;
+    expect(section['entries']).toBeNull();
+    expect(section['unavailable']).toBe('the system did not answer with a list of boot environments');
+  });
+
+  it('reports the pool as unread where the system answered with no pool state', async () => {
+    const section = (await reported('boot-pool'))['pool'] as Record<string, unknown>;
+    expect(section).toEqual({
+      unavailable: 'the system did not answer with a boot pool state',
+      name: null,
+      status: null,
+      healthy: null,
+      warning: null,
+      status_code: null,
+      status_detail: null,
+      features_current: null,
+      size_bytes: null,
+      allocated_bytes: null,
+      free_bytes: null,
+    });
+  });
+
+  it('still answers the environments where the pool read failed', async () => {
+    const { ctx } = failingSystem(
+      { ['boot.environment.query']: [environment()] },
+      { ['boot.get_state']: new Error('boot pool unavailable') },
+    );
+    const result = (await bootPoolStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['pool']).toMatchObject({
+      unavailable: 'boot pool unavailable',
+      healthy: null,
+      status: null,
+    });
+    expect((result['environments'] as Record<string, unknown>)['entries']).toEqual([
+      expect.objectContaining({ name: '25.10.0' }),
+    ]);
+  });
+
+  it('still answers the pool where the environment read failed', async () => {
+    const { ctx } = failingSystem(
+      { ['boot.get_state']: state() },
+      { ['boot.environment.query']: { reason: 'no such method' } },
+    );
+    const result = (await bootPoolStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['environments']).toEqual({ unavailable: 'no such method', entries: null });
+    expect(result['pool']).toMatchObject({ unavailable: null, name: 'boot-pool', healthy: true });
+  });
+
+  it('names a failure that carried no text of its own rather than reporting nothing', async () => {
+    const { ctx } = failingSystem(
+      { ['boot.environment.query']: [] },
+      { ['boot.get_state']: {} },
+    );
+    const result = (await bootPoolStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect((result['pool'] as Record<string, unknown>)['unavailable']).toBe(
+      'the system reported no reason',
+    );
+  });
+});

--- a/src/tools/boot.ts
+++ b/src/tools/boot.ts
@@ -59,8 +59,11 @@ interface BootEnvironment {
 
 /**
  * One section read, or the reason it could not be — the per-family attempt pair
- * `system.ts` and `fleet.ts` each keep, typed here by this family's own two
- * payloads rather than generalised over them.
+ * `system.ts` and `fleet.ts` each keep, generic over this family's own two
+ * payloads and no further. It stays in this file rather than moving to
+ * `common.ts`: what the four files holding one of these share is the shape, not
+ * the function, and generalising over the failure type would couple every
+ * family to one signature for no gain.
  */
 interface Attempt<T> {
   value: T | null;

--- a/src/tools/boot.ts
+++ b/src/tools/boot.ts
@@ -1,0 +1,270 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import {
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  textOrNull,
+} from '@/tools/common';
+
+/**
+ * The boot pool: the ZFS pool the system itself runs from, and the boot
+ * environments held on it.
+ *
+ * `storage_pool_status` and `storage_pool_topology` read `pool.query`, which
+ * lists data pools and not this one, so before this tool the device the system
+ * actually boots from was invisible to the whole catalog. A boot device on its
+ * way out is exactly the thing worth flagging before it strands the machine.
+ *
+ * The boot environments are the other half of the same question. They are what
+ * a failed update falls back to, so "is it safe to update this system" partly
+ * means "does it have an environment to return to".
+ *
+ * The two are SEPARATE READS and either can fail on its own, so each is a
+ * section carrying its own `unavailable` rather than one read that can take the
+ * whole answer down. Nothing here mutates: activating, cloning, destroying and
+ * scrubbing all exist on the middleware and none of them is in this catalog.
+ */
+
+/** What a system answering `boot.get_state` with something else is reported as. */
+const NOT_A_POOL_STATE = 'the system did not answer with a boot pool state';
+
+/** What a system answering `boot.environment.query` with something else is reported as. */
+const NOT_A_LIST = 'the system did not answer with a list of boot environments';
+
+/** The boot pool as this tool reports it. */
+interface BootPool {
+  name: string | null;
+  status: string | null;
+  healthy: boolean | null;
+  warning: boolean | null;
+  status_code: string | null;
+  status_detail: string | null;
+  features_current: boolean | null;
+  size_bytes: number | null;
+  allocated_bytes: number | null;
+  free_bytes: number | null;
+}
+
+/** One boot environment as this tool reports it. */
+interface BootEnvironment {
+  name: string | null;
+  active: boolean | null;
+  active_on_reboot: boolean | null;
+  size_bytes: number | null;
+  created_at: string | null;
+}
+
+/**
+ * One section read, or the reason it could not be — the per-family attempt pair
+ * `system.ts` and `fleet.ts` each keep, typed here by this family's own two
+ * payloads rather than generalised over them.
+ */
+interface Attempt<T> {
+  value: T | null;
+  error: string | null;
+}
+
+/**
+ * The boot pool's state, with a failure named rather than thrown.
+ *
+ * The payload is read through `recordOrNull` rather than reached into, for the
+ * reason `audit_config` gives: a system answering the call with something that
+ * is not a pool state would otherwise throw naming a property, and the caller
+ * would see the name of a field rather than the read that failed. Here it is
+ * not thrown at all — a boot pool that could not be read must still leave the
+ * environments section answering.
+ *
+ * `scan` and `expand` are read by nothing here and are deliberately absent from
+ * the result. Both arrive as open records the generated types do not describe,
+ * and passing either through would put whatever a later TrueNAS release adds to
+ * them into a tool result — the allowlist convention this repository keeps. The
+ * one reading of a ZFS scan record in this repository is `pools.ts`'s, and it is
+ * that family's: it carries a scrub-vs-resilver vocabulary decided for data
+ * pools. See the decision in `CLAUDE.md`.
+ */
+async function readPool(system: SystemHandle): Promise<Attempt<BootPool>> {
+  try {
+    const answer = await firstValueFrom(system.client.api.call('boot.get_state'));
+    const state = recordOrNull(answer);
+    if (state === null) return { value: null, error: NOT_A_POOL_STATE };
+    return {
+      value: {
+        name: textOrNull(state['name']),
+        // A bare string with no declared union, so it is passed through as the
+        // system spelled it and the description says the set is not closed.
+        status: textOrNull(state['status']),
+        // Independent, not two points on one scale: a pool can be healthy and
+        // still be carrying a warning, and the two are reported side by side
+        // rather than collapsed into a verdict this tool has not been given.
+        healthy: booleanOrNull(state['healthy']),
+        warning: booleanOrNull(state['warning']),
+        status_code: textOrNull(state['status_code']),
+        status_detail: textOrNull(state['status_detail']),
+        // `is_upgraded` is optional in the payload, so it has three states and
+        // not two — upgraded, not upgraded, and not reported at all. Read
+        // through `booleanOrNull`, an absent field becomes null, which is what
+        // keeps "the pool is behind" and "the system did not say" apart.
+        features_current: booleanOrNull(state['is_upgraded']),
+        size_bytes: numberOrNull(state['size']),
+        allocated_bytes: numberOrNull(state['allocated']),
+        free_bytes: numberOrNull(state['free']),
+      },
+      error: null,
+    };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/**
+ * One boot environment, every field read through a guard.
+ *
+ * An entry the system sent that this tool cannot read as a record is KEPT, as a
+ * row of nulls, rather than dropped. A list one entry shorter would understate
+ * how many environments the pool holds — and the unreadable entry may be the
+ * active one, which is why the description says an absence of `active: true` is
+ * not evidence that no environment is active.
+ */
+function mapEnvironment(row: unknown): BootEnvironment {
+  const held = recordOrNull(row);
+  return {
+    // `id` is what the middleware names a boot environment by; there is no
+    // separate name field.
+    name: held === null ? null : textOrNull(held['id']),
+    active: held === null ? null : booleanOrNull(held['active']),
+    // `activated` is the middleware's name for the environment marked to boot
+    // next, which is a different question from `active` and one letter away
+    // from it in the payload. Renamed here so the two cannot be read as each
+    // other.
+    active_on_reboot: held === null ? null : booleanOrNull(held['activated']),
+    size_bytes: held === null ? null : numberOrNull(held['used_bytes']),
+    // The creation time as the system reports it, passed through as text rather
+    // than parsed: the client declares it a string, and a timestamp in a shape
+    // this tool guessed at would be confidently wrong about a timezone instead
+    // of absent.
+    created_at: held === null ? null : textOrNull(held['created']),
+  };
+}
+
+/**
+ * The boot environments, with a failure named rather than thrown.
+ *
+ * An answer that is not a list at all is reported as this section being
+ * unreadable rather than as the pool holding no environments — the difference
+ * between "no fallback exists" and "nothing was established about the
+ * fallbacks", which on this subject are opposite answers.
+ */
+async function readEnvironments(system: SystemHandle): Promise<Attempt<BootEnvironment[]>> {
+  try {
+    const rows = await firstValueFrom(system.client.api.query('boot.environment.query'));
+    if (!Array.isArray(rows)) return { value: null, error: NOT_A_LIST };
+    return { value: rows.map(mapEnvironment), error: null };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/**
+ * The `pool` section's fields on a read that did not happen.
+ *
+ * Spelled out rather than left off, because `undefined` serializes to no key at
+ * all: a caller would receive an object missing fields the description promises
+ * — a shape it has not been told about — rather than nulls it can see are
+ * absent. The same reading `pools.ts` gives for a field the middleware omitted.
+ */
+const UNREAD_POOL: BootPool = {
+  name: null,
+  status: null,
+  healthy: null,
+  warning: null,
+  status_code: null,
+  status_detail: null,
+  features_current: null,
+  size_bytes: null,
+  allocated_bytes: null,
+  free_bytes: null,
+};
+
+export const bootPoolStatus: ReadOnlyTool = {
+  name: 'boot_pool_status',
+  description:
+    'The health of the ZFS pool a TrueNAS system BOOTS FROM, and the boot ' +
+    'environments held on it. NOTHING ELSE IN THIS CATALOG REPORTS THE BOOT ' +
+    'POOL: `storage_pool_status`, `storage_pool_topology` and ' +
+    '`storage_scrub_history` all read the data pools and none of them lists ' +
+    'this one, so a healthy answer from those says nothing about the device ' +
+    'the system itself runs from. The result has TWO SECTIONS, `pool` and ' +
+    '`environments`, which come from SEPARATE READS AND CAN FAIL ' +
+    'INDEPENDENTLY. Each carries `unavailable`: null where that section was ' +
+    'read, and otherwise what the system said about the failure — and then ' +
+    'EVERY OTHER FIELD IN THAT SECTION IS NULL BECAUSE IT WAS NOT READ, not ' +
+    'because the system reported nothing. A failure in one section never ' +
+    'empties or falsifies the other. ' +
+    'In `pool`: `name` is what the boot pool is called, `status` is the ' +
+    "system's own word for its state — ONLINE, DEGRADED and FAULTED are the " +
+    'common ones, and THE SET IS NOT CLOSED, so any other value is passed ' +
+    'through as the system spelled it and should be read as itself. `healthy` ' +
+    'and `warning` are INDEPENDENT and are not two points on one scale: a boot ' +
+    'pool can be healthy and still be carrying a warning. `healthy` true is ' +
+    'the system reporting the pool as healthy and `healthy` FALSE IS A ' +
+    'POSITIVE FINDING that it reported it as not healthy — something is wrong ' +
+    'with the pool the system boots from. `warning` true is the system raising ' +
+    'a warning about it and `warning` false is the system raising none, which ' +
+    'is also a positive finding. EITHER IS NULL WHERE THE SYSTEM REPORTED NO ' +
+    'VALUE THIS TOOL COULD READ, and a null is neither of those answers — a ' +
+    'null `healthy` must never be read as healthy, and a null `warning` must ' +
+    'never be read as no warning. `status_code` is a symbol to match on and ' +
+    '`status_detail` is prose written for a person saying what is wrong; each ' +
+    'is null where the system reported no text this tool could read, which on ' +
+    'a healthy pool is the normal case and is not a finding. ' +
+    '`features_current` is whether the ' +
+    "pool's on-disk ZFS features have been upgraded to what the running " +
+    'version supports: true where the system reported them upgraded, FALSE ' +
+    'WHERE IT REPORTED THEM NOT UPGRADED — a pool that still works and is ' +
+    'behind the version running on it — and NULL WHERE IT DID NOT REPORT AN ' +
+    'UPGRADE STATE AT ALL. Those last two are different answers and null is ' +
+    'never to be read as the false one. `size_bytes`, `allocated_bytes` and ' +
+    '`free_bytes` are the pool total, what is used and what is left, in bytes, ' +
+    'each null where the system reported no number this tool could read. THE ' +
+    "BOOT POOL'S SCAN AND EXPANSION RECORDS ARE NOT REPORTED — no scrub " +
+    'outcome, state, time or error count for the boot pool is available from ' +
+    'this tool or from any other in this catalog, and `storage_scrub_history` ' +
+    'covers the DATA pools only. Do not read its answer as covering this pool. ' +
+    'In `environments`: `entries` is one entry per boot environment, in the ' +
+    'order the system listed them, and is NULL WHENEVER `unavailable` IS ' +
+    'NON-NULL. An EMPTY `entries` is a different answer — the system listed ' +
+    'the environments and there were none — and null is never to be read as ' +
+    'that. `name` is what the environment is called. `active` is whether it is ' +
+    'the one the system is running from NOW; `active_on_reboot` is whether it ' +
+    'is the one marked to be used at the NEXT boot. THOSE ARE DIFFERENT ' +
+    'QUESTIONS: an environment activated but not yet booted into has ' +
+    '`active_on_reboot` true and `active` false, which is a system whose next ' +
+    'restart changes what it runs. `size_bytes` is what the environment ' +
+    'occupies on the boot pool and `created_at` is when it was made, as the ' +
+    'system reports it, in whatever format the system used. Any field is null ' +
+    'where the system reported no value this tool could read. AN ENTRY WHOSE ' +
+    'FIELDS ARE ALL NULL IS STILL AN ENVIRONMENT THE SYSTEM LISTED: it is ' +
+    'kept rather than dropped, so the number of entries stays true — and ' +
+    'because such an entry may be the active one, NO ENTRY REPORTING `active` ' +
+    'TRUE IS NOT EVIDENCE THAT NONE IS ACTIVE. This tool only reports. It does ' +
+    'not activate, clone, rename, destroy or keep a boot environment, it does ' +
+    'not scrub the boot pool or set its scrub schedule, and it does not report ' +
+    'the physical disks under the boot pool.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other, and neither can fail the tool: the answer to "is the boot device
+    // in trouble" and the answer to "is there an environment to fall back to"
+    // are separately useful, and losing one must not lose the other.
+    const [pool, environments] = await Promise.all([readPool(system), readEnvironments(system)]);
+    return {
+      pool: { unavailable: pool.error, ...(pool.value ?? UNREAD_POOL) },
+      environments: { unavailable: environments.error, entries: environments.value },
+    };
+  },
+};

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty-one sketch tools', () => {
+  it('registers the forty-two sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -13,6 +13,7 @@ describe('createDefaultCatalog', () => {
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
+      'boot_pool_status',
       'storage_list_datasets',
       'datasets_quota_report',
       'disks_list',
@@ -244,6 +245,12 @@ describe('createDefaultCatalog', () => {
   it('advertises system_reboot_info to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'system_reboot_info',
+    );
+  });
+
+  it('advertises boot_pool_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'boot_pool_status',
     );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import { directoryServicesStatus, usersList } from '@/tools/accounts';
 import { alertSettings, alertsList } from '@/tools/alerts';
 import { appsList } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
+import { bootPoolStatus } from '@/tools/boot';
 import { certificatesList } from '@/tools/certificates';
 import { cloudCredentialsList } from '@/tools/credentials';
 import { disksList } from '@/tools/disks';
@@ -25,7 +26,7 @@ import { auditConfig, auditLogQuery, rebootInfo, systemInfo, updateStatus } from
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty-one read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -36,6 +37,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
+  catalog.register(bootPoolStatus);
   catalog.register(listDatasets);
   catalog.register(quotaReport);
   catalog.register(disksList);
@@ -78,6 +80,7 @@ export {
   appsList,
   auditConfig,
   auditLogQuery,
+  bootPoolStatus,
   certificatesList,
   cloudCredentialsList,
   cloudsyncTasksList,


### PR DESCRIPTION
Closes #95.

`pool.query` — which `storage_pool_status`, `storage_pool_topology` and
`storage_scrub_history` all read — does not list the boot pool. So before this,
the device the system itself runs from was invisible to the entire catalog: a
clean answer from all three said nothing about whether the machine is one boot
device away from being stranded.

`boot_pool_status` reads `boot.get_state` and `boot.environment.query` and adds
no endpoint of its own.

## What it reports

**Two sections, `pool` and `environments`, from two independent reads.** Each
carries its own `unavailable`, and a failure in either leaves the other
answering — the seam `system_health_report` and `fleet_compliance_report`
already use. A section that could not be read still carries every field it
promises, as nulls, because `undefined` serializes to no key at all and a caller
would otherwise receive a shape it was never told about.

**`healthy` and `warning` are side by side, not collapsed.** They are
independent booleans on this payload, so a pool can be healthy and still carry a
warning. Both are three-valued: false is a positive finding, null is the system
having reported no value this tool could read, and the description says a null
`healthy` must never be read as healthy.

**`features_current` is three-valued because `is_upgraded` is optional.** A pool
behind on ZFS features and a pool that reported no upgrade state at all are
different answers, and null is never the false one. There is a test asserting
the two are distinguishable, not just that the field exists.

**An unreadable environment entry is kept, as a row of nulls.** Per the #93
decision, which way a shorter list moves the answer decides this: a list one
entry shorter understates how many environments the pool holds, and the entry
that could not be read may be the active one. So it stays, and the description
says that no entry reporting `active: true` is not evidence that none is active.

**`active` and `active_on_reboot`.** The middleware spells these `active` and
`activated`, one letter apart, meaning "running now" and "marked to boot next".
Renamed here so they cannot be read as each other.

## What it deliberately does not report

**`scan` and `expand`, in any form.** The ticket offered reusing `pools.ts`'s
scan reading or dropping the fields; this drops them. The *shape* of a ZFS scan
record is common, but everything that reading does with it — `SCRUB` vs
`RESILVER`, `NEVER_SCRUBBED`, `UNKNOWN` — is a vocabulary decided for data
pools, and `app/CLAUDE.md` names a state vocabulary as a family's own. Copying
it into a second family is the drift `common.ts` was cut to stop; moving it to
`common.ts` would move the vocabulary with it. So the boot pool's scrub outcome
is a stated gap: the description says outright that no tool in this catalog
reports it and that `storage_scrub_history` covers the data pools only. There is
a test asserting the raw records never reach the result. Promoting that reading
is worth its own ticket rather than a side effect of this one.

**The physical disks under the boot pool** (`boot.get_disks`), and anything
mutating — activate, clone, destroy, keep, scrub, set the scrub interval. All
out of scope per the ticket.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (867 passing), `yarn test:coverage`
and `yarn build` all run locally and pass. `src/tools/boot.ts` reports 100% of
statements, branches, functions and lines; the global floors in
`vitest.config.ts` are unchanged and met. Nothing here needs a service, a
browser or a device, so every gating job was runnable on this machine.

## Local review

`local-review.py` ran the project's own reviewer in a separate process — the
same rubric, threshold and parser as the required check — and exited 0: nothing
at or above MEDIUM. Five LOW findings, none acted on except the one below.

**Fixed:** the `Attempt<T>` JSDoc claimed the pair was typed "rather than
generalised over" the two payloads while sitting above a generic interface. A
comment stating the opposite of its own code is a defect the reviewer happened
to score low, so it was corrected in a second commit that touches no executable
code.

**Not changed, and I think each is right:**

- The description gives no explicit null reading for `pool.name` and
  `pool.status`, though `textOrNull` can null them inside a successfully read
  section. This repository's most-cited convention says state it; it is worth
  stating.
- `storage_scrub_history`'s own description still says "each ZFS pool" while
  this tool's says that one covers the data pools only. **The two descriptions
  disagree, and `storage_scrub_history` is the one that is wrong** — it has been
  since before this PR, because `pool.query` never listed the boot pool. It is
  not in this ticket's scope and the same is arguably true of
  `storage_pool_status` and `storage_pool_topology`, so it is worth a ticket
  covering all three rather than a drive-by edit to one.
- `mapEnvironment` repeats a `held === null` ternary per field where the
  `UNREAD_POOL` constant idiom would say it once.
- The description is long — the reviewer measured it as the catalog's longest —
  and repeats a few points. That cost is paid on every request.

## `app/CLAUDE.md`

One `## Decisions` entry, recording the three things a later cycle would
otherwise guess wrong about: that `pool.query` excludes the boot pool, why the
scan reading was not shared, and that two independent reads become two sections
with their own `unavailable`.
