### PR TITLE
feat(tools): report app engine status and what an available app update changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,53 @@ since a tool result is recorded verbatim in the audit trail (S3.3). Naming the
 arm's fields one by one is what keeps it out, and what keeps out a second
 credential-shaped field a later release adds to any arm.
 
+### Two tools that make a third interpretable are still two tools (#101)
+
+`app_engine_status` and `apps_update_summary` arrived on one ticket, land in one
+file, and exist for the same reason — `apps_list` alone is misread without them.
+That is the whole case for folding them into one tool with two sections, and it
+is not enough.
+
+**The section test is #97's, and it is about the CALLER's answer rather than
+about where the tools came from.** `automated_tasks_list` returns four sections
+because a caller reaching three of them gets a confident answer with a category
+silently missing — the missing kind is the finding. Neither of these completes
+the other that way: a caller reading only the engine status is not given a wrong
+answer about updates, and a caller reading only the updates is not given a wrong
+answer about the engine. Shared motivation, one file and one pull request are
+not the test. **Ask whether a caller who reads only one of them is misled by
+what the other would have said.**
+
+What settles the remainder is the name, under #97's first bullet. A single tool
+over both would have to be named for the engine or for the applications, and
+either name promises what only the other half delivers.
+
+**What they owe each other instead is a POINTER, and both descriptions carry
+one.** Twelve applications reporting as stopped because the engine is down is
+the misreading this family is most likely to produce, and splitting the tools is
+only safe because each description names the other. A split that leaves a caller
+unable to discover the second tool reintroduces the defect the section seam
+exists to prevent.
+
+**A CAP can be worse than an omission, which is #44's rule deciding against
+truncation rather than for it.** `apps_update_summary` reports no changelog: it
+is unbounded upstream prose returned once per application, and the cap that
+would bound it could drop the line naming a breaking change while the field
+still presented itself as the answer to what the update alters — a cap dropping
+the finding rather than the line describing it. The list of other versions
+available to upgrade to goes for the same reason at lower stakes. What that buys
+is an entry fixed in size, so the response grows only with the number of
+applications that have an update; both omissions are named in the description,
+as `boot_pool_status` names the boot pool's scan record.
+
+**A status word this catalog has not read is UNKNOWN, never the negative.**
+`app_engine_status`'s `running` is derived through a total `Record` over the
+client's own status union, so a TrueNAS release adding a word breaks the build
+rather than being answered `false` — and `false` there is the positive claim
+that nothing on the system can run. The membership test is `Object.hasOwn` and
+not `in`, which walks the prototype: `'constructor'` is `in` every object
+literal and would have been read back as a boolean the field cannot hold.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,11 +589,24 @@ as `boot_pool_status` names the boot pool's scan record.
 
 **A status word this catalog has not read is UNKNOWN, never the negative.**
 `app_engine_status`'s `running` is derived through a total `Record` over the
-client's own status union, so a TrueNAS release adding a word breaks the build
-rather than being answered `false` — and `false` there is the positive claim
-that nothing on the system can run. The membership test is `Object.hasOwn` and
-not `in`, which walks the prototype: `'constructor'` is `in` every object
-literal and would have been read back as a boolean the field cannot hold.
+status union, which is exhaustiveness-checked against the surface and answers
+null for anything not in it — `false` there is the positive claim that nothing
+on the system can run.
+
+**The exhaustiveness check is not a bound on what a system can send, and
+reading it as one is the trap.** `ApiSurface` is `DefaultApiDirectory`, the
+OLDEST supported directory (#91), so a total `Record` over a union taken from it
+is total over the oldest surface only: `docker.status` declares seven status
+words there and nine on a later one, and a system on that release can send
+`MIGRATING` today with nothing failing to compile. **Every mapping keyed off a
+union derived from `ApiSurface` needs the unmapped case to be an honest answer
+rather than a branch presumed unreachable** — which is the same reading #100
+gives its `default` arm, arrived at from the version skew instead of from a
+method's union differing from an event's.
+
+The membership test is `Object.hasOwn` and not `in`, which walks the prototype:
+`'constructor'` is `in` every object literal and would have been read back as a
+boolean the field cannot hold.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,
+  `app_engine_status`, `apps_update_summary`,
   `vms_list`, `vm_logs`, `vm_devices`, `alerts_list`, `snapshots_list`,
   `replication_status`,
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `automated_tasks_list`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,8 @@ export {
   quotaReport,
   disksList,
   appsList,
+  appEngineStatus,
+  appsUpdateSummary,
   vmsList,
   vmLogs,
   vmDevices,

--- a/src/tools/apps.spec.ts
+++ b/src/tools/apps.spec.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { fakeSystem } from '@/testing/fake-systems';
-import { appsList } from '@/tools/index';
+import { describe, expect, it, vi } from 'vitest';
+import { Observable, from, of, throwError } from 'rxjs';
+import { SystemHandle, ToolContext } from '@/catalog/tool';
+import { failingSystem, fakeSystem } from '@/testing/fake-systems';
+import { appEngineStatus, appsList, appsUpdateSummary } from '@/tools/index';
 
 describe('apps_list', () => {
   // Every property the middleware's app row carries, so the assertions below
@@ -129,5 +131,353 @@ describe('apps_list', () => {
   it('returns [] for a system with no apps installed', async () => {
     const { ctx } = fakeSystem({ ['app.query']: [] });
     expect(await appsList.handler(ctx, {})).toEqual([]);
+  });
+});
+
+describe('app_engine_status', () => {
+  const status = (over: Record<string, unknown>) => ({
+    status: 'RUNNING',
+    description: 'Docker service is running',
+    ...over,
+  });
+
+  it('reports the engine as running, with the system\'s own words', async () => {
+    const { ctx, call } = fakeSystem({ ['docker.status']: status({}) });
+    expect(await appEngineStatus.handler(ctx, {})).toEqual({
+      unavailable: null,
+      running: true,
+      status: 'RUNNING',
+      description: 'Docker service is running',
+    });
+    // No arguments: the engine's status is a fact about the host.
+    expect(call.mock.calls).toEqual([['docker.status']]);
+  });
+
+  it.each([
+    ['STOPPED', 'the engine is down'],
+    ['FAILED', 'the engine failed to come up'],
+    ['UNCONFIGURED', 'apps have never been set up'],
+    ['INITIALIZING', 'the engine is on its way up and not there yet'],
+    ['PENDING', 'the engine has been asked for and is not there yet'],
+    ['STOPPING', 'the engine is on its way down'],
+  ])('reports %s as not running — %s', async (word) => {
+    const { ctx } = fakeSystem({ ['docker.status']: status({ status: word }) });
+    const result = (await appEngineStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['running']).toBe(false);
+    expect(result['status']).toBe(word);
+  });
+
+  it('reports a status word it has not read as UNKNOWN rather than as not running', async () => {
+    // A later TrueNAS release adding a word must not be answered `false`, which
+    // is the positive claim that nothing on the system can run. The word itself
+    // is still passed through, so the caller sees what the system said.
+    const { ctx } = fakeSystem({ ['docker.status']: status({ status: 'QUIESCED' }) });
+    expect(await appEngineStatus.handler(ctx, {})).toEqual({
+      unavailable: null,
+      running: null,
+      status: 'QUIESCED',
+      description: 'Docker service is running',
+    });
+  });
+
+  it('answers UNKNOWN for a status inherited from the prototype rather than reported', async () => {
+    // `'constructor' in ENGINE_RUNNING` is true for any object literal, so a
+    // membership test that walked the prototype would answer this one with
+    // `undefined` — read back as a boolean the field cannot hold.
+    const { ctx } = fakeSystem({ ['docker.status']: status({ status: 'constructor' }) });
+    const result = (await appEngineStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['running']).toBeNull();
+  });
+
+  it('reports the reason it could not read the engine, with every field null', async () => {
+    // A system with no apps support rejects here; that is an answer about the
+    // system rather than a fault, so the tool does not throw.
+    const { ctx } = failingSystem({}, { ['docker.status']: new Error('Method not found') });
+    expect(await appEngineStatus.handler(ctx, {})).toEqual({
+      unavailable: 'Method not found',
+      running: null,
+      status: null,
+      description: null,
+    });
+  });
+
+  it('reads an answer that is not a status as unreadable rather than as stopped', async () => {
+    const { ctx } = fakeSystem({ ['docker.status']: 'RUNNING' });
+    expect(await appEngineStatus.handler(ctx, {})).toEqual({
+      unavailable: 'the system did not answer with an app engine status',
+      running: null,
+      status: null,
+      description: null,
+    });
+  });
+
+  it('nulls a status and a description the system reported as something else', async () => {
+    const { ctx } = fakeSystem({ ['docker.status']: status({ status: 7, description: '' }) });
+    expect(await appEngineStatus.handler(ctx, {})).toEqual({
+      unavailable: null,
+      running: null,
+      status: null,
+      description: null,
+    });
+  });
+
+  it('returns no field a later release adds to the status record', async () => {
+    const { ctx } = fakeSystem({
+      ['docker.status']: status({ container_count: 12, dataset: 'tank/ix-apps' }),
+    });
+    const result = (await appEngineStatus.handler(ctx, {})) as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual(['unavailable', 'running', 'status', 'description']);
+  });
+});
+
+describe('apps_update_summary', () => {
+  const app = (over: Record<string, unknown>) => ({
+    name: 'plex',
+    version: '1.2.3',
+    human_version: '1.41.0.8994_1.2.3',
+    upgrade_available: true,
+    latest_version: '1.3.0',
+    image_updates_available: false,
+    config: { plex_claim_token: 'claim-abc123' },
+    ...over,
+  });
+
+  const summary = (over: Record<string, unknown>) => ({
+    latest_version: '1.3.0',
+    latest_human_version: '1.42.0.9000_1.3.0',
+    upgrade_version: '1.3.0',
+    upgrade_human_version: '1.42.0.9000_1.3.0',
+    available_versions_for_upgrade: [{ version: '1.3.0', human_version: '1.42.0.9000_1.3.0' }],
+    changelog: '# 1.3.0\n\nBREAKING: the config format changed.',
+    ...over,
+  });
+
+  /**
+   * A system whose `app.upgrade_summary` answers per application name, which
+   * neither shared fixture can do — both answer one canned value per METHOD,
+   * and every test below that matters is about one application's summary
+   * differing from another's.
+   */
+  const perApp = (
+    rows: unknown,
+    summaries: Record<string, unknown>,
+    failures: Record<string, unknown> = {},
+    respond: (value: unknown) => Observable<unknown> = of,
+  ) => {
+    const query = vi.fn(() => of(rows));
+    const call = vi.fn((_method: string, args: unknown[]) => {
+      const name = String(args[0]);
+      return name in failures ? throwError(() => failures[name]) : respond(summaries[name]);
+    });
+    const system = { name: 'nas', client: { api: { query, call } } } as unknown as SystemHandle;
+    return { ctx: { system } as ToolContext, query, call };
+  };
+
+  it('reports the version an update would move to, beside the installed one', async () => {
+    const { ctx, call } = fakeSystem({
+      ['app.query']: [app({})],
+      ['app.upgrade_summary']: summary({}),
+    });
+    expect(await appsUpdateSummary.handler(ctx, {})).toEqual({
+      unavailable: null,
+      entries: [
+        {
+          app: 'plex',
+          unavailable: null,
+          installed_version: '1.2.3',
+          installed_human_version: '1.41.0.8994_1.2.3',
+          upgrade_version: '1.3.0',
+          upgrade_human_version: '1.42.0.9000_1.3.0',
+          latest_version: '1.3.0',
+          latest_human_version: '1.42.0.9000_1.3.0',
+        },
+      ],
+    });
+    expect(call.mock.calls).toEqual([['app.upgrade_summary', ['plex']]]);
+  });
+
+  it('reports neither the changelog nor the other versions available', async () => {
+    // Both are dropped deliberately — see the tool's description. A trim would
+    // have carried the changelog, which is unbounded upstream prose, and
+    // `config`, which holds the install-time claim token.
+    const { ctx } = fakeSystem({
+      ['app.query']: [app({})],
+      ['app.upgrade_summary']: summary({ future_field: 'added by a later release' }),
+    });
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect(Object.keys(entries[0])).toEqual([
+      'app',
+      'unavailable',
+      'installed_version',
+      'installed_human_version',
+      'upgrade_version',
+      'upgrade_human_version',
+      'latest_version',
+      'latest_human_version',
+    ]);
+  });
+
+  it('keeps upgrade_version and latest_version apart where the upgrade stops short', async () => {
+    const { ctx } = fakeSystem({
+      ['app.query']: [app({})],
+      ['app.upgrade_summary']: summary({
+        upgrade_version: '1.2.9',
+        upgrade_human_version: '1.41.9.8999_1.2.9',
+        latest_version: '2.0.0',
+        latest_human_version: '2.0.0.1_2.0.0',
+      }),
+    });
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect([entries[0]['upgrade_version'], entries[0]['latest_version']]).toEqual([
+      '1.2.9',
+      '2.0.0',
+    ]);
+  });
+
+  it('does not read a summary for an app with no update waiting, and leaves it out', async () => {
+    const { ctx, call } = perApp(
+      [app({ name: 'plex' }), app({ name: 'nextcloud', upgrade_available: false })],
+      { plex: summary({}) },
+    );
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: { app: string }[];
+    };
+    expect(entries.map((entry) => entry.app)).toEqual(['plex']);
+    expect(call.mock.calls).toEqual([['app.upgrade_summary', ['plex']]]);
+  });
+
+  it('returns [] where every app is up to date, reading no summary at all', async () => {
+    const { ctx, call } = perApp([app({ upgrade_available: false })], {});
+    expect(await appsUpdateSummary.handler(ctx, {})).toEqual({ unavailable: null, entries: [] });
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('issues every per-app read together rather than one after another', async () => {
+    // Nothing resolves until the gate opens, so a handler reading these in
+    // sequence would never get past the first: the wait below is what
+    // distinguishes issued-together from issued-one-at-a-time, and a `toEqual`
+    // on the call count after the fact would pass either way.
+    let open!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+    const { ctx, call } = perApp(
+      [app({ name: 'plex' }), app({ name: 'sonarr' }), app({ name: 'immich' })],
+      { plex: summary({}), sonarr: summary({}), immich: summary({}) },
+      {},
+      (value) => from(gate.then(() => value)),
+    );
+    const pending = appsUpdateSummary.handler(ctx, {});
+    await vi.waitFor(() => expect(call).toHaveBeenCalledTimes(3));
+    open();
+    const { entries } = (await pending) as { entries: { app: string }[] };
+    expect(entries.map((entry) => entry.app)).toEqual(['plex', 'sonarr', 'immich']);
+  });
+
+  it('reports an app whose summary failed as unread, without losing the others', async () => {
+    const { ctx } = perApp(
+      [app({ name: 'plex' }), app({ name: 'sonarr' }), app({ name: 'immich' })],
+      { plex: summary({}), immich: summary({ upgrade_version: '9.9.9' }) },
+      { sonarr: { reason: 'catalog is unreachable' } },
+    );
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect(
+      entries.map((entry) => [entry['app'], entry['unavailable'], entry['upgrade_version']]),
+    ).toEqual([
+      ['plex', null, '1.3.0'],
+      ['sonarr', 'catalog is unreachable', null],
+      ['immich', null, '9.9.9'],
+    ]);
+  });
+
+  it('keeps the installed version on an entry whose summary failed', async () => {
+    // It came from the listing, which did not fail. Dropping it with the
+    // summary would lose a fact the read established.
+    const { ctx } = perApp([app({ version: '1.2.3' })], {}, { plex: new Error('timed out') });
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect(entries).toEqual([
+      {
+        app: 'plex',
+        unavailable: 'timed out',
+        installed_version: '1.2.3',
+        installed_human_version: '1.41.0.8994_1.2.3',
+        upgrade_version: null,
+        upgrade_human_version: null,
+        latest_version: null,
+        latest_human_version: null,
+      },
+    ]);
+  });
+
+  it('reads a summary that is not a record as unreadable rather than as no update', async () => {
+    const { ctx } = fakeSystem({
+      ['app.query']: [app({})],
+      ['app.upgrade_summary']: 'no upgrade available',
+    });
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect(entries[0]['unavailable']).toBe('the system did not answer with an upgrade summary');
+  });
+
+  it('keeps an app whose update state could not be read, and does not ask about it', async () => {
+    // Dropping it would say the system reported no update waiting, which is
+    // more than the read established.
+    const { ctx, call } = perApp([app({ upgrade_available: 'maybe' })], {});
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect([entries[0]['app'], entries[0]['unavailable']]).toEqual([
+      'plex',
+      'the system did not report whether an update is waiting for this application, so no ' +
+        'update summary was read',
+    ]);
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('keeps an app the system named nothing, and does not ask about it', async () => {
+    const { ctx, call } = perApp([app({ name: '' })], {});
+    const { entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      entries: Record<string, unknown>[];
+    };
+    expect([entries[0]['app'], entries[0]['unavailable']]).toEqual([
+      null,
+      'the system reported no name for this application, so no update summary was read',
+    ]);
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  it('reports the reason the app listing could not be read, with entries null', async () => {
+    const { ctx } = failingSystem({}, { ['app.query']: { reason: 'connection reset' } });
+    expect(await appsUpdateSummary.handler(ctx, {})).toEqual({
+      unavailable: 'connection reset',
+      entries: null,
+    });
+  });
+
+  it('reads an answer that is not a list as unreadable rather than as no apps', async () => {
+    const { ctx } = fakeSystem({ ['app.query']: { plex: {} } });
+    expect(await appsUpdateSummary.handler(ctx, {})).toEqual({
+      unavailable: 'the system did not answer with a list of applications',
+      entries: null,
+    });
+  });
+
+  it('reports a row it cannot walk as the listing being unreadable, rather than throwing', async () => {
+    const { ctx } = perApp([null], {});
+    const { unavailable, entries } = (await appsUpdateSummary.handler(ctx, {})) as {
+      unavailable: string | null;
+      entries: unknown;
+    };
+    expect(unavailable).not.toBeNull();
+    expect(entries).toBeNull();
   });
 });

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -94,13 +94,19 @@ type EngineStatus = CallResponse<ApiSurface, 'docker.status'>['status'];
 
 /**
  * Which of the engine's status words mean applications can run, one entry per
- * declared member.
+ * member the PINNED surface declares.
  *
- * Typed as a total `Record` over the union ON PURPOSE. A TrueNAS release that
- * adds a status word breaks this build, which is the point: the alternative — a
- * list of the words that mean "not running" — would silently answer `false` for
- * a word nobody here has read, and `false` on this field is the positive claim
- * that nothing on the system can run.
+ * Typed as a total `Record` over the union ON PURPOSE, so that a member added to
+ * the surface this reads cannot be left unmapped silently. What it does NOT do
+ * is bound what a live system can send, and the client already shows why:
+ * `ApiSurface` is `DefaultApiDirectory`, the OLDEST supported directory (seven
+ * words), while a later one declares `MIGRATING` and `MIGRATION_FAILED` too. A
+ * system running that release can send either of them TODAY.
+ *
+ * That is the reason the lookup below answers null for an unmapped word rather
+ * than false. The exhaustiveness is a check on this file against the surface it
+ * compiles against; the null is what keeps the answer honest about every
+ * surface it does not.
  */
 const ENGINE_RUNNING: Record<EngineStatus, boolean> = {
   PENDING: false,

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -177,9 +177,13 @@ export const appEngineStatus: ReadOnlyTool = {
     'ANYTHING FROM SEVERAL STOPPED APPLICATIONS. `running` is the answer: TRUE ' +
     'where the system reported a status meaning applications can run, FALSE ' +
     'WHERE IT REPORTED ONE MEANING THEY CANNOT — which is a positive finding, ' +
-    'the engine is down — and NULL WHERE NOTHING WAS ESTABLISHED, either ' +
-    'because the read failed or because the system used a status word this ' +
-    'catalog does not know. A NULL `running` IS NEVER TO BE READ AS THE FALSE ' +
+    'the engine is down — and NULL WHERE NOTHING WAS ESTABLISHED, which is any ' +
+    'of three: the read failed, the system used a status word this catalog does ' +
+    'not know, or it reported no status this tool could read at all. THOSE LAST ' +
+    'TWO BOTH ANSWER WITH `unavailable` NULL, since the engine was read and only ' +
+    'its status was not understood; they are told apart by `status`, which ' +
+    'carries the unknown word in the second case and is null in the third. ' +
+    'A NULL `running` IS NEVER TO BE READ AS THE FALSE ' +
     'ONE. `status` is the system\'s own word, passed through as it spelled it: ' +
     'RUNNING means the engine is up, STOPPED and FAILED mean it is not, ' +
     'PENDING, INITIALIZING and STOPPING are transient, and UNCONFIGURED means ' +
@@ -389,9 +393,13 @@ export const appsUpdateSummary: ReadOnlyTool = {
     'application rather than of its TrueNAS packaging, and the two vocabularies ' +
     'are not comparable: compare a human version only with another human ' +
     'version, and a plain version only with another plain version. Every field ' +
-    'is null where the system reported no value this tool could read, and every ' +
-    'field but the two installed ones is null on an entry whose ' +
-    '`unavailable` is non-null. ' +
+    'is null where the system reported no value this tool could read. ON AN ' +
+    'ENTRY WHOSE `unavailable` IS NON-NULL, the four version fields above are ' +
+    'ALL NULL and the three that came from the LISTING — `app`, ' +
+    '`installed_version` and `installed_human_version` — still carry whatever ' +
+    'the listing reported, because that read did not fail. A null among those ' +
+    'three is the listing having reported no value, not the summary having ' +
+    'failed. ' +
     'THE RELEASE NOTES ARE NOT REPORTED. The middleware offers a changelog and ' +
     'it is deliberately dropped: it is unbounded upstream prose returned once ' +
     'per application, and a cap on it could drop the very line naming a ' +
@@ -414,10 +422,17 @@ export const appsUpdateSummary: ReadOnlyTool = {
     try {
       const rows = await firstValueFrom(system.client.api.query('app.query'));
       if (!Array.isArray(rows)) return { unavailable: NOT_A_LIST, entries: null };
-      // Chosen inside the `try` with the read that produced them: a row the
-      // system sent in a shape this cannot walk at all is the LISTING being
-      // unreadable, which is an answer, rather than an exception out of a tool
-      // that promises never to throw.
+      // Chosen inside the `try` with the read that produced them, so a row that
+      // cannot be reached into at all — a null or an undefined in the list — is
+      // the LISTING being unreadable, which is an answer, rather than an
+      // exception out of a tool that promises never to throw.
+      //
+      // That is narrower than "any row this cannot read". A string or a number
+      // IS reached into successfully and answers `undefined` to every field, so
+      // it becomes an entry saying the system did not report whether an update
+      // is waiting for it. That is the direction rule again and it is the
+      // intended answer: the system listed something, and dropping it would say
+      // one fewer application has an update waiting than was established.
       candidates = rows.flatMap((row) => {
         const candidate = candidateOf(row);
         return candidate === null ? [] : [candidate];

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -1,6 +1,37 @@
+import type { CallResponse } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { booleanOrNull, errorText, recordOrNull, textOrNull } from '@/tools/common';
+
+/**
+ * The applications family. Three tools, and they are three rather than one
+ * because they answer three questions: `apps_list` is what is installed,
+ * `app_engine_status` is whether the layer they run on is up at all, and
+ * `apps_update_summary` is what a waiting update would actually change.
+ *
+ * **Why the engine and the updates are not one tool.** They arrived on one
+ * ticket and both exist to make `apps_list` interpretable, which is the case
+ * for folding them together. The case against is the one `CLAUDE.md` records
+ * for `automated_tasks_list`: sections belong in one tool when the subject is
+ * COMPLETENESS ACROSS KINDS — when a caller reaching only some of them gets a
+ * confident answer with a category silently missing from it. That is not this.
+ * A caller reading only the engine status is not given a wrong answer about
+ * updates, and a caller reading only the updates is not given a wrong answer
+ * about the engine; neither completes the other, and the two are read by
+ * different calls over different subjects — one host-wide record with no
+ * arguments, and one read per application. The name settles what is left: a
+ * single tool over both would have to be named for the engine or for the apps,
+ * and either name promises what only the other half delivers.
+ *
+ * What they do owe each other is a POINTER, and both descriptions carry one.
+ * Twelve applications reporting as stopped because the engine is down is the
+ * misreading this family is most likely to produce, and it is only avoidable if
+ * a caller reading one tool knows the other exists.
+ *
+ * Nothing here mutates. Upgrading, starting and stopping an app all exist on
+ * the middleware and none of them is in this catalog.
+ */
 
 /** Applications installed on a system: what is deployed, what is running, and
  * what has an update waiting.
@@ -50,5 +81,356 @@ export const appsList: ReadOnlyTool = {
       upgrade_available: app.upgrade_available,
       image_updates_available: app.image_updates_available,
     }));
+  },
+};
+
+/**
+ * The app engine's status words, as the pinned client declares them, derived
+ * from the call rather than imported by name — the route `CLAUDE.md` records
+ * for a generated type, since the `$N` suffix a colliding interface carries in
+ * one release is not the one it carries in the next.
+ */
+type EngineStatus = CallResponse<ApiSurface, 'docker.status'>['status'];
+
+/**
+ * Which of the engine's status words mean applications can run, one entry per
+ * declared member.
+ *
+ * Typed as a total `Record` over the union ON PURPOSE. A TrueNAS release that
+ * adds a status word breaks this build, which is the point: the alternative — a
+ * list of the words that mean "not running" — would silently answer `false` for
+ * a word nobody here has read, and `false` on this field is the positive claim
+ * that nothing on the system can run.
+ */
+const ENGINE_RUNNING: Record<EngineStatus, boolean> = {
+  PENDING: false,
+  RUNNING: true,
+  STOPPED: false,
+  INITIALIZING: false,
+  STOPPING: false,
+  UNCONFIGURED: false,
+  FAILED: false,
+};
+
+/** What a system answering `docker.status` with something else is reported as. */
+const NOT_A_STATUS = 'the system did not answer with an app engine status';
+
+/** What a system answering `app.query` with something else is reported as. */
+const NOT_A_LIST = 'the system did not answer with a list of applications';
+
+/** What an application the system named nothing is reported as. */
+const NO_APP_NAME =
+  'the system reported no name for this application, so no update summary was read';
+
+/** What an application whose `upgrade_available` could not be read is reported as. */
+const UPDATE_UNKNOWN =
+  'the system did not report whether an update is waiting for this application, so no ' +
+  'update summary was read';
+
+/** What a system answering `app.upgrade_summary` with something else is reported as. */
+const NOT_A_SUMMARY = 'the system did not answer with an upgrade summary';
+
+/** The app engine as this tool reports it. */
+interface Engine {
+  running: boolean | null;
+  status: string | null;
+  description: string | null;
+}
+
+/**
+ * The engine's fields on a read that did not happen.
+ *
+ * Spelled out rather than left off, for the reason `boot.ts` gives: `undefined`
+ * serializes to no key at all, so a caller would receive an object missing
+ * fields the description promises rather than nulls it can see are absent.
+ */
+const UNREAD_ENGINE: Engine = { running: null, status: null, description: null };
+
+/**
+ * Whether a status word means applications can run — and null where it means
+ * nothing this catalog has read.
+ *
+ * A word that is not a declared member is UNKNOWN rather than not-running. That
+ * is the direction rule `CLAUDE.md` records for an unreadable list entry,
+ * applied to a boolean: `false` here says the app engine is down, which is more
+ * than "the system used a word added after this was written" established.
+ *
+ * The membership test is `Object.hasOwn` and not `status in ENGINE_RUNNING`,
+ * because `in` walks the prototype: `'toString'` and `'constructor'` are `in`
+ * every object literal, and either would have been answered `undefined` — read
+ * back as a boolean the field's type says cannot be one.
+ */
+function engineRunning(status: string | null): boolean | null {
+  if (status === null) return null;
+  if (!Object.hasOwn(ENGINE_RUNNING, status)) return null;
+  return ENGINE_RUNNING[status as EngineStatus];
+}
+
+export const appEngineStatus: ReadOnlyTool = {
+  name: 'app_engine_status',
+  description:
+    'Whether the CONTAINER ENGINE that TrueNAS applications run on is up. This ' +
+    'is the one call that tells "these applications are stopped" apart from ' +
+    '"nothing on this system can run": when the engine is down every ' +
+    'application reports as not running, and `apps_list` alone presents that as ' +
+    'a list of independently broken applications. READ THIS BEFORE CONCLUDING ' +
+    'ANYTHING FROM SEVERAL STOPPED APPLICATIONS. `running` is the answer: TRUE ' +
+    'where the system reported a status meaning applications can run, FALSE ' +
+    'WHERE IT REPORTED ONE MEANING THEY CANNOT — which is a positive finding, ' +
+    'the engine is down — and NULL WHERE NOTHING WAS ESTABLISHED, either ' +
+    'because the read failed or because the system used a status word this ' +
+    'catalog does not know. A NULL `running` IS NEVER TO BE READ AS THE FALSE ' +
+    'ONE. `status` is the system\'s own word, passed through as it spelled it: ' +
+    'RUNNING means the engine is up, STOPPED and FAILED mean it is not, ' +
+    'PENDING, INITIALIZING and STOPPING are transient, and UNCONFIGURED means ' +
+    'the applications feature has never been set up on this system — commonly ' +
+    'because no pool has been chosen to hold it, which is a configuration ' +
+    'answer rather than a fault. THE SET IS NOT CLOSED and any other value is ' +
+    'to be read as itself. `description` is the prose the system offered about ' +
+    'that status, written for a person, and is null where it offered none. ' +
+    '`unavailable` is null where the engine was read, and otherwise what the ' +
+    'system said about the failure — AND THEN EVERY OTHER FIELD IS NULL ' +
+    'BECAUSE NOTHING WAS READ, not because the system reported nothing. A ' +
+    'system with no applications support at all answers here rather than ' +
+    'failing. This tool reports the ENGINE and NOT the applications on it: ' +
+    '`apps_list` is what is installed and what state each one is in, and ' +
+    '`apps_update_summary` is what a waiting update would change. It does not ' +
+    "report the engine's settings — its address pools, its dataset or its " +
+    'network configuration are in no tool in this catalog — it does not report ' +
+    'how many containers are running, and it starts, stops and configures ' +
+    'nothing.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    try {
+      const answer = await firstValueFrom(system.client.api.call('docker.status'));
+      // Read through `recordOrNull` rather than reached into, as `boot.ts`
+      // does: a system answering this call with something that is not a status
+      // would otherwise throw naming a property, and the caller would see the
+      // name of a field rather than the read that failed.
+      const held = recordOrNull(answer);
+      if (held === null) return { unavailable: NOT_A_STATUS, ...UNREAD_ENGINE };
+      const status = textOrNull(held['status']);
+      return {
+        unavailable: null,
+        running: engineRunning(status),
+        status,
+        description: textOrNull(held['description']),
+      };
+    } catch (reason) {
+      // An engine that is not installed rejects here rather than answering, and
+      // that is an answer about the system rather than a fault of the tool.
+      return { unavailable: errorText(reason), ...UNREAD_ENGINE };
+    }
+  },
+};
+
+/** An application as `app.query` reports it. */
+type AppEntry = ApiSurface['call']['app.query']['entity'];
+
+/**
+ * One application's waiting update, or the stated reason none was read.
+ *
+ * `installed_*` come from the listing and are filled in even where the summary
+ * could not be read: they are what the system already told us, and dropping
+ * them with the summary would lose a fact that did not fail.
+ */
+interface UpdateEntry {
+  app: string | null;
+  unavailable: string | null;
+  installed_version: string | null;
+  installed_human_version: string | null;
+  upgrade_version: string | null;
+  upgrade_human_version: string | null;
+  latest_version: string | null;
+  latest_human_version: string | null;
+}
+
+/** What the listing said about one application, whatever the summary adds. */
+interface Listed {
+  app: string | null;
+  installed_version: string | null;
+  installed_human_version: string | null;
+}
+
+/**
+ * One listed application, and either the name to ask by or the reason no call
+ * will be made.
+ *
+ * A UNION rather than two nullable fields, so that "there is a reason not to
+ * ask" and "there is no name to ask by" cannot disagree. Written as one shape
+ * it needed a fallback name on a branch nothing can reach — a guard no test can
+ * observe, which is a review finding this repository has already paid for once.
+ *
+ * `skip` holds a fact about the APPLICATION rather than about a read that
+ * failed, which is the distinction `reporting_app_vm_usage` keeps when it
+ * declines to ask a stopped VM for its memory.
+ */
+type Candidate =
+  | { listed: Listed; name: string; skip: null }
+  | { listed: Listed; name: null; skip: string };
+
+/**
+ * The applications whose update is worth asking about, and the reason for each
+ * one that is listed but will not be asked.
+ *
+ * An application the system reported as having NO update waiting is left out
+ * entirely — that is this tool's subject, and its absence is a claim the read
+ * established. One whose `upgrade_available` could not be read is KEPT, because
+ * dropping it would make the same claim without having established it: the
+ * direction rule `CLAUDE.md` records, where a shorter list must not say more
+ * than the read did.
+ *
+ * `app.upgrade_summary` is not called for such an application either. Whether
+ * it rejects for one with no update waiting is unconfirmed against a live
+ * system, and asking would turn "we do not know" into either a false answer or
+ * an error reported as a failed read.
+ */
+function candidateOf(entry: AppEntry): Candidate | null {
+  const waiting = booleanOrNull(entry.upgrade_available);
+  if (waiting === false) return null;
+  const name = textOrNull(entry.name);
+  const listed: Listed = {
+    app: name,
+    installed_version: textOrNull(entry.version),
+    // The upstream software's own version, which `apps_list` deliberately does
+    // not surface: there it would sit beside a catalog `version` it is not
+    // comparable with, and the two read as disagreeing. Here it has something
+    // to be compared WITH — the human version the upgrade moves to — and that
+    // pair is the only part of this result that says what the application
+    // itself changes rather than what its packaging does.
+    installed_human_version: textOrNull(entry.human_version),
+  };
+  if (waiting === null) return { listed, name: null, skip: UPDATE_UNKNOWN };
+  if (name === null) return { listed, name: null, skip: NO_APP_NAME };
+  return { listed, name, skip: null };
+}
+
+/**
+ * An entry for an application that was listed and not read, or not asked about.
+ *
+ * The fields are named in the same order the read path names them rather than
+ * spread, so every entry in `entries` carries its keys in one order whichever
+ * branch produced it.
+ */
+function unread(listed: Listed, reason: string): UpdateEntry {
+  return {
+    app: listed.app,
+    unavailable: reason,
+    installed_version: listed.installed_version,
+    installed_human_version: listed.installed_human_version,
+    upgrade_version: null,
+    upgrade_human_version: null,
+    latest_version: null,
+    latest_human_version: null,
+  };
+}
+
+/**
+ * One application's upgrade summary, with a failure named rather than thrown.
+ *
+ * NO SUMMARY MAY FAIL THE TOOL. Each is a separate call and one application's
+ * catalog being unreachable must not take the rest of the report down with it —
+ * the same seam `reporting_app_vm_usage` uses for its per-VM memory reads.
+ */
+async function readSummary(system: SystemHandle, candidate: Candidate): Promise<UpdateEntry> {
+  // `skip` is the discriminant: non-null on exactly the shape whose `name` is
+  // null, so the call below has a name to ask by without a fallback.
+  if (candidate.skip !== null) return unread(candidate.listed, candidate.skip);
+  const { listed } = candidate;
+  try {
+    const answer = await firstValueFrom(
+      system.client.api.call('app.upgrade_summary', [candidate.name]),
+    );
+    const held = recordOrNull(answer);
+    if (held === null) return unread(listed, NOT_A_SUMMARY);
+    return {
+      app: listed.app,
+      unavailable: null,
+      installed_version: listed.installed_version,
+      installed_human_version: listed.installed_human_version,
+      upgrade_version: textOrNull(held['upgrade_version']),
+      upgrade_human_version: textOrNull(held['upgrade_human_version']),
+      latest_version: textOrNull(held['latest_version']),
+      latest_human_version: textOrNull(held['latest_human_version']),
+    };
+  } catch (reason) {
+    return unread(listed, errorText(reason));
+  }
+}
+
+export const appsUpdateSummary: ReadOnlyTool = {
+  name: 'apps_update_summary',
+  description:
+    'For each installed application with a CATALOG UPDATE WAITING, what version ' +
+    'it would move to. `apps_list` reports THAT an update exists; this reports ' +
+    'WHAT IT IS, which is what an operator needs to decide whether to take it. ' +
+    '`entries` is one entry per such application, in the order the system ' +
+    'listed them, and is NULL WHENEVER `unavailable` IS NON-NULL. An EMPTY ' +
+    '`entries` is a different answer — the applications were listed and none ' +
+    'has an update waiting — and null is never to be read as that. ' +
+    '`unavailable` at the top level is why the application listing could not be ' +
+    'read; each ENTRY carries its own `unavailable` for why that one ' +
+    "application's summary could not be, and one failing there never empties or " +
+    'falsifies another. AN APPLICATION IS ABSENT FROM `entries` ONLY WHERE THE ' +
+    'SYSTEM REPORTED THAT NO CATALOG UPDATE IS WAITING FOR IT. One whose update ' +
+    'state could not be read is PRESENT with `unavailable` saying so, so a ' +
+    'short list never quietly means "everything else is up to date". ' +
+    '`app` is the application name, null where the system reported none — and ' +
+    'an application with no name cannot be looked up, which is what that ' +
+    "entry's `unavailable` says. `installed_version` and " +
+    '`installed_human_version` come from the LISTING rather than the summary, ' +
+    'so they are reported even for an entry whose summary failed. ' +
+    '`upgrade_version` is the catalog version this upgrade would move to and ' +
+    '`latest_version` is the newest the system knows of; THEY ARE NOT ALWAYS ' +
+    'THE SAME, and where they differ the upgrade stops short of the newest. ' +
+    'The `*_human_version` pair is the version of the SOFTWARE INSIDE the ' +
+    'application rather than of its TrueNAS packaging, and the two vocabularies ' +
+    'are not comparable: compare a human version only with another human ' +
+    'version, and a plain version only with another plain version. Every field ' +
+    'is null where the system reported no value this tool could read, and every ' +
+    'field but the two installed ones is null on an entry whose ' +
+    '`unavailable` is non-null. ' +
+    'THE RELEASE NOTES ARE NOT REPORTED. The middleware offers a changelog and ' +
+    'it is deliberately dropped: it is unbounded upstream prose returned once ' +
+    'per application, and a cap on it could drop the very line naming a ' +
+    'breaking change while still presenting itself as the answer to what the ' +
+    'update alters. Neither is the list of OTHER versions available to upgrade ' +
+    'to; every entry here is fixed in size, so this response grows only with ' +
+    'the number of applications that have an update. NO OTHER KIND OF UPDATE IS ' +
+    "COVERED: `apps_list`'s `image_updates_available` — whether the containers " +
+    'an application already runs have newer images — is a separate question ' +
+    'this tool says nothing about, and a custom application, which has no ' +
+    'catalog version at all, never appears here even when its images are out of ' +
+    'date. If several applications also report as not running, read ' +
+    '`app_engine_status` before concluding anything about them. This tool ' +
+    'upgrades nothing and changes nothing.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    let candidates: Candidate[];
+    try {
+      const rows = await firstValueFrom(system.client.api.query('app.query'));
+      if (!Array.isArray(rows)) return { unavailable: NOT_A_LIST, entries: null };
+      // Chosen inside the `try` with the read that produced them: a row the
+      // system sent in a shape this cannot walk at all is the LISTING being
+      // unreadable, which is an answer, rather than an exception out of a tool
+      // that promises never to throw.
+      candidates = rows.flatMap((row) => {
+        const candidate = candidateOf(row);
+        return candidate === null ? [] : [candidate];
+      });
+    } catch (reason) {
+      return { unavailable: errorText(reason), entries: null };
+    }
+    // One read per application with an update waiting, all issued together.
+    // Only those are asked at all, which is what keeps this bounded by the
+    // applications that have an update rather than by every one installed.
+    const entries = await Promise.all(
+      candidates.map((candidate) => readSummary(system, candidate)),
+    );
+    return { unavailable: null, entries };
   },
 };

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty-six sketch tools', () => {
+  it('registers the forty-eight sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -19,6 +19,8 @@ describe('createDefaultCatalog', () => {
       'datasets_quota_report',
       'disks_list',
       'apps_list',
+      'app_engine_status',
+      'apps_update_summary',
       'vms_list',
       'vm_logs',
       'vm_devices',
@@ -156,6 +158,18 @@ describe('createDefaultCatalog', () => {
 
   it('advertises apps_list to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('apps_list');
+  });
+
+  it('advertises app_engine_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'app_engine_status',
+    );
+  });
+
+  it('advertises apps_update_summary to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'apps_update_summary',
+    );
   });
 
   it('advertises storage_pool_topology to a read-only credential', () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { ToolCatalog } from '@/catalog/catalog';
 import { directoryServicesStatus, usersList } from '@/tools/accounts';
 import { alertSettings, alertsList } from '@/tools/alerts';
-import { appsList } from '@/tools/apps';
+import { appEngineStatus, appsList, appsUpdateSummary } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
 import { bootPoolStatus } from '@/tools/boot';
 import { certificatesList } from '@/tools/certificates';
@@ -33,7 +33,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-five read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty-seven read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -50,6 +50,8 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(quotaReport);
   catalog.register(disksList);
   catalog.register(appsList);
+  catalog.register(appEngineStatus);
+  catalog.register(appsUpdateSummary);
   catalog.register(vmsList);
   catalog.register(vmLogs);
   catalog.register(vmDevices);
@@ -88,7 +90,9 @@ export function createDefaultCatalog(): ToolCatalog {
 export {
   alertSettings,
   alertsList,
+  appEngineStatus,
   appsList,
+  appsUpdateSummary,
   auditConfig,
   auditLogQuery,
   automatedTasksList,


### PR DESCRIPTION
Fixes #101.

`apps_list` reports each app's state and that an update is waiting. Two questions it cannot answer are the ones asked next, and this adds a tool for each.

- **`app_engine_status`** reads `docker.status`. It is what tells "these apps are stopped" apart from "nothing on this system can run" — when the container engine is down every app reports as not running, and `apps_list` alone presents that as a list of independently broken apps.
- **`apps_update_summary`** reads `app.query`, then `app.upgrade_summary` once per app that has an update waiting, all issued together. It reports what version each update would move to.

## Two tools rather than one with two sections

The ticket left this open and asked for it to be decided explicitly. They share a ticket, a file and a motivation, which is the case for folding them together; the case against is `CLAUDE.md`'s own section test from #97. Sections belong in one tool when the subject is *completeness across kinds* — when a caller reaching only some of them gets a confident answer with a category silently missing. Neither of these completes the other that way: a caller reading only the engine status is not misled about updates, and a caller reading only the updates is not misled about the engine. The name settles the remainder — one tool over both would have to be named for the engine or for the apps, and either name promises what only the other half delivers.

What they do owe each other is a pointer, and both descriptions carry one. Recorded as a decision in `CLAUDE.md`, along with the two design calls below.

## Design calls worth reading before the diff

**An unmapped engine status word answers `running: null`, never `false`.** `false` there is the positive claim that nothing on the system can run. `ENGINE_RUNNING` is a total `Record` over the status union so an unmapped member cannot pass silently — but that check is against `ApiSurface`, which is `DefaultApiDirectory`, the *oldest* supported directory. `docker.status` declares seven status words there and nine on a later one, so a system on that release can send `MIGRATING` today with nothing failing to compile. The exhaustiveness checks this file; the null is what keeps the answer honest about the surfaces it does not compile against. (Round 2 of review caught the comment claiming otherwise — the behaviour was right and the stated reason was wrong.)

**No changelog, and that is a size decision made against #44's rule rather than despite it.** `app.upgrade_summary` carries release notes. They are unbounded upstream prose returned once per app, and the cap that would bound them could drop the line naming a breaking change while the field still presented itself as the answer to what the update alters — a cap dropping the finding, not the line describing it. The list of other versions available to upgrade to is dropped for the same reason at lower stakes. What that buys is an entry fixed in size, so the response grows only with the number of apps that have an update. Both omissions are named in the tool's description.

**An app whose update state could not be read is kept, not dropped.** Absence from `entries` means the system reported no update waiting, which is a claim; #93's direction rule says a list that gets shorter must not say more than the read established. Such an app is present with `unavailable` saying so, and `app.upgrade_summary` is not called for it — whether it rejects for an app with no update waiting is unconfirmed against a live system, and asking would turn "we do not know" into either a false answer or an error reported as a failed read.

## Acceptance criteria

- [x] Engine status reported, `Role.ReadOnly`.
- [x] For an app with an update available, what version it would move to.
- [x] The summary is not read for apps with no update waiting (asserted on the call spy).
- [x] Per-app reads issued together — asserted through a gate that releases nothing until all three calls have been made, so a sequential implementation fails the test rather than passing it incidentally.
- [x] An app whose summary cannot be read is reported as unread and does not prevent the others or the engine answering.
- [x] The app engine not installed yields a clean answer rather than throwing.
- [x] `createDefaultCatalog` exact-list test updated in registration order, count wording forty-six → forty-eight.
- [x] `README.md` names both tools.
- [x] `yarn test:coverage` meets the floors; `apps.ts` is at 100% statements *and* branches.

`yarn lint`, `yarn typecheck`, `yarn test` (1017 passing) and `yarn build` all run clean locally. The coverage floors in `vitest.config.ts` are unchanged: global branch moved 99.33 → 99.38 against a floor of 96, and no tool PR since #79 has raised them.

## Review

Run locally with `local-review.py`, which ran the same shared reviewer this PR's required check runs. Round 1 returned one MEDIUM and two LOWs; round 2 returned five LOWs and nothing at or above MEDIUM.

The MEDIUM was the repository's most common finding: the description said every field but the two installed ones is null on an entry whose `unavailable` is non-null, and `app` also survives, because it too comes from the listing rather than the summary. Fixed by naming the three listing-sourced fields together and saying what a null among them means.

### What I did not change, and why

Round 2's five LOWs. One of them — the `ENGINE_RUNNING` rationale above — is fixed, because a comment giving a false reason invites a later reader to treat the unmapped branch as unreachable, and the same claim had been generalised into a `CLAUDE.md` rule. The other four are left, and each is a fair reading:

- **`UNCONFIGURED` maps to `running: false` while the description calls it a configuration answer rather than a fault.** Both are true and I think they belong apart: `running` answers "can anything run", and on an unconfigured system nothing can. The description carries the nuance in the sentence about `status`, which is where a reader deciding what to do about it will be looking.
- **A null `app` is not always explained by that entry's `unavailable`.** An app with an unreadable `upgrade_available` *and* no name reports `UPDATE_UNKNOWN`, which says nothing about the name. Correct — the two reasons are checked in that order, and only the first is reported. Worth a follow-up if the pair ever shows up together in practice.
- **A null row in the listing surfaces a raw `TypeError` as the top-level `unavailable`.** It names an internal field, which is the shape `app_engine_status` avoids by reading through `recordOrNull`. The listing does not throw and the tool still answers; the text is uglier than it should be.
- **`app.query` is issued without `select`,** so every app's chart metadata, portals, `active_workloads` and secret-bearing `config` cross the wire to read four fields. This is real, and it is not this tool's alone: `apps_list` and `reporting_app_vm_usage` both issue the same unselected query. The allowlist keeps all of it out of the tool result either way, so nothing leaks — the cost is bandwidth. Narrowing it is a change to the family rather than to this diff, and worth its own ticket.

<!-- harness:proposed-ticket -->

### Proposed ticket: narrow the app family's `app.query` to the fields it reads

**Description.** `apps_list`, `reporting_app_vm_usage` and `apps_update_summary` all issue `app.query` with no `select`, so each reads back every app's full chart metadata, rendered portals, `active_workloads` (every container, port and volume) and install-time `config` in order to use four to six named fields. The allowlist mapping keeps all of it out of the tool result, so this is a bandwidth and latency cost rather than a disclosure one — but `apps.ts`'s own doc comment already calls this the most expensive response in the catalog if passed through, and the query is where that expense actually starts.

**Acceptance criteria.**
- [ ] Every `app.query` call in `src/tools/` names the fields its mapping reads.
- [ ] A field named in a `select` and absent from the response still reads as null rather than throwing, and a test covers it.
- [ ] The tool results are unchanged, asserted by the existing specs passing unmodified.
- [ ] Whether `select` is honoured on the pinned surface is confirmed against the client's types before relying on it — an unrecognised query parameter is dropped rather than refused, which would silently return everything and look identical to success.
