### PR TITLE
feat(tools): add security_config, the FIPS/STIG/password/2FA settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,28 @@ not be read still carries every field it promises, as nulls: `undefined`
 serializes to no key at all, and a caller would otherwise get a shape it was
 never told about.
 
+### A unit goes in a field name only where the unit was established (#96)
+
+`security_config` reports `min_password_age`, `max_password_age` and `window`
+with no unit in the name, where `audit_config` reports `retention_days` and
+`boot_pool_status` reports `size_bytes`. The difference is not style either.
+`size_bytes` is a unit the payload's own field name carries; the three above are
+bare numbers on the pinned surface, which declares no unit for any of them and
+documents none. Suffixing them would have been this repository asserting a unit
+it never read — the same defect as a description promising more than the
+normalization delivers, one level down in the name.
+
+**A suffix is a claim, and a caller acts on it.** A `_days` on a number the
+system meant as seconds is worse than no suffix at all: an unsuffixed number is
+read as itself and asked about, and a wrongly suffixed one is converted. So
+carry the unit when the API states it, and otherwise keep the middleware's own
+name and say in the description that no unit is reported and the number is not
+to be converted.
+
+`retention_days` predates this and is not being renamed here — it is on a
+public barrel export and out of this ticket's scope. Treat it as the shape to
+check rather than the shape to copy.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,12 +335,20 @@ never told about.
 
 `security_config` reports `min_password_age`, `max_password_age` and `window`
 with no unit in the name, where `audit_config` reports `retention_days` and
-`boot_pool_status` reports `size_bytes`. The difference is not style either.
-`size_bytes` is a unit the payload's own field name carries; the three above are
-bare numbers on the pinned surface, which declares no unit for any of them and
-documents none. Suffixing them would have been this repository asserting a unit
-it never read — the same defect as a description promising more than the
-normalization delivers, one level down in the name.
+`boot_pool_status` reports `size_bytes`. The difference is not style either. A
+suffix is carried where the unit was established, and there are two ways it can
+have been: the payload's own field name states it — the boot *environment*
+`size_bytes`, which reads `held['used_bytes']` (`src/tools/boot.ts:146`) — or the
+domain fixes it, as it does for the boot *pool*'s `size_bytes`,
+`allocated_bytes` and `free_bytes`, which read the bare `size`, `allocated` and
+`free` of a ZFS pool (`src/tools/boot.ts:114-116`) and could not be counted in
+anything but bytes. The three fields above have neither: they are bare numbers on
+the pinned surface, which declares no unit for any of them, and nothing about a
+password age or a one-time-password window fixes one — days and seconds are both
+ordinary answers for the first, seconds and steps for the second. Suffixing them
+would have been this repository asserting a unit it never read — the same defect
+as a description promising more than the normalization delivers, one level down
+in the name.
 
 **A suffix is a claim, and a caller acts on it.** A `_days` on a number the
 system meant as seconds is worse than no suffix at all: an unsuffixed number is

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `system_update_status`, `system_reboot_info`,
-  `audit_log_query`, `audit_config`,
+  `audit_log_query`, `audit_config`, `security_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export {
   rebootInfo,
   auditLogQuery,
   auditConfig,
+  securityConfig,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,13 +3,14 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty-two sketch tools', () => {
+  it('registers the forty-three sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
       'system_reboot_info',
       'audit_log_query',
       'audit_config',
+      'security_config',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -251,6 +252,12 @@ describe('createDefaultCatalog', () => {
   it('advertises boot_pool_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'boot_pool_status',
+    );
+  });
+
+  it('advertises security_config to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'security_config',
     );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import {
   reportingUtilisation,
   systemHealthReport,
 } from '@/tools/reporting';
+import { securityConfig } from '@/tools/security';
 import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
@@ -26,7 +27,7 @@ import { auditConfig, auditLogQuery, rebootInfo, systemInfo, updateStatus } from
 import { cloudsyncTasksList, snapshotTasksList, tasksRecentRuns } from '@/tools/tasks';
 import { vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-one read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty-two read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -34,6 +35,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(rebootInfo);
   catalog.register(auditLogQuery);
   catalog.register(auditConfig);
+  catalog.register(securityConfig);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -105,6 +107,7 @@ export {
   reportingSpaceTrends,
   reportingUtilisation,
   scrubHistory,
+  securityConfig,
   servicesStatus,
   shareAccess,
   sharesList,

--- a/src/tools/security.spec.ts
+++ b/src/tools/security.spec.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { securityConfig } from '@/tools/index';
+
+describe('security_config', () => {
+  /** A `system.security.config` payload, complete unless overridden. */
+  const security = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    enable_fips: true,
+    enable_gpos_stig: false,
+    min_password_age: 1,
+    max_password_age: 60,
+    password_complexity_ruleset: ['UPPER', 'LOWER', 'NUMBER', 'SPECIAL'],
+    min_password_length: 12,
+    password_history_length: 5,
+    ...over,
+  });
+
+  /** An `auth.twofactor.config` payload, complete unless overridden. */
+  const twoFactor = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    enabled: true,
+    services: { ssh: true },
+    window: 30,
+    ...over,
+  });
+
+  const reported = async (
+    securityPayload: unknown = security(),
+    twoFactorPayload: unknown = twoFactor(),
+  ): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({
+      ['system.security.config']: securityPayload,
+      ['auth.twofactor.config']: twoFactorPayload,
+    });
+    return (await securityConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  const posture = async (over: Record<string, unknown> = {}) =>
+    (await reported(security(over)))['security'] as Record<string, unknown>;
+
+  const factor = async (over: Record<string, unknown> = {}) =>
+    (await reported(security(), twoFactor(over)))['two_factor'] as Record<string, unknown>;
+
+  it('is read-only and requires no arguments', () => {
+    expect(securityConfig.mutating).toBe(false);
+    expect(securityConfig.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('reports the security settings and the password policy', async () => {
+    expect(await posture()).toEqual({
+      unavailable: null,
+      fips_enabled: true,
+      stig_enabled: false,
+      min_password_age: 1,
+      max_password_age: 60,
+      min_password_length: 12,
+      password_history_length: 5,
+      password_complexity_ruleset: ['UPPER', 'LOWER', 'NUMBER', 'SPECIAL'],
+    });
+  });
+
+  it('reports the two-factor settings', async () => {
+    expect(await factor()).toEqual({
+      unavailable: null,
+      enabled: true,
+      services: [{ service: 'ssh', enabled: true }],
+      window: 30,
+    });
+  });
+
+  it('states no verdict, on either section or the result', async () => {
+    const result = await reported();
+    for (const section of [result, result['security'], result['two_factor']]) {
+      const fields = Object.keys(section as Record<string, unknown>);
+      expect(fields).not.toContain('verdict');
+      expect(fields).not.toContain('compliant');
+      expect(fields).not.toContain('secure');
+      expect(fields).not.toContain('passed');
+    }
+  });
+
+  it('never reports the middleware row id, from either read', async () => {
+    const result = await reported();
+    expect((result['security'] as Record<string, unknown>)['id']).toBeUndefined();
+    expect((result['two_factor'] as Record<string, unknown>)['id']).toBeUndefined();
+  });
+
+  it('reports STIG mode off as false rather than as unreported', async () => {
+    expect(await posture({ enable_fips: false, enable_gpos_stig: false })).toMatchObject({
+      fips_enabled: false,
+      stig_enabled: false,
+    });
+  });
+
+  it('reports a mode the system did not state as a boolean as null, not as off', async () => {
+    const section = await posture({ enable_fips: 'yes', enable_gpos_stig: null });
+    expect(section['fips_enabled']).toBeNull();
+    expect(section['stig_enabled']).toBeNull();
+    expect(section['fips_enabled']).not.toBe(false);
+  });
+
+  it('keeps a password-policy zero distinct from a policy field the system unset', async () => {
+    expect(
+      await posture({ min_password_length: 0, password_history_length: null }),
+    ).toMatchObject({ min_password_length: 0, password_history_length: null });
+  });
+
+  it('reports a password-policy field this version does not send as null', async () => {
+    // Deleted rather than set to undefined: every password-policy field is
+    // optional in the payload, and a system on a version that does not report
+    // one sends no key at all.
+    const withoutPolicy: Record<string, unknown> = security();
+    delete withoutPolicy['min_password_length'];
+    delete withoutPolicy['max_password_age'];
+    const section = (await reported(withoutPolicy))['security'] as Record<string, unknown>;
+    expect(section['min_password_length']).toBeNull();
+    expect(section['max_password_age']).toBeNull();
+    expect(section['min_password_length']).not.toBe(0);
+  });
+
+  it('reports a password-policy field that is not a finite number as null', async () => {
+    expect(
+      await posture({ min_password_age: '1', max_password_age: Number.NaN }),
+    ).toMatchObject({ min_password_age: null, max_password_age: null });
+  });
+
+  it('reports a system requiring no character classes as an empty ruleset, not as unread', async () => {
+    expect(await posture({ password_complexity_ruleset: [] })).toMatchObject({
+      password_complexity_ruleset: [],
+    });
+  });
+
+  it('passes a character class it does not recognise through as the system spelled it', async () => {
+    expect(await posture({ password_complexity_ruleset: ['UPPER', 'EMOJI'] })).toMatchObject({
+      password_complexity_ruleset: ['UPPER', 'EMOJI'],
+    });
+  });
+
+  it('nulls the whole ruleset rather than reporting one it had to shorten', async () => {
+    // A ruleset one class short would say the policy requires less than it
+    // does, so the unreadable entry nulls the list instead of being dropped.
+    expect(await posture({ password_complexity_ruleset: ['UPPER', 7] })).toMatchObject({
+      password_complexity_ruleset: null,
+    });
+  });
+
+  it('reports a ruleset that is not a list at all as null', async () => {
+    expect(await posture({ password_complexity_ruleset: 'UPPER' })).toMatchObject({
+      password_complexity_ruleset: null,
+    });
+  });
+
+  it('reports two-factor switched on and covering nothing as exactly that', async () => {
+    expect(await factor({ enabled: true, services: {} })).toMatchObject({
+      enabled: true,
+      services: [],
+    });
+  });
+
+  it('reports a service the system named but switched off as false', async () => {
+    expect(await factor({ enabled: true, services: { ssh: false } })).toMatchObject({
+      services: [{ service: 'ssh', enabled: false }],
+    });
+  });
+
+  it('sorts the services by name and passes a later one through', async () => {
+    expect(await factor({ services: { ssh: true, api: false } })).toMatchObject({
+      services: [
+        { service: 'api', enabled: false },
+        { service: 'ssh', enabled: true },
+      ],
+    });
+  });
+
+  it('keeps a service whose value it cannot read, as a named entry saying nothing', async () => {
+    expect(await factor({ services: { ssh: 'on' } })).toMatchObject({
+      services: [{ service: 'ssh', enabled: null }],
+    });
+  });
+
+  it('nulls the whole service list where a service could not be named', async () => {
+    expect(await factor({ services: { '': true, ssh: true } })).toMatchObject({ services: null });
+  });
+
+  it('reports the services as null where the system sent no service configuration', async () => {
+    expect(await factor({ services: ['ssh'] })).toMatchObject({ services: null });
+  });
+
+  it('reports a two-factor field the system did not state as null', async () => {
+    expect(await factor({ enabled: 1, window: null })).toMatchObject({
+      enabled: null,
+      window: null,
+    });
+  });
+
+  it('reports the security section as unread where the system answered with no configuration', async () => {
+    const section = (await reported('hardened'))['security'] as Record<string, unknown>;
+    expect(section).toEqual({
+      unavailable: 'the system did not answer with a security configuration',
+      fips_enabled: null,
+      stig_enabled: null,
+      min_password_age: null,
+      max_password_age: null,
+      min_password_length: null,
+      password_history_length: null,
+      password_complexity_ruleset: null,
+    });
+  });
+
+  it('reports the two-factor section as unread where the system answered with no configuration', async () => {
+    const section = (await reported(security(), []))['two_factor'] as Record<string, unknown>;
+    expect(section).toEqual({
+      unavailable: 'the system did not answer with a two-factor configuration',
+      enabled: null,
+      services: null,
+      window: null,
+    });
+  });
+
+  it('still answers the two-factor settings where the security read failed', async () => {
+    const { ctx } = failingSystem(
+      { ['auth.twofactor.config']: twoFactor() },
+      { ['system.security.config']: new Error('unknown method') },
+    );
+    const result = (await securityConfig.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['security']).toMatchObject({
+      unavailable: 'unknown method',
+      fips_enabled: null,
+      min_password_length: null,
+    });
+    expect(result['two_factor']).toMatchObject({ unavailable: null, enabled: true });
+  });
+
+  it('still answers the security settings where the two-factor read failed', async () => {
+    const { ctx } = failingSystem(
+      { ['system.security.config']: security() },
+      { ['auth.twofactor.config']: { reason: 'not authorised' } },
+    );
+    const result = (await securityConfig.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['two_factor']).toEqual({
+      unavailable: 'not authorised',
+      enabled: null,
+      services: null,
+      window: null,
+    });
+    expect(result['security']).toMatchObject({ unavailable: null, fips_enabled: true });
+  });
+
+  it('names a failure that carried no text of its own rather than reporting nothing', async () => {
+    const { ctx } = failingSystem(
+      { ['system.security.config']: security() },
+      { ['auth.twofactor.config']: {} },
+    );
+    const result = (await securityConfig.handler(ctx, {})) as Record<string, unknown>;
+    expect((result['two_factor'] as Record<string, unknown>)['unavailable']).toBe(
+      'the system reported no reason',
+    );
+  });
+});

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -1,0 +1,339 @@
+import { firstValueFrom } from 'rxjs';
+import { Role } from '@/interfaces';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { booleanOrNull, errorText, numberOrNull, recordOrNull, textOrNull } from '@/tools/common';
+
+/**
+ * The security posture SETTINGS of a system: FIPS and STIG mode, the password
+ * policy, and whether two-factor authentication is switched on.
+ *
+ * `fleet_compliance_report` is asked about compliance and reports auditing,
+ * certificates, directory services, shares and updates — not the settings an
+ * auditor asks about first, because until this tool nothing in the catalog read
+ * them. This is the settings half only. Folding it into that composite is a
+ * separate deliverable and is not done here.
+ *
+ * THIS TOOL STATES NO VERDICT, per the #47 decision in `CLAUDE.md`. "Secure" is
+ * a claim against a standard that lives outside this repository — a framework,
+ * a policy, a customer's contract — and nobody has told this tool which one. It
+ * reports the settings and names what it could not read; any pass/fail reading
+ * of them is the caller's.
+ *
+ * The two calls are SEPARATE READS on unrelated middleware namespaces
+ * (`system.security` and `auth.twofactor`) and either can fail on its own, so
+ * each is a section carrying its own `unavailable` — the same shape `boot.ts`
+ * uses, and for the same reason: half an answer about a system's posture is
+ * worth more than an error. Nothing here mutates; `system.security.update` and
+ * `auth.twofactor.update` both exist on the middleware and neither is in this
+ * catalog.
+ */
+
+/** What a system answering `system.security.config` with something else is reported as. */
+const NOT_A_SECURITY_CONFIG = 'the system did not answer with a security configuration';
+
+/** What a system answering `auth.twofactor.config` with something else is reported as. */
+const NOT_A_TWO_FACTOR_CONFIG = 'the system did not answer with a two-factor configuration';
+
+/** The security settings as this tool reports them. */
+interface SecuritySettings {
+  fips_enabled: boolean | null;
+  stig_enabled: boolean | null;
+  min_password_age: number | null;
+  max_password_age: number | null;
+  min_password_length: number | null;
+  password_history_length: number | null;
+  password_complexity_ruleset: string[] | null;
+}
+
+/** One service the two-factor configuration named, and what it said about it. */
+interface TwoFactorService {
+  service: string;
+  enabled: boolean | null;
+}
+
+/** The two-factor settings as this tool reports them. */
+interface TwoFactorSettings {
+  enabled: boolean | null;
+  services: TwoFactorService[] | null;
+  window: number | null;
+}
+
+/**
+ * One section read, or the reason it could not be — the per-family attempt pair
+ * `boot.ts`, `system.ts` and `fleet.ts` each keep, generic over this family's
+ * own two payloads and no further. It stays in this file for the reason
+ * `CLAUDE.md` records: what those files share is the shape, not the function,
+ * and generalising over the failure type would couple every family to one
+ * signature for no gain.
+ */
+interface Attempt<T> {
+  value: T | null;
+  error: string | null;
+}
+
+/**
+ * The character classes the password policy requires, as names — or null where
+ * the system listed something this tool cannot read as one.
+ *
+ * All-or-nothing rather than per-entry, which is why `textList` from
+ * `common.ts` is not the guard here: that one drops an entry it cannot read,
+ * and a ruleset one class shorter says the policy requires LESS than it does.
+ * That is the #93 decision applied — a list that drops towards a claim must be
+ * nulled, and "this system does not require special characters" is a claim a
+ * dropped entry would make on no evidence. An EMPTY list is kept and is a
+ * different answer: the system reported the ruleset and it names no classes.
+ */
+function complexityRuleset(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const classes: string[] = [];
+  for (const entry of value) {
+    const name = textOrNull(entry);
+    if (name === null) return null;
+    classes.push(name);
+  }
+  return classes;
+}
+
+/**
+ * The services the two-factor configuration named, with what it said about
+ * each — or null where the system sent no service configuration this tool could
+ * read.
+ *
+ * Read from the payload's own keys rather than from the one field the client
+ * declares, the same way `audit_config` reads `enabled_services`: a service a
+ * later TrueNAS release begins covering is then answerable without a change
+ * here, because these are values rather than fields and the allowlist this file
+ * keeps is over the fields of the result.
+ *
+ * An entry whose value is not a boolean is KEPT, with `enabled` null, rather
+ * than dropped. That is the other half of #93: keeping it asserts nothing —
+ * the service was named and nothing was established about it — while dropping
+ * it would say the system does not cover that service at all.
+ *
+ * A key that is not a name nulls the whole list, on the all-or-nothing reading
+ * `audit_config`'s `configuredServices` takes and for the same reason: a
+ * service that cannot be named cannot be reported, and a list quietly one
+ * service shorter reads as a service two-factor does not cover.
+ *
+ * Sorted by name, because the middleware sends a keyed object and the order of
+ * its keys means nothing; leaving it alone would make the result differ between
+ * two reads of the same unchanged configuration.
+ */
+function twoFactorServices(value: unknown): TwoFactorService[] | null {
+  const services = recordOrNull(value);
+  if (services === null) return null;
+  const names = Object.keys(services);
+  if (names.some((name) => name.length === 0)) return null;
+  return names.sort().map((service) => ({ service, enabled: booleanOrNull(services[service]) }));
+}
+
+/**
+ * The security settings, with a failure named rather than thrown.
+ *
+ * `enable_fips` and `enable_gpos_stig` are declared required booleans and are
+ * still read through `booleanOrNull`: a declared type is a claim about what the
+ * middleware sends and not the value received, which is the #91 decision, and
+ * on this subject a wrong `false` is the expensive direction — it reads as "FIPS
+ * is off" rather than as "nothing was established".
+ *
+ * Every password-policy field is optional AND nullable in the payload, so it
+ * arrives in three states: a value, an explicit null, and no key at all on a
+ * version that does not report it. The last two collapse to null here, and that
+ * is deliberate — both say the system stated no value, which is one answer to a
+ * caller, and the distinction that matters is against a value of ZERO. A
+ * `min_password_length` of null is not a minimum length of zero, and the
+ * description says so per field.
+ *
+ * `id` is read by nothing and is deliberately absent from the result: it is a
+ * middleware row id and means nothing outside the middleware.
+ */
+async function readSecurity(system: SystemHandle): Promise<Attempt<SecuritySettings>> {
+  try {
+    const answer = await firstValueFrom(system.client.api.call('system.security.config'));
+    // Read through `recordOrNull` rather than reached into, for the reason
+    // `audit_config` gives: a system answering the call with something that is
+    // not a configuration would otherwise throw naming a property, and the
+    // caller would see the name of a field rather than the read that failed.
+    const settings = recordOrNull(answer);
+    if (settings === null) return { value: null, error: NOT_A_SECURITY_CONFIG };
+    return {
+      value: {
+        // Renamed off the imperative the middleware spells them with:
+        // `enable_fips` reads as an instruction to turn FIPS on, and this is a
+        // report of whether it is on.
+        fips_enabled: booleanOrNull(settings['enable_fips']),
+        stig_enabled: booleanOrNull(settings['enable_gpos_stig']),
+        // These keep the middleware's own names, unit and all — which is to say
+        // without one. The pinned surface declares them bare numbers and states
+        // no unit, so a `_days` or `_seconds` suffix here would be this tool
+        // asserting something it never read. See the decision in `CLAUDE.md`.
+        min_password_age: numberOrNull(settings['min_password_age']),
+        max_password_age: numberOrNull(settings['max_password_age']),
+        min_password_length: numberOrNull(settings['min_password_length']),
+        password_history_length: numberOrNull(settings['password_history_length']),
+        password_complexity_ruleset: complexityRuleset(settings['password_complexity_ruleset']),
+      },
+      error: null,
+    };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/**
+ * The two-factor settings, with a failure named rather than thrown.
+ *
+ * `window` keeps the middleware's own name and carries no unit, for the reason
+ * given above and one more: what it is a window of is documented nowhere on the
+ * pinned surface. It is passed through as the number the system reported.
+ *
+ * `id` is dropped here too, on the same terms as in {@link readSecurity}.
+ */
+async function readTwoFactor(system: SystemHandle): Promise<Attempt<TwoFactorSettings>> {
+  try {
+    const answer = await firstValueFrom(system.client.api.call('auth.twofactor.config'));
+    const settings = recordOrNull(answer);
+    if (settings === null) return { value: null, error: NOT_A_TWO_FACTOR_CONFIG };
+    return {
+      value: {
+        enabled: booleanOrNull(settings['enabled']),
+        services: twoFactorServices(settings['services']),
+        window: numberOrNull(settings['window']),
+      },
+      error: null,
+    };
+  } catch (reason) {
+    return { value: null, error: errorText(reason) };
+  }
+}
+
+/**
+ * The `security` section's fields on a read that did not happen.
+ *
+ * Spelled out rather than left off, because `undefined` serializes to no key at
+ * all: a caller would receive an object missing fields the description promises
+ * — a shape it has not been told about — rather than nulls it can see are
+ * absent.
+ */
+const UNREAD_SECURITY: SecuritySettings = {
+  fips_enabled: null,
+  stig_enabled: null,
+  min_password_age: null,
+  max_password_age: null,
+  min_password_length: null,
+  password_history_length: null,
+  password_complexity_ruleset: null,
+};
+
+/** The `two_factor` section's fields on a read that did not happen. */
+const UNREAD_TWO_FACTOR: TwoFactorSettings = {
+  enabled: null,
+  services: null,
+  window: null,
+};
+
+export const securityConfig: ReadOnlyTool = {
+  name: 'security_config',
+  description:
+    'The security posture SETTINGS of a TrueNAS system: FIPS mode, STIG mode, ' +
+    'the password policy, and whether two-factor authentication is switched ' +
+    'on. THIS TOOL STATES NO VERDICT and has no compliant, secure or pass/fail ' +
+    'field of any kind. "Secure" and "compliant" are claims against a standard ' +
+    'that lives outside this system — a framework, a policy, a contract — and ' +
+    'nothing has told this tool which one, so it reports the settings and names ' +
+    'what it could not read. Any pass/fail reading of them is yours, and must ' +
+    'be stated as being against a named standard. `fleet_compliance_report` ' +
+    'does not read any of these settings; it reports auditing, certificates, ' +
+    'directory services, shares and updates, so a clean answer from it says ' +
+    'NOTHING about anything below. ' +
+    'The result has TWO SECTIONS, `security` and `two_factor`, which come from ' +
+    'SEPARATE READS ON UNRELATED PARTS OF THE MIDDLEWARE AND CAN FAIL ' +
+    'INDEPENDENTLY. Each carries `unavailable`: null where that section was ' +
+    'read, and otherwise what the system said about the failure — and then ' +
+    'EVERY OTHER FIELD IN THAT SECTION IS NULL BECAUSE IT WAS NOT READ, not ' +
+    'because the system reported nothing. A failure in one section never ' +
+    'empties or falsifies the other. ' +
+    'In `security`: `fips_enabled` is whether the system runs in FIPS 140 ' +
+    'validated-cryptography mode. `stig_enabled` is whether it runs in STIG ' +
+    'mode — the General Purpose Operating System Security Technical ' +
+    'Implementation Guide hardening profile, which the middleware spells ' +
+    '`enable_gpos_stig`; it is a hardening mode and NOT a statement that the ' +
+    'system passes a STIG assessment. Each is true, false, or NULL WHERE THE ' +
+    'SYSTEM REPORTED NO VALUE THIS TOOL COULD READ — and a null is neither ' +
+    'answer, so a null must never be read as the mode being off. ' +
+    'THE PASSWORD POLICY FIELDS ARE THE ONES MOST EASILY MISREAD. ' +
+    '`min_password_length` is the shortest password the system accepts, ' +
+    '`password_history_length` is how many previous passwords it refuses to let ' +
+    'a user reuse, and `min_password_age` and `max_password_age` are how long a ' +
+    'password must be kept before it may be changed and how long it may be kept ' +
+    'before it must be. EACH IS NULL WHERE THE SYSTEM STATED NO VALUE FOR IT, ' +
+    'which covers both a system that reported the field as unset and a TrueNAS ' +
+    'version that does not report the field at all — those are one answer here, ' +
+    'and that answer is "this was not established". A NULL IS NEVER A ZERO AND ' +
+    'IS NEVER "NO POLICY". A null `min_password_length` does NOT mean passwords ' +
+    'of any length are accepted, a null `password_history_length` does NOT mean ' +
+    'reuse is allowed, and a null `max_password_age` does NOT mean passwords ' +
+    'never expire. Reporting any of those as a finding on a null is reporting a ' +
+    'finding that has not been established; say the setting was not reported ' +
+    'instead. A ZERO, where one is reported, IS a value the system stated and ' +
+    'is to be read as itself. NO UNIT IS REPORTED FOR ANY OF THESE NUMBERS: ' +
+    'the API this tool reads declares `min_password_age` and `max_password_age` ' +
+    'as bare numbers and states no unit for them, so this tool states none ' +
+    'either — do not assume days, and do not convert them. ' +
+    '`password_complexity_ruleset` is the character classes a password must ' +
+    'draw from, as the system names them; `UPPER`, `LOWER`, `NUMBER` and ' +
+    '`SPECIAL` are the declared values and THE SET IS NOT CLOSED, so any other ' +
+    'value is passed through as the system spelled it. An EMPTY list is a real ' +
+    'answer — the system reported the ruleset and it names no classes — while ' +
+    'NULL means no ruleset this tool could read was reported, and null is never ' +
+    'to be read as the empty one. The list is nulled WHOLE rather than shortened ' +
+    'if any entry cannot be read, so a ruleset that is reported is complete. ' +
+    'In `two_factor`: `enabled` is whether two-factor authentication is ' +
+    'switched on at all — true, false, or null where the system reported no ' +
+    'value this tool could read, and a null is not a false. `services` is one ' +
+    'entry per service the two-factor configuration named, sorted by name, with ' +
+    '`service` as the system spelled it and `enabled` true, false, or null ' +
+    'where the system said nothing this tool could read about that service. ' +
+    'THE ONLY SERVICE THIS PAYLOAD CAN REPORT IS SSH: the API surface this tool ' +
+    'is pinned to declares exactly one service field, `ssh`, so a name a later ' +
+    'TrueNAS release adds is passed through if it arrives but nothing here can ' +
+    'be relied on to name it. THAT MAKES ABSENCE UNINFORMATIVE — this tool ' +
+    'CANNOT tell you whether two-factor applies to the web UI, the API, or ' +
+    'anything else that is not SSH, and a service not appearing here is not ' +
+    'evidence that two-factor does not cover it. `services` is null where the ' +
+    'system reported no service configuration this tool could read; an EMPTY ' +
+    'list, or a list whose entries are all false, is the different and stronger ' +
+    'answer that two-factor covers NOTHING THIS PAYLOAD NAMES. `enabled` true ' +
+    'with such a list is two-factor switched on and applied to nothing it can ' +
+    'name, which is a real state and is worth reporting as itself rather than ' +
+    'as "two-factor is on". `window` is the one-time-password validity window ' +
+    'the system reported, passed through as the number it gave; THE API ' +
+    'DECLARES NO UNIT FOR IT and neither does this tool, so do not render it as ' +
+    'seconds, minutes or steps. It is null where the system reported no number ' +
+    'this tool could read. ' +
+    'Neither section reports anything about the users on the system: whether an ' +
+    'individual account has two-factor set up, and who has which privileges, ' +
+    'are `users_list`, not this tool. Whether the hardware is CAPABLE of FIPS, ' +
+    'as opposed to whether it is on, is not reported. This tool only reports. ' +
+    'It does not enable or disable FIPS or STIG mode, change any password ' +
+    'policy setting, or turn two-factor authentication on or off — those are ' +
+    '`system.security.update` and `auth.twofactor.update`, and neither is in ' +
+    'this catalog.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Both reads are issued before either is awaited, so neither waits on the
+    // other, and neither can fail the tool: "is this box hardened" and "is
+    // two-factor on" are separately useful answers, and losing one must not
+    // lose the other.
+    const [security, twoFactor] = await Promise.all([
+      readSecurity(system),
+      readTwoFactor(system),
+    ]);
+    return {
+      security: { unavailable: security.error, ...(security.value ?? UNREAD_SECURITY) },
+      two_factor: { unavailable: twoFactor.error, ...(twoFactor.value ?? UNREAD_TWO_FACTOR) },
+    };
+  },
+};

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -269,9 +269,10 @@ export const securityConfig: ReadOnlyTool = {
     '`password_history_length` is how many previous passwords it refuses to let ' +
     'a user reuse, and `min_password_age` and `max_password_age` are how long a ' +
     'password must be kept before it may be changed and how long it may be kept ' +
-    'before it must be. EACH IS NULL WHERE THE SYSTEM STATED NO VALUE FOR IT, ' +
-    'which covers both a system that reported the field as unset and a TrueNAS ' +
-    'version that does not report the field at all — those are one answer here, ' +
+    'before it must be. EACH IS NULL WHERE THE SYSTEM REPORTED NO VALUE THIS ' +
+    'TOOL COULD READ, which covers a system that reported the field as unset, a ' +
+    'TrueNAS version that does not report the field at all, and a value that ' +
+    'arrived as something other than a finite number — those are one answer here, ' +
     'and that answer is "this was not established". A NULL IS NEVER A ZERO AND ' +
     'IS NEVER "NO POLICY". A null `min_password_length` does NOT mean passwords ' +
     'of any length are accepted, a null `password_history_length` does NOT mean ' +
@@ -315,11 +316,14 @@ export const securityConfig: ReadOnlyTool = {
     'seconds, minutes or steps. It is null where the system reported no number ' +
     'this tool could read. ' +
     'EVERYTHING HERE IS SYSTEM-WIDE SETTINGS AND NOTHING HERE IS PER-ACCOUNT. ' +
-    'Whether an individual account has two-factor set up, and what any account ' +
-    'is permitted to do, are reported by NO TOOL IN THIS CATALOG — `users_list` ' +
-    'returns no two-factor state and says outright that it does not report what ' +
-    'an account is permitted to do, so do not send a caller there for either. ' +
-    'Whether the hardware is CAPABLE of FIPS, ' +
+    'Whether an individual account has two-factor set up is reported by NO ' +
+    'TOOL IN THIS CATALOG — `users_list` returns no two-factor state, so do ' +
+    'not send a caller there for it. What an account is permitted to do is not ' +
+    'reported here either, and `users_list` says outright that it does not ' +
+    'report it; who may reach a SHARE, and with what rights, is `share_access`, ' +
+    'asked one share at a time rather than one account at a time, and nothing ' +
+    'in this catalog reports the privileges an account holds more broadly than ' +
+    'that. Whether the hardware is CAPABLE of FIPS, ' +
     'as opposed to whether it is on, is not reported. This tool only reports. ' +
     'It does not enable or disable FIPS or STIG mode, change any password ' +
     'policy setting, or turn two-factor authentication on or off — those are ' +

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -184,8 +184,11 @@ async function readSecurity(system: SystemHandle): Promise<Attempt<SecuritySetti
  * The two-factor settings, with a failure named rather than thrown.
  *
  * `window` keeps the middleware's own name and carries no unit, for the reason
- * given above and one more: what it is a window of is documented nowhere on the
- * pinned surface. It is passed through as the number the system reported.
+ * given above: the pinned surface declares it a bare number and documents no
+ * unit for it, so it is passed through as the number the system reported.
+ * (unconfirmed) It is the validity window of a one-time password, read off the
+ * field's name and its place in the two-factor configuration rather than off
+ * anything the surface states.
  *
  * `id` is dropped here too, on the same terms as in {@link readSecurity}.
  */
@@ -306,14 +309,17 @@ export const securityConfig: ReadOnlyTool = {
     'answer that two-factor covers NOTHING THIS PAYLOAD NAMES. `enabled` true ' +
     'with such a list is two-factor switched on and applied to nothing it can ' +
     'name, which is a real state and is worth reporting as itself rather than ' +
-    'as "two-factor is on". `window` is the one-time-password validity window ' +
-    'the system reported, passed through as the number it gave; THE API ' +
+    'as "two-factor is on". `window` is (unconfirmed) the validity window of a ' +
+    'one-time password, passed through as the number the system gave; THE API ' +
     'DECLARES NO UNIT FOR IT and neither does this tool, so do not render it as ' +
     'seconds, minutes or steps. It is null where the system reported no number ' +
     'this tool could read. ' +
-    'Neither section reports anything about the users on the system: whether an ' +
-    'individual account has two-factor set up, and who has which privileges, ' +
-    'are `users_list`, not this tool. Whether the hardware is CAPABLE of FIPS, ' +
+    'EVERYTHING HERE IS SYSTEM-WIDE SETTINGS AND NOTHING HERE IS PER-ACCOUNT. ' +
+    'Whether an individual account has two-factor set up, and what any account ' +
+    'is permitted to do, are reported by NO TOOL IN THIS CATALOG — `users_list` ' +
+    'returns no two-factor state and says outright that it does not report what ' +
+    'an account is permitted to do, so do not send a caller there for either. ' +
+    'Whether the hardware is CAPABLE of FIPS, ' +
     'as opposed to whether it is on, is not reported. This tool only reports. ' +
     'It does not enable or disable FIPS or STIG mode, change any password ' +
     'policy setting, or turn two-factor authentication on or off — those are ' +

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -160,7 +160,9 @@ async function readSecurity(system: SystemHandle): Promise<Attempt<SecuritySetti
       value: {
         // Renamed off the imperative the middleware spells them with:
         // `enable_fips` reads as an instruction to turn FIPS on, and this is a
-        // report of whether it is on.
+        // report of whether it is SET. Not of whether the system is running
+        // that way: `system.security.info.fips_enabled` is a separate call and
+        // this tool does not make it, which the description says outright.
         fips_enabled: booleanOrNull(settings['enable_fips']),
         stig_enabled: booleanOrNull(settings['enable_gpos_stig']),
         // These keep the middleware's own names, unit and all — which is to say
@@ -256,12 +258,19 @@ export const securityConfig: ReadOnlyTool = {
     'EVERY OTHER FIELD IN THAT SECTION IS NULL BECAUSE IT WAS NOT READ, not ' +
     'because the system reported nothing. A failure in one section never ' +
     'empties or falsifies the other. ' +
-    'In `security`: `fips_enabled` is whether the system runs in FIPS 140 ' +
-    'validated-cryptography mode. `stig_enabled` is whether it runs in STIG ' +
-    'mode — the General Purpose Operating System Security Technical ' +
-    'Implementation Guide hardening profile, which the middleware spells ' +
-    '`enable_gpos_stig`; it is a hardening mode and NOT a statement that the ' +
-    'system passes a STIG assessment. Each is true, false, or NULL WHERE THE ' +
+    'In `security`: BOTH MODE FIELDS ARE THE CONFIGURED SETTING AND NEITHER IS ' +
+    'THE RUNNING STATE. `fips_enabled` is whether the system is CONFIGURED to ' +
+    'run in FIPS 140 validated-cryptography mode, read from the setting the ' +
+    'middleware spells `enable_fips`. Whether it is ACTUALLY running that way is ' +
+    'a separate call, `system.security.info.fips_enabled`, which NO TOOL IN THIS ' +
+    'CATALOG makes — that the middleware answers the two separately is the ' +
+    'reason to keep them distinct, so a true here is that the mode is set and is ' +
+    'NOT proof the running system is in it. `stig_enabled` is the same kind of ' +
+    'answer for STIG mode — the General Purpose Operating System Security ' +
+    'Technical Implementation Guide hardening profile, which the middleware ' +
+    'spells `enable_gpos_stig`; it is a hardening mode and NOT a statement that ' +
+    'the system passes a STIG assessment, and the surface this tool is pinned to ' +
+    'offers no running-state call for it at all. Each is true, false, or NULL WHERE THE ' +
     'SYSTEM REPORTED NO VALUE THIS TOOL COULD READ — and a null is neither ' +
     'answer, so a null must never be read as the mode being off. ' +
     'THE PASSWORD POLICY FIELDS ARE THE ONES MOST EASILY MISREAD. ' +


### PR DESCRIPTION
Closes #96

Adds `security_config`, a read-only tool over `system.security.config` and
`auth.twofactor.config`. Both are confirmed present on `DefaultApiDirectory`
(the v25.10.0 call directory the pinned client's `ApiCallDirectoryBase` is
`Pick`ed from), which #42 and #48 were each stopped at — so that was checked
before anything was designed.

New family file `src/tools/security.ts`, with `src/tools/security.spec.ts`
beside it under the #87 rule. Registered after `audit_config` in
`createDefaultCatalog()`, exported from both barrels, and named in the
`README.md` listing and the exact-list assertion in `index.spec.ts` (count
wording forty-two → forty-three).

## What it reports

Two sections, `security` and `two_factor`, from two separate reads issued
together. Each carries its own `unavailable` and every other field in that
section is null when it is non-null, so either call failing still leaves the
other answering — the `boot_pool_status` shape.

**No verdict, per the #47 decision.** No `verdict`, `compliant`, `secure` or
pass/fail field of any kind, asserted by a test over the field names of the
result and of both sections. "Secure" is a claim against a standard that lives
outside this repository and nothing has told this tool which one.

`security` reports `fips_enabled`, `stig_enabled` and the five password-policy
fields. `two_factor` reports `enabled`, `services` and `window`. `id` is dropped
from both.

## The four things this tool is mostly about

**The two mode fields are the CONFIGURED setting, not the running state.** They
read `enable_fips` and `enable_gpos_stig` off `system.security.config`, renamed
off the middleware's imperative spelling. Whether the system is actually running
in FIPS mode is a *different* call on the same pinned surface,
`system.security.info.fips_enabled`, and no tool in this catalog makes it — that
the middleware answers the two separately is itself the reason to keep the claims
apart, so a true here is that the mode is set and not that the system is in it.
STIG has no running-state call on this surface at all, and the description says
both of those outright. `stig_enabled` also says in words that it is the General
Purpose Operating System STIG hardening profile and not a statement that the
system passes an assessment.

**A null password-policy field is never a zero.** Every one of them is optional
*and* nullable, so it arrives in three states: a value, an explicit null, and no
key at all on a version that does not report it. Those collapse to null here,
together with a value that arrives as something other than a finite number —
all of them say the system reported no value this tool could read, which is one
answer to a caller — and the description says per field that null is not zero and
not "no policy": a null `min_password_length` does not mean any length is
accepted, a null `max_password_age` does not mean passwords never expire. A
reported zero is a value and is read as itself. Covered by a test that deletes
the keys rather than setting them undefined, one that keeps a zero distinct from
an unset field, and one for a non-finite number.

**The complexity ruleset is nulled whole, not shortened.** `textList` from
`common.ts` drops an entry it cannot read, and a ruleset one class short says
the policy requires *less* than it does — the #93 rule, drop-towards-a-claim.
So `complexityRuleset` nulls the list instead. An empty list is kept and is the
different, real answer that the system reported the ruleset and it names no
classes.

**The 2FA service list can only ever report SSH.** The pinned surface declares
exactly one field on `TwoFactorAuthServices`, `ssh?`, so the description says
outright that this tool cannot tell you whether two-factor applies to the web
UI, the API or anything else, and that a service not appearing is not evidence
it is uncovered. `enabled: true` with an empty list, or with every entry false,
is reported as what it is — two-factor switched on and applied to nothing this
payload names — rather than as "two-factor is on".

## Where the tool stops, and what does answer instead

Nothing here is per-account. No tool in this catalog reports whether an
individual account has two-factor set up — `users_list` returns no two-factor
state — so the description says not to send a caller there for it. What an
account is *permitted* to do is not reported here either, and `users_list` says
outright that it does not report it; who may reach a **share**, and with what
rights, is `share_access`, asked one share at a time rather than one account at
a time, and nothing in this catalog reports an account's privileges more broadly
than that.

## No unit in a field name that was not established

`min_password_age`, `max_password_age` and `window` keep the middleware's own
names with no unit suffix. The ticket flags `window`'s unit as unconfirmed and
asks for it to be read off the middleware; there is no live system here, and the
pinned surface declares all three as bare numbers and documents no unit for any
of them, so the tool asserts none and the description tells a caller not to
convert them. That the `window` is a one-time-password validity window is marked
`(unconfirmed)` in both the description and the code, since it is read off the
field's name and its place in the configuration rather than off anything stated.

This diverges from `audit_config`'s `retention_days`, so it is recorded as a
decision in `CLAUDE.md` rather than left as an unexplained inconsistency: a
suffix is a claim, and a wrongly suffixed number gets converted where an
unsuffixed one gets asked about. The decision names the two ways a unit can have
been established — the payload's own field name states it (the boot *environment*
`size_bytes`, from `used_bytes`), or the domain fixes it (the boot *pool*'s
`size_bytes`/`allocated_bytes`/`free_bytes`, from a ZFS pool's bare
`size`/`allocated`/`free`, which cannot be counted in anything else) — and why a
password age and an OTP window have neither. `retention_days` is not renamed
here: it is on a public barrel export and out of this ticket's scope.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test` (894 passing) and `yarn build` all
run locally and pass, and were re-run after every round below.
`yarn test:coverage` meets the floors in `vitest.config.ts` —
`src/tools/security.ts` is at 100% statements and 100% branches, and the global
figures are 99.67 / 99.34 against floors of 97 / 96. No floor is changed. Every
CI step ran here; none needed anything this machine does not have.

## Review history

Four rounds of `local-review.py`, which ran the project's own reviewer in a
separate process every time — so each verdict is the required check's own rather
than a subagent's — plus the check itself once, on the first push.

**Round 1 (local), one MEDIUM.** The description routed a caller to `users_list`
for whether an individual account has two-factor set up and for what an account
may do. `users_list` reports neither. Fixed in `df7df9b`.

**Round 2 (local)** returned nothing at or above MEDIUM, and the branch was
pushed.

**The check's review then raised a MEDIUM on that same fix** (`32125bf`): round 1
had over-corrected into a catalog-wide negative that is false for half of what it
covers. `share_access` does report what an account may do in the share dimension,
and `users_list`'s own description routes a caller there for exactly that — so a
model reading `security_config` was being told no tool answers permissions at all
and would not call the one that does. Rewritten as the section above describes:
the two-factor half of the claim stands, the privileges half now names
`share_access`.

Two of the same round's LOWs went in with it, both because they were wrong about
the code in this diff rather than merely incomplete:

- the password-policy paragraph enumerated the causes of a null exhaustively
  ("covers **both** … unset and … does not report the field at all") while
  `numberOrNull` nulls a third case the spec already covers, a value present but
  not a finite number;
- the `CLAUDE.md` decision rested on `boot_pool_status`'s `size_bytes` as the
  case where "the API states it", but three of that tool's four `_bytes` fields
  read bare payload names — read literally the rule said `boot_pool_status`
  needed renaming.

**Round 3 (local), one MEDIUM** — and it is the one worth reading: `fips_enabled`
and `stig_enabled` were described as whether the system *runs* in those modes,
where the payload they read is what is *configured*. Fixed in `bcdacb3`, in the
description and in the comment above the reads, which had made the same claim.
Description only — reading `system.security.info.fips_enabled` would be a second
subject and a second endpoint, which this ticket did not ask for.

**Round 4 (local)** returned nothing at or above MEDIUM. That is where the local
loop stopped.

## What I did not change

LOWs from the clean round and from the check, left because fixing a LOW starts
another review round and this one came back clean. Each is real enough to be
worth a later ticket:

- `twoFactorServices` is close to `system.ts`'s `configuredServices`, and
  `complexityRuleset` to its `scopeNames` — same `recordOrNull`, same
  all-or-nothing nulling, same sort — differing in the value mapper and in the
  field names of what they produce. Sharing them would mean generalising over the
  entry type, which the #86 decision puts on the wrong side of its line ("what
  does not belong is anything whose meaning is a family's own: … a field name").
  The all-or-nothing *rule* having several homes is the fair half of the finding,
  and is what a follow-up would address.
- The description calls an empty `services` list the stronger answer that
  two-factor covers nothing, while `ssh` is optional in the payload, so `{}` is
  also just an absence. As worded the claim is scoped — "covers nothing **this
  payload names**" — which is true of `{}` as well; but the scoping is carrying
  more weight than one clause comfortably should.
- The description states the whole-list nulling rule for
  `password_complexity_ruleset` and not for `services`, which has the same rule.
  An omission rather than a wrong claim, and worth closing.
- The description does not warn about `enabled: false` with a service entry set
  true, which could read as SSH being protected while two-factor is globally off.
- `CLAUDE.md`'s `common.ts` decision says "**Four** files hold one" of the
  per-family `Attempt` pairs. That count was already stale before this ticket —
  `grep` finds `interface Attempt` in seven files without this one, plus the
  named variants in `system.ts` and `fleet.ts`. This diff adds another instance
  and does not correct the census, because the census was not made false by this
  change and the file is being edited by other tickets in flight.
