### PR TITLE
feat(tools): add system_general_config, the timezone the catalog's times sit in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,8 +221,8 @@ field, so a release that does not add it still answers.
 
 Every tool file reads middleware payloads whose declared shape it does not take
 as given, so each needed the same narrowings — `textOrNull`, `numberOrNull`,
-`booleanOrNull`, `recordOrNull`, `textList` — and the same reading of a
-rejection, `errorText`. The pinned client left many of those payloads as
+`booleanOrNull`, `recordOrNull`, `textList`, `strictTextList` — and the same
+reading of a rejection, `errorText`. The pinned client left many of those payloads as
 `unknown` outright; 4.x declares nearly all of them, which changed what the
 compiler knows and not what a system sends (#91).
 Each file grew a private copy, on the stated ground that a tool file is read on
@@ -249,6 +249,16 @@ Where the line falls, since "shared" is not the same as "generic":
 - **`common.ts` is internal.** It is not a family, `createDefaultCatalog()` does
   not know about it, and it must not reach `src/index.ts` — an export there is
   a contract, and none of this is one.
+
+**The two list guards are a pair, and picking between them is the #93 decision
+rather than taste.** `textList` DROPS an entry it cannot read; `strictTextList`
+nulls the WHOLE list instead. Reach for the second wherever a shorter list would
+make a claim — a password ruleset one class shorter says the policy requires
+less, an audit scope one name shorter says a share is unaudited, a TLS protocol
+list one entry shorter hides the old version the field is read for — and for the
+first only where a shorter list understates a fact the tool itself asserts.
+`strictTextList` was promoted in #102, after `audit_config` and `security_config`
+had each grown their own identical copy of it and a third tool was about to.
 
 Reaching for a private copy of something already in `common.ts` is the thing to
 notice in review. The comment that used to justify each copy — *a tool file is
@@ -294,7 +304,8 @@ excluded there.
 
 ### An unreadable list entry is nulled or kept by which way it moves the summary (#93)
 
-`audit_config`'s `scopeNames` nulls its WHOLE list when one entry cannot be read;
+`audit_config`'s scope nulls its WHOLE list when one entry cannot be read — it
+reads through `strictTextList`, which is what that guard is for;
 `system_reboot_info`'s `rebootReasons` KEEPS such an entry, as a pair of nulls.
 Both are the null/empty/unreadable convention below, and they disagree because
 the convention alone does not decide this — what decides it is the direction the
@@ -607,6 +618,32 @@ method's union differing from an event's.
 The membership test is `Object.hasOwn` and not `in`, which walks the prototype:
 `'constructor'` is `in` every object literal and would have been read back as a
 boolean the field cannot hold.
+
+### A declared field whose meaning the surface does not state is left out (#102)
+
+`system_general_config` reads a payload the client declares in full — seventeen
+named fields, every one of them typed — and reports fourteen. `wizardshown` and
+`ds_auth` are booleans the pinned surface declares and documents nowhere, and
+they are omitted rather than passed through under a name this repository made up
+for them. **A declared type says what arrives, never what it means**, and the two
+are separate questions: #91 settled the first, and a field that survives it can
+still fail this one. Reporting a guessed meaning is worse than omitting the
+field, because a caller cannot tell a reading from a guess — the same argument
+`nfs_clients` makes about unconfirmed KEY NAMES (#98), one level up, about a
+confirmed key whose SEMANTICS are unconfirmed.
+
+The corollary is the cheap one to get wrong: **an omission a caller might notice
+is named in the description**, as `boot_pool_status` names the boot pool's scan
+record. This tool says outright that it does not report the setup wizard state or
+the directory-service authentication flag, so a later reader can tell a
+deliberate omission from a field nobody saw.
+
+`ui_certificate` is omitted differently and for the other reason: it is an open
+record, so it is REDUCED — to `ui_certificate_configured`, the one fact reading
+it establishes — rather than forwarded, and `certificates_list` is where the
+detail lives. Note that `recordOrNull` alone cannot do that reduction: it answers
+null both for the explicit null that means "no certificate" and for a payload
+that could not be read, and those are different answers.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,6 +645,19 @@ detail lives. Note that `recordOrNull` alone cannot do that reduction: it answer
 null both for the explicit null that means "no certificate" and for a payload
 that could not be read, and those are different answers.
 
+**Reducing a field to a fact is also what lets it survive the shape changing,
+and that is worth reaching for deliberately.** `ui_certificate` is an embedded
+record on `DefaultApiDirectory` and a certificate ID — a bare `number` — on a
+later directory in the same client. `certificateConfigured` reads BOTH as
+"configured", because at the resolution this tool reports the two payloads say
+the same thing; a guard written to the pinned shape alone would have answered
+"could not be read" for every system on the newer release, which is the reading
+that means the opposite of the truth. #91 says a declared type is a claim about
+what arrives rather than the value received — the version skew behind it is
+readable in the client, and **where two directories declare one field
+differently, a reduction that both shapes satisfy is worth more than a guard
+that matches the pinned one exactly.**
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,10 +622,13 @@ boolean the field cannot hold.
 ### A declared field whose meaning the surface does not state is left out (#102)
 
 `system_general_config` reads a payload the client declares in full — seventeen
-named fields, every one of them typed — and reports fourteen. `wizardshown` and
-`ds_auth` are booleans the pinned surface declares and documents nowhere, and
-they are omitted rather than passed through under a name this repository made up
-for them. **A declared type says what arrives, never what it means**, and the two
+named fields, every one of them typed — and reports fourteen. `ds_auth` is the
+one this rule is about: a boolean the pinned surface declares and documents
+nowhere, omitted rather than passed through under a name this repository made up
+for it. (`wizardshown` is dropped for the simpler reason beside it — it is the
+setup wizard's own bookkeeping and answers no question anyone would ask a NAS.
+Two omissions, two different reasons, and only the first is a decision.)
+**A declared type says what arrives, never what it means**, and the two
 are separate questions: #91 settled the first, and a field that survives it can
 still fail this one. Reporting a guessed meaning is worse than omitting the
 field, because a caller cannot tell a reading from a guess — the same argument

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Tool catalog** — curated tools with role metadata; irreversibly destructive
   operations are rejected at registration by policy. Read-only family:
   `system_info`, `system_update_status`, `system_reboot_info`,
-  `audit_log_query`, `audit_config`, `security_config`,
+  `audit_log_query`, `audit_config`, `security_config`, `system_general_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`, `apps_list`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   auditLogQuery,
   auditConfig,
   securityConfig,
+  systemGeneralConfig,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -84,6 +84,34 @@ export function textList(value: unknown): string[] | null {
   });
 }
 
+/**
+ * The names of a list field, all of them or none — null where the field was not
+ * a list at all, AND null where any one entry could not be read as a name.
+ *
+ * The all-or-nothing counterpart to {@link textList}, and which of the two a
+ * caller wants is decided by the direction a shorter list moves the answer, not
+ * by taste. `textList` drops what it cannot read, so the list it returns is
+ * shorter than the one the system sent and nothing says so; that is right where
+ * a shorter list understates a fact the tool asserts, and wrong where a shorter
+ * list makes a CLAIM — a ruleset one class shorter says the policy requires
+ * less, an audit scope one name shorter says a share is not audited, an
+ * allowlist one entry shorter says an address may not reach the system. Nulling
+ * the whole list refuses the claim instead of quietly making it.
+ *
+ * An EMPTY list is not the same answer and is returned as itself: the system
+ * reported the list and it names nothing.
+ */
+export function strictTextList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const names: string[] = [];
+  for (const entry of value) {
+    const name = textOrNull(entry);
+    if (name === null) return null;
+    names.push(name);
+  }
+  return names;
+}
+
 /** What a failure carrying no text of its own is reported as. */
 export const NO_REASON = 'the system reported no reason';
 

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty-eight sketch tools', () => {
+  it('registers the forty-nine sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -11,6 +11,7 @@ describe('createDefaultCatalog', () => {
       'audit_log_query',
       'audit_config',
       'security_config',
+      'system_general_config',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -290,5 +291,11 @@ describe('createDefaultCatalog', () => {
 
   it('advertises nfs_clients to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('nfs_clients');
+  });
+
+  it('advertises system_general_config to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'system_general_config',
+    );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,7 +24,14 @@ import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
 import { createSnapshot, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport } from '@/tools/storage';
-import { auditConfig, auditLogQuery, rebootInfo, systemInfo, updateStatus } from '@/tools/system';
+import {
+  auditConfig,
+  auditLogQuery,
+  rebootInfo,
+  systemGeneralConfig,
+  systemInfo,
+  updateStatus,
+} from '@/tools/system';
 import {
   automatedTasksList,
   cloudsyncTasksList,
@@ -33,7 +40,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-seven read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty-eight read-only tools plus one mutating tool. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -42,6 +49,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(auditLogQuery);
   catalog.register(auditConfig);
   catalog.register(securityConfig);
+  catalog.register(systemGeneralConfig);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -128,6 +136,7 @@ export {
   sharesList,
   snapshotsList,
   snapshotTasksList,
+  systemGeneralConfig,
   systemHealthReport,
   systemInfo,
   tasksRecentRuns,

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -1,7 +1,13 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
-import { booleanOrNull, errorText, numberOrNull, recordOrNull, textOrNull } from '@/tools/common';
+import {
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  strictTextList,
+} from '@/tools/common';
 
 /**
  * The security posture SETTINGS of a system: FIPS and STIG mode, the password
@@ -69,29 +75,6 @@ interface TwoFactorSettings {
 interface Attempt<T> {
   value: T | null;
   error: string | null;
-}
-
-/**
- * The character classes the password policy requires, as names — or null where
- * the system listed something this tool cannot read as one.
- *
- * All-or-nothing rather than per-entry, which is why `textList` from
- * `common.ts` is not the guard here: that one drops an entry it cannot read,
- * and a ruleset one class shorter says the policy requires LESS than it does.
- * That is the #93 decision applied — a list that drops towards a claim must be
- * nulled, and "this system does not require special characters" is a claim a
- * dropped entry would make on no evidence. An EMPTY list is kept and is a
- * different answer: the system reported the ruleset and it names no classes.
- */
-function complexityRuleset(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  const classes: string[] = [];
-  for (const entry of value) {
-    const name = textOrNull(entry);
-    if (name === null) return null;
-    classes.push(name);
-  }
-  return classes;
 }
 
 /**
@@ -173,7 +156,13 @@ async function readSecurity(system: SystemHandle): Promise<Attempt<SecuritySetti
         max_password_age: numberOrNull(settings['max_password_age']),
         min_password_length: numberOrNull(settings['min_password_length']),
         password_history_length: numberOrNull(settings['password_history_length']),
-        password_complexity_ruleset: complexityRuleset(settings['password_complexity_ruleset']),
+        // `strictTextList` rather than `textList`, which drops what it cannot
+        // read: a ruleset one class shorter says the policy requires LESS than
+        // it does, and "this system does not require special characters" is a
+        // claim a dropped entry would make on no evidence. That is the #93
+        // direction rule. An EMPTY list is kept and is a different answer — the
+        // system reported the ruleset and it names no classes.
+        password_complexity_ruleset: strictTextList(settings['password_complexity_ruleset']),
       },
       error: null,
     };

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -937,30 +937,25 @@ describe('system_general_config', () => {
     });
   });
 
-  it('says in its description which way the timezone applies to each kind of time', async () => {
-    // The two are opposite operations, and telling a caller "the catalog
-    // reports local times" would make it convert the UTC ones a second time.
+  it('tells the three kinds of time apart by the value, not by the tool', async () => {
+    // A list of tool names is incomplete the day a tool is added and is
+    // silently wrong rather than loudly so; the shape of the value a caller is
+    // holding is not.
     expect(systemGeneralConfig.description).toContain(
-      'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE',
+      'DECIDE FROM THE VALUE YOU ARE HOLDING, NEVER FROM WHICH TOOL RETURNED IT',
+    );
+    // Already local, and converting it would move it by the offset.
+    expect(systemGeneralConfig.description).toContain(
+      'A RENDERED SCHEDULE — the English in a `schedule_description`',
     );
     expect(systemGeneralConfig.description).toContain('do NOT convert it');
-    expect(systemGeneralConfig.description).toContain('A REPORTED INSTANT IS NOT');
-    expect(systemGeneralConfig.description).toContain('CONVERT those INTO this zone');
-    // The schedule renderers on one side of that line and the instant
-    // reporters on the other, named so a caller can place a tool it is holding.
-    expect(systemGeneralConfig.description).toContain('snapshot_tasks_list');
-    expect(systemGeneralConfig.description).toContain('audit_log_query');
-    // Every caller of `describeSchedule` belongs in the schedule group, which
-    // is three tools rather than the two the cron rendering started with.
-    expect(systemGeneralConfig.description).toContain('automated_tasks_list');
-  });
-
-  it('puts storage_scrub_history in neither group rather than asserting its frame', async () => {
-    // That tool reports its times "as the system reports them" and states no
-    // zone, so telling a caller to convert them would assert a frame it
-    // refuses to — and would shift an offsetless local string a second time.
+    // Absolute, and stating it as a wall-clock hour needs converting.
+    expect(systemGeneralConfig.description).toContain('IS ABSOLUTE');
+    expect(systemGeneralConfig.description).toContain('CONVERT one INTO this zone');
+    // Unstated, which is neither of the above and is the one a caller is most
+    // likely to convert twice.
     expect(systemGeneralConfig.description).toContain(
-      '`storage_scrub_history` IS IN NEITHER GROUP AND MUST NOT BE CONVERTED',
+      'NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN',
     );
   });
 
@@ -968,7 +963,6 @@ describe('system_general_config', () => {
     // `system_info` returns the same setting. What it does not do is say what
     // the zone is the frame for, which is what this tool adds.
     expect(systemGeneralConfig.description).toContain('`system_info` also returns a `timezone`');
-    expect(systemGeneralConfig.description).not.toContain('NO OTHER TOOL');
   });
 
   it('nulls a timezone it could not read rather than falling back to UTC', async () => {
@@ -1005,15 +999,12 @@ describe('system_general_config', () => {
   it('reduces the certificate to whether one is configured, never the record', async () => {
     // An open record forwarded would carry whatever a later release puts in it,
     // and `certificates_list` is the tool for the detail.
-    expect(await field({ ui_certificate: { id: 3, name: 'letsencrypt' } }, 'ui_certificate_configured')).toBe(
-      true,
-    );
-    expect(JSON.stringify(await forConfig({ ui_certificate: { name: 'letsencrypt' } }))).not.toContain(
-      'letsencrypt',
-    );
+    const named = { ui_certificate: { id: 3, name: 'letsencrypt' } };
+    expect(await field(named, 'ui_certificate_configured')).toBe(true);
+    expect(JSON.stringify(await forConfig(named))).not.toContain('letsencrypt');
   });
 
-  it('reads the newer surface\'s certificate id as one being configured', async () => {
+  it("reads the newer surface's certificate id as one being configured", async () => {
     // A later directory in the same client declares `ui_certificate` as the
     // certificate's id rather than an embedded record, so a system on that
     // release sends a number for a web UI that DOES have one. Reading only the
@@ -1035,14 +1026,24 @@ describe('system_general_config', () => {
   it('reports the usage-collection pair together, keeping off apart from never chosen', async () => {
     // Reporting the boolean alone loses exactly the distinction the second
     // field exists to preserve.
-    expect(await forConfig({ usage_collection: false, usage_collection_is_set: false })).toMatchObject(
-      { usage_collection: false, usage_collection_is_set: false },
-    );
-    expect(await forConfig({ usage_collection: false, usage_collection_is_set: true })).toMatchObject(
-      { usage_collection: false, usage_collection_is_set: true },
-    );
+    const pair = async (over: Record<string, unknown>): Promise<unknown> => {
+      const result = await forConfig(over);
+      return [result['usage_collection'], result['usage_collection_is_set']];
+    };
+    // Nobody has answered the question, so the false beside it is a default
+    // rather than a decision.
+    expect(await pair({ usage_collection: false, usage_collection_is_set: false })).toEqual([
+      false,
+      false,
+    ]);
+    // The same false, and this time somebody chose it.
+    expect(await pair({ usage_collection: false, usage_collection_is_set: true })).toEqual([
+      false,
+      true,
+    ]);
     for (const unreadable of [null, undefined, 'true', 1]) {
-      expect(await field({ usage_collection_is_set: unreadable }, 'usage_collection_is_set')).toBeNull();
+      const [, isSet] = (await pair({ usage_collection_is_set: unreadable })) as unknown[];
+      expect(isSet).toBeNull();
     }
   });
 

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -937,7 +937,7 @@ describe('system_general_config', () => {
     });
   });
 
-  it('tells the three kinds of time apart by the value, not by the tool', async () => {
+  it('tells the kinds of time apart by the value, not by the tool', async () => {
     // A list of tool names is incomplete the day a tool is added and is
     // silently wrong rather than loudly so; the shape of the value a caller is
     // holding is not.
@@ -957,6 +957,29 @@ describe('system_general_config', () => {
     expect(systemGeneralConfig.description).toContain(
       'NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN',
     );
+  });
+
+  it('covers the middleware date envelope, which a tool can forward unread', async () => {
+    // `alerts_list` returns `alert.datetime` as it arrived, and that can be the
+    // `{ $date: <epoch ms> }` carrier `common.ts` names — absolute, and needing
+    // the same conversion as a `Z`-suffixed string. Sorting it by "carries no
+    // `Z`" gives the answer backwards, which is why it is its own rule.
+    expect(systemGeneralConfig.description).toContain('AN OBJECT CARRYING A `$date`');
+    expect(systemGeneralConfig.description).toContain('MILLISECONDS SINCE THE EPOCH');
+    expect(systemGeneralConfig.description).toContain('CONVERT it into this zone exactly as (2)');
+    expect(systemGeneralConfig.description).toContain('It is not (3)');
+  });
+
+  it('names tools as examples and ends on a rule for a shape it does not describe', async () => {
+    // The defect a count of forms reproduces one level up from a list of tool
+    // names: both are closed, and the catalog grows. The last rule is what
+    // makes a form nobody has written down yet answerable honestly.
+    expect(systemGeneralConfig.description).toContain('AMONG THEM, named as');
+    expect(systemGeneralConfig.description).toContain('examples and not as the whole set');
+    expect(systemGeneralConfig.description).toContain(
+      'a shape none of the above describes — IS NOT COVERED BY THIS RULE',
+    );
+    expect(systemGeneralConfig.description).not.toContain('the catalog reports times in three');
   });
 
   it('does not claim to be the only tool reporting the timezone', async () => {

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -937,15 +937,20 @@ describe('system_general_config', () => {
     });
   });
 
-  it('says in its description that the timezone is the frame for the catalog', async () => {
-    // The sentence that makes an LLM reach for this before it renders a
-    // schedule or a local timestamp from any other tool.
+  it('says in its description which way the timezone applies to each kind of time', async () => {
+    // The two are opposite operations, and telling a caller "the catalog
+    // reports local times" would make it convert the UTC ones a second time.
     expect(systemGeneralConfig.description).toContain(
-      '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE FRAME EVERY OTHER ' +
-        "TOOL'S LOCAL TIMES AND SCHEDULES SIT IN",
+      'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE',
     );
+    expect(systemGeneralConfig.description).toContain('do NOT convert it');
+    expect(systemGeneralConfig.description).toContain('A REPORTED INSTANT IS NOT');
+    expect(systemGeneralConfig.description).toContain('CONVERT those INTO this zone');
+    // The schedule renderers on one side of that line and the instant
+    // reporters on the other, named so a caller can place a tool it is holding.
     expect(systemGeneralConfig.description).toContain('snapshot_tasks_list');
     expect(systemGeneralConfig.description).toContain('audit_log_query');
+    expect(systemGeneralConfig.description).toContain('storage_scrub_history');
   });
 
   it('nulls a timezone it could not read rather than falling back to UTC', async () => {
@@ -990,11 +995,21 @@ describe('system_general_config', () => {
     );
   });
 
+  it('reads the newer surface\'s certificate id as one being configured', async () => {
+    // A later directory in the same client declares `ui_certificate` as the
+    // certificate's id rather than an embedded record, so a system on that
+    // release sends a number for a web UI that DOES have one. Reading only the
+    // record shape would answer null — "could not be read" — for exactly those
+    // systems.
+    expect(await field({ ui_certificate: 1 }, 'ui_certificate_configured')).toBe(true);
+    expect(await field({ ui_certificate: 0 }, 'ui_certificate_configured')).toBe(true);
+  });
+
   it('keeps "no certificate" and "could not be read" apart', async () => {
     // `recordOrNull` alone would answer null for both, and only one of them is
     // something the system said.
     expect(await field({ ui_certificate: null }, 'ui_certificate_configured')).toBe(false);
-    for (const unreadable of [undefined, 'truenas_default', 7, []]) {
+    for (const unreadable of [undefined, 'truenas_default', [], Number.NaN]) {
       expect(await field({ ui_certificate: unreadable }, 'ui_certificate_configured')).toBeNull();
     }
   });

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -950,7 +950,22 @@ describe('system_general_config', () => {
     // reporters on the other, named so a caller can place a tool it is holding.
     expect(systemGeneralConfig.description).toContain('snapshot_tasks_list');
     expect(systemGeneralConfig.description).toContain('audit_log_query');
-    expect(systemGeneralConfig.description).toContain('storage_scrub_history');
+  });
+
+  it('puts storage_scrub_history in neither group rather than asserting its frame', async () => {
+    // That tool reports its times "as the system reports them" and states no
+    // zone, so telling a caller to convert them would assert a frame it
+    // refuses to — and would shift an offsetless local string a second time.
+    expect(systemGeneralConfig.description).toContain(
+      '`storage_scrub_history` IS IN NEITHER GROUP AND MUST NOT BE CONVERTED',
+    );
+  });
+
+  it('does not claim to be the only tool reporting the timezone', async () => {
+    // `system_info` returns the same setting. What it does not do is say what
+    // the zone is the frame for, which is what this tool adds.
+    expect(systemGeneralConfig.description).toContain('`system_info` also returns a `timezone`');
+    expect(systemGeneralConfig.description).not.toContain('NO OTHER TOOL');
   });
 
   it('nulls a timezone it could not read rather than falling back to UTC', async () => {

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -950,6 +950,9 @@ describe('system_general_config', () => {
     // reporters on the other, named so a caller can place a tool it is holding.
     expect(systemGeneralConfig.description).toContain('snapshot_tasks_list');
     expect(systemGeneralConfig.description).toContain('audit_log_query');
+    // Every caller of `describeSchedule` belongs in the schedule group, which
+    // is three tools rather than the two the cron rendering started with.
+    expect(systemGeneralConfig.description).toContain('automated_tasks_list');
   });
 
   it('puts storage_scrub_history in neither group rather than asserting its frame', async () => {

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeSystem, failingSystem } from '@/testing/fake-systems';
-import { auditConfig, auditLogQuery, rebootInfo, updateStatus } from '@/tools/index';
+import {
+  auditConfig,
+  auditLogQuery,
+  rebootInfo,
+  systemGeneralConfig,
+  updateStatus,
+} from '@/tools/index';
 
 describe('system_update_status', () => {
   /** `update.status` as the middleware sends it on a system with an update. */
@@ -870,6 +876,242 @@ describe('system_reboot_info', () => {
     const { ctx, call, query } = fakeSystem({ ['system.reboot.info']: info() });
     await rebootInfo.handler(ctx, {});
     expect(call.mock.calls.map((args) => args[0])).toEqual(['system.reboot.info']);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('system_general_config', () => {
+  /** `system.general.config` as the middleware sends it, every field present. */
+  const config = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    ui_certificate: { id: 1, name: 'truenas_default' },
+    ui_httpsport: 443,
+    ui_httpsredirect: true,
+    ui_httpsprotocols: ['TLSv1.2', 'TLSv1.3'],
+    ui_port: 80,
+    ui_address: ['0.0.0.0'],
+    ui_v6address: ['::'],
+    ui_allowlist: [],
+    ui_consolemsg: false,
+    ui_x_frame_options: 'SAMEORIGIN',
+    kbdmap: 'us',
+    timezone: 'America/Los_Angeles',
+    usage_collection: true,
+    wizardshown: true,
+    usage_collection_is_set: true,
+    ds_auth: false,
+    ...over,
+  });
+
+  // Required rather than defaulted, so that a case about a system answering
+  // with `undefined` is not swallowed by the default.
+  const reported = async (answer: unknown): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['system.general.config']: answer });
+    return (await systemGeneralConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  /** The result for a payload differing only in the fields the case is about. */
+  const forConfig = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    reported(config(over));
+
+  /** One field of such a result, which is what most cases here are about. */
+  const field = async (over: Record<string, unknown>, name: string): Promise<unknown> =>
+    (await forConfig(over))[name];
+
+  it('reports the timezone and the settings beside it through named fields', async () => {
+    expect(await reported(config())).toEqual({
+      timezone: 'America/Los_Angeles',
+      keyboard_map: 'us',
+      ui_port: 80,
+      ui_https_port: 443,
+      ui_https_redirect: true,
+      ui_https_protocols: ['TLSv1.2', 'TLSv1.3'],
+      ui_addresses: ['0.0.0.0'],
+      ui_v6_addresses: ['::'],
+      ui_allowlist: [],
+      ui_x_frame_options: 'SAMEORIGIN',
+      ui_console_messages: false,
+      ui_certificate_configured: true,
+      usage_collection: true,
+      usage_collection_is_set: true,
+    });
+  });
+
+  it('says in its description that the timezone is the frame for the catalog', async () => {
+    // The sentence that makes an LLM reach for this before it renders a
+    // schedule or a local timestamp from any other tool.
+    expect(systemGeneralConfig.description).toContain(
+      '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE FRAME EVERY OTHER ' +
+        "TOOL'S LOCAL TIMES AND SCHEDULES SIT IN",
+    );
+    expect(systemGeneralConfig.description).toContain('snapshot_tasks_list');
+    expect(systemGeneralConfig.description).toContain('audit_log_query');
+  });
+
+  it('nulls a timezone it could not read rather than falling back to UTC', async () => {
+    // The expensive direction: a wrong frame is applied silently to every time
+    // in the catalog, where a null is a question the caller has to ask.
+    for (const unreadable of [null, undefined, '', 7, ['UTC']]) {
+      expect(await field({ timezone: unreadable }, 'timezone')).toBeNull();
+    }
+    expect(systemGeneralConfig.description).toContain('which is NOT UTC');
+  });
+
+  it('carries no field the tool does not name, whatever the payload holds', async () => {
+    // `id`, `wizardshown` and `ds_auth` are in the fixture above and none of
+    // them is here; nor is a field a later TrueNAS release adds.
+    const result = await forConfig({ ui_restart_delay: 5, rollback_timeout: 60 });
+    expect(Object.keys(result)).toEqual([
+      'timezone',
+      'keyboard_map',
+      'ui_port',
+      'ui_https_port',
+      'ui_https_redirect',
+      'ui_https_protocols',
+      'ui_addresses',
+      'ui_v6_addresses',
+      'ui_allowlist',
+      'ui_x_frame_options',
+      'ui_console_messages',
+      'ui_certificate_configured',
+      'usage_collection',
+      'usage_collection_is_set',
+    ]);
+  });
+
+  it('reduces the certificate to whether one is configured, never the record', async () => {
+    // An open record forwarded would carry whatever a later release puts in it,
+    // and `certificates_list` is the tool for the detail.
+    expect(await field({ ui_certificate: { id: 3, name: 'letsencrypt' } }, 'ui_certificate_configured')).toBe(
+      true,
+    );
+    expect(JSON.stringify(await forConfig({ ui_certificate: { name: 'letsencrypt' } }))).not.toContain(
+      'letsencrypt',
+    );
+  });
+
+  it('keeps "no certificate" and "could not be read" apart', async () => {
+    // `recordOrNull` alone would answer null for both, and only one of them is
+    // something the system said.
+    expect(await field({ ui_certificate: null }, 'ui_certificate_configured')).toBe(false);
+    for (const unreadable of [undefined, 'truenas_default', 7, []]) {
+      expect(await field({ ui_certificate: unreadable }, 'ui_certificate_configured')).toBeNull();
+    }
+  });
+
+  it('reports the usage-collection pair together, keeping off apart from never chosen', async () => {
+    // Reporting the boolean alone loses exactly the distinction the second
+    // field exists to preserve.
+    expect(await forConfig({ usage_collection: false, usage_collection_is_set: false })).toMatchObject(
+      { usage_collection: false, usage_collection_is_set: false },
+    );
+    expect(await forConfig({ usage_collection: false, usage_collection_is_set: true })).toMatchObject(
+      { usage_collection: false, usage_collection_is_set: true },
+    );
+    for (const unreadable of [null, undefined, 'true', 1]) {
+      expect(await field({ usage_collection_is_set: unreadable }, 'usage_collection_is_set')).toBeNull();
+    }
+  });
+
+  it('reports the boolean settings three-valued, and never defaults one to false', async () => {
+    // A system that reported no value has not been shown to be redirecting
+    // plain HTTP, or to be hiding console messages.
+    for (const [sent, reported_] of [
+      ['ui_httpsredirect', 'ui_https_redirect'],
+      ['ui_consolemsg', 'ui_console_messages'],
+    ] as const) {
+      expect(await field({ [sent]: true }, reported_)).toBe(true);
+      expect(await field({ [sent]: false }, reported_)).toBe(false);
+      for (const unreadable of [null, undefined, 'true', 1]) {
+        expect(await field({ [sent]: unreadable }, reported_)).toBeNull();
+      }
+    }
+  });
+
+  it('nulls a port the system reported no number for, and keeps a zero', async () => {
+    expect(await field({ ui_port: 0 }, 'ui_port')).toBe(0);
+    for (const unreadable of [null, undefined, '443', Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(await field({ ui_port: unreadable }, 'ui_port')).toBeNull();
+      expect(await field({ ui_httpsport: unreadable }, 'ui_https_port')).toBeNull();
+    }
+  });
+
+  it('distinguishes a list the system named nothing in from one it could not read', async () => {
+    // Empty is an answer — the system reported the list and it names nothing —
+    // and null is the absence of one.
+    for (const [sent, reported_] of [
+      ['ui_httpsprotocols', 'ui_https_protocols'],
+      ['ui_address', 'ui_addresses'],
+      ['ui_v6address', 'ui_v6_addresses'],
+      ['ui_allowlist', 'ui_allowlist'],
+    ] as const) {
+      expect(await field({ [sent]: [] }, reported_)).toEqual([]);
+      for (const unreadable of [null, undefined, 'TLSv1.2', 7, {}]) {
+        expect(await field({ [sent]: unreadable }, reported_)).toBeNull();
+      }
+    }
+  });
+
+  it('nulls a list whole rather than dropping the entry it could not read', async () => {
+    // The #93 direction rule: a protocol list one entry shorter would hide the
+    // old TLS version this field is read for, and an address list one entry
+    // shorter would understate what the web UI listens on.
+    expect(await field({ ui_httpsprotocols: ['TLSv1', 7] }, 'ui_https_protocols')).toBeNull();
+    expect(await field({ ui_httpsprotocols: ['TLSv1', ''] }, 'ui_https_protocols')).toBeNull();
+    expect(await field({ ui_address: ['10.0.0.1', null] }, 'ui_addresses')).toBeNull();
+    expect(await field({ ui_v6address: ['::', {}] }, 'ui_v6_addresses')).toBeNull();
+    expect(await field({ ui_allowlist: ['10.0.0.0/8', 7] }, 'ui_allowlist')).toBeNull();
+  });
+
+  it('passes through a protocol and a framing policy the pinned client does not declare', async () => {
+    // These are values rather than fields, so a value a later TrueNAS release
+    // adds is answerable without a change here.
+    expect(await field({ ui_httpsprotocols: ['TLSv1.4'] }, 'ui_https_protocols')).toEqual([
+      'TLSv1.4',
+    ]);
+    expect(await field({ ui_x_frame_options: 'ALLOW_FROM' }, 'ui_x_frame_options')).toBe(
+      'ALLOW_FROM',
+    );
+  });
+
+  it('states no verdict about the TLS protocol list', async () => {
+    // The #47 decision: the list is the fact, and "acceptable" is a claim
+    // against a standard nobody supplied. A system still accepting TLSv1 gets
+    // the same shape of result as one that does not.
+    const legacy = await forConfig({ ui_httpsprotocols: ['TLSv1', 'TLSv1.1'] });
+    expect(legacy['ui_https_protocols']).toEqual(['TLSv1', 'TLSv1.1']);
+    expect(Object.keys(legacy)).toEqual(Object.keys(await reported(config())));
+    expect(systemGeneralConfig.description).toContain('THIS TOOL STATES NO VERDICT ABOUT THAT LIST');
+  });
+
+  it('nulls a keyboard map or a framing policy it could not read', async () => {
+    for (const unreadable of [null, undefined, '', 7]) {
+      expect(await field({ kbdmap: unreadable }, 'keyboard_map')).toBeNull();
+      expect(await field({ ui_x_frame_options: unreadable }, 'ui_x_frame_options')).toBeNull();
+    }
+  });
+
+  it('fails rather than answering nulls when the payload is not a configuration', async () => {
+    // Reached into rather than guarded, this would throw naming a property
+    // rather than the read that failed.
+    for (const answer of [null, undefined, 'general', 7, []]) {
+      await expect(reported(answer)).rejects.toThrow(
+        'system.general.config did not answer with a general configuration',
+      );
+    }
+  });
+
+  it('fails rather than answering a timezone of null when the read could not be made', async () => {
+    const { ctx } = failingSystem({}, { ['system.general.config']: new Error('connection reset') });
+    await expect(systemGeneralConfig.handler(ctx, {})).rejects.toThrow('connection reset');
+  });
+
+  it('never mutates, and reads no choices method', async () => {
+    // `timezone_choices`, `kbdmap_choices` and `country_choices` enumerate valid
+    // form values rather than facts about this system, and none of them is read.
+    const { ctx, call, query } = fakeSystem({ ['system.general.config']: config() });
+    await systemGeneralConfig.handler(ctx, {});
+    expect(call.mock.calls.map((args) => args[0])).toEqual(['system.general.config']);
     expect(query).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -898,9 +898,8 @@ function certificateConfigured(value: unknown): boolean | null {
  *   which local, so an assistant reporting it to a user in another timezone was
  *   off by the offset and confident.
  * - **A reported INSTANT is not.** `audit_log_query`, `tasks_recent_runs` and
- *   `snapshots_list` render ISO 8601 UTC, and `storage_scrub_history` passes the
- *   middleware's own string through. Those need CONVERTING into this timezone
- *   before anyone is told a wall-clock hour, which is the opposite operation.
+ *   `snapshots_list` render ISO 8601 UTC, so those need CONVERTING into this
+ *   timezone before anyone is told a wall-clock hour — the opposite operation.
  *
  * Getting the two the wrong way round is worse than not having the timezone at
  * all, so the description states which is which rather than saying "the catalog
@@ -908,19 +907,32 @@ function certificateConfigured(value: unknown): boolean | null {
  * restating it inside every tool that reports a time is a separate change and is
  * not made here.
  *
+ * `storage_scrub_history` is in NEITHER group and the description says so
+ * outright: it reports `started_at` and `finished_at` "as the system reports
+ * them" and states no zone for either, so this tool must not tell a caller to
+ * convert them. Doing so would assert a frame the sibling tool refuses to, and
+ * an offsetless string already written in local time would be shifted by the
+ * offset a second time.
+ *
+ * `system_info` ALREADY RETURNS A `timezone`, off `system.info`, and this tool
+ * is not a duplicate of it. What was missing was never the string — it was any
+ * statement of what the string is the frame FOR, which `system_info` does not
+ * make and which is most of this tool's description.
+ *
  * THIS TOOL STATES NO VERDICT, per the #47 decision in `CLAUDE.md` and for the
  * same reason `security_config` states none: a TLS protocol list is a fact, and
  * whether accepting TLSv1 is acceptable is a claim against a standard that lives
  * outside this repository. So `ui_https_protocols` is reported as the system
  * spelled it and no field here scores it.
  *
- * Three fields of the payload are DELIBERATELY not reported, and each is a
- * different reason:
+ * Four fields of the payload do NOT appear under their own names, for three
+ * different reasons:
  *
  * - **`id`** is a middleware row id and means nothing outside the middleware —
  *   the same omission `security_config` makes.
- * - **`ui_certificate`** is an open record, reduced to
- *   {@link certificateConfigured} rather than forwarded.
+ * - **`ui_certificate`** is not dropped but REDUCED: it is an open record, and
+ *   {@link certificateConfigured} turns it into the one fact reading it
+ *   establishes, reported as `ui_certificate_configured`.
  * - **`wizardshown` and `ds_auth`** are read by nothing here. `wizardshown` is
  *   the setup wizard's own bookkeeping and answers no question about the system;
  *   `ds_auth` is a boolean whose meaning the pinned surface states nowhere, and
@@ -937,10 +949,11 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'and TLS configuration, and its console keyboard map. ' +
     '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE SYSTEM\'S LOCAL ' +
     'TIME ZONE. It is the name the system holds, such as `America/Los_Angeles` ' +
-    'or `UTC`. NO OTHER TOOL IN THIS CATALOG REPORTS IT, so read it here before ' +
-    'telling anyone when something runs or when something happened — otherwise ' +
-    'a user in a different timezone from their NAS is told the wrong hour with ' +
-    'full confidence. ' +
+    'or `UTC`. Read it before telling anyone when something runs or when ' +
+    'something happened — otherwise a user in a different timezone from their ' +
+    'NAS is told the wrong hour with full confidence. `system_info` also ' +
+    'returns a `timezone` and it is the same setting; what it does not say, and ' +
+    'what follows here, is what that zone is the frame FOR. ' +
     'IT APPLIES TO THE CATALOG\'S TWO KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
     'GETTING THAT ROUND THE WRONG WAY IS WORSE THAN NOT READING IT AT ALL. ' +
     'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE: the cron schedules ' +
@@ -948,9 +961,14 @@ export const systemGeneralConfig: ReadOnlyTool = {
     '"daily at 02:00" — run at that hour LOCAL to the system, so name this zone ' +
     'when repeating one and do NOT convert it. A REPORTED INSTANT IS NOT: ' +
     '`audit_log_query`, `tasks_recent_runs` and `snapshots_list` report ISO ' +
-    '8601 UTC timestamps, and `storage_scrub_history` passes through the time ' +
-    'the system itself wrote, so CONVERT those INTO this zone before stating a ' +
+    '8601 UTC timestamps, so CONVERT those INTO this zone before stating a ' +
     'wall-clock time. ' +
+    '`storage_scrub_history` IS IN NEITHER GROUP AND MUST NOT BE CONVERTED ON ' +
+    'THE STRENGTH OF THIS FIELD: it reports its times as the system wrote them ' +
+    'and states no zone for either, so nothing here establishes what frame they ' +
+    'are in — a string already written in local time would be shifted by this ' +
+    'offset a second time. Read what that tool returned before deciding it ' +
+    'needs anything done to it. ' +
     '`timezone` is null where the system reported no timezone this tool could ' +
     'read — which is NOT UTC, and must not be treated as UTC; say the zone is ' +
     'unknown instead of assuming one. ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -900,7 +900,19 @@ function certificateConfigured(value: unknown): boolean | null {
  * written — `describeSchedule` has three callers rather than the two the cron
  * rendering started with, and `toISOString` is reached for in six files. A list
  * of tool names cannot be right for long in a catalog that grows by a tool a
- * ticket, and it is silently wrong rather than loudly so. The three forms are:
+ * ticket, and it is silently wrong rather than loudly so.
+ *
+ * **A COUNT OF FORMS IS A LIST OF THE SAME KIND**, which is the fourth draft's
+ * version of the defect and is why the description states no number now. It
+ * said the catalog reported times in three forms and every tool that reported
+ * one used them, and `alerts_list` already returned a fourth: it forwards
+ * `alert.datetime` unread, and what arrives can be the middleware's own
+ * {@link MiddlewareDate} envelope, which this repository's own fixture uses for
+ * exactly that field. An envelope carries epoch milliseconds and is absolute,
+ * so the only rule it matched on its face was the one for a string carrying no
+ * zone — *do not convert* — which is the answer backwards. The rules sort a
+ * value by its SHAPE and end in a case for a shape none of them describe, so a
+ * form nobody has written down yet is answered honestly rather than absorbed:
  *
  * - **A rendered schedule** — the English a `schedule_description` holds — is
  *   already local, because the system runs the cron expression behind it at that
@@ -909,18 +921,23 @@ function certificateConfigured(value: unknown): boolean | null {
  *   what every `toISOString` in the catalog produces. To be converted into this
  *   zone before anyone is told a wall-clock hour.
  * - **A timestamp carrying neither** was written by the system and passed
- *   through — `storage_scrub_history`'s scan times, `boot_pool_status`'s
- *   `created_at`. NOTHING in the catalog establishes what zone those are in,
- *   this tool included, so they are not to be converted either. Saying otherwise
- *   would assert a frame the sibling tool refuses to state, and would shift a
- *   string already written in local time by this offset a second time.
+ *   through unread. NOTHING in the catalog establishes what zone those are in,
+ *   this tool included, so they are not to be converted. Saying otherwise would
+ *   assert a frame the sibling tool refuses to state, and would shift a string
+ *   already written in local time by this offset a second time.
+ * - **An object carrying `$date`** is the middleware's date representation
+ *   passed through unread, and the number in it is milliseconds since the epoch
+ *   — absolute, and to be converted exactly as the second bullet is. Every tool
+ *   that READS one turns it into `Z`-suffixed text and so reports the second
+ *   form; this bullet is for the ones that forward it.
+ * - **Anything else** is not covered, and is to be reported as what it is with
+ *   its frame unstated rather than sorted into the nearest rule.
  *
- * The third bullet names tools and the first two do not, which looks like the
- * defect above and is the other half of the same rule: the API declares both of
- * those fields as bare strings and states no format, so what those two tools
- * pass through MIGHT carry a zone and might not. Naming them tells a caller
- * where to look, and the sorting is still done on the value — which is why the
- * description says to read it rather than which group it lands in.
+ * Tools ARE named in the description, under the last three bullets and as
+ * examples rather than as the set — the API declares those fields as bare
+ * strings and states no format, so what a given one passes through might carry
+ * a zone, might not, and might not be a string at all. Naming them tells a
+ * caller where to look, and the sorting is still done on the value.
  *
  * One tool reporting the frame once is the deliverable; restating it inside every
  * tool that reports a time is a separate change and is not made here.
@@ -967,9 +984,8 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'what follows here, is what that zone is the frame FOR. ' +
     'IT APPLIES TO THE CATALOG\'S KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
     'GETTING THAT ROUND THE WRONG WAY IS WORSE THAN NOT READING IT AT ALL. ' +
-    'DECIDE FROM THE VALUE YOU ARE HOLDING, NEVER FROM WHICH TOOL RETURNED IT — ' +
-    'the catalog reports times in three forms and every tool that reports one ' +
-    'uses these. (1) A RENDERED SCHEDULE — the English in a ' +
+    'DECIDE FROM THE VALUE YOU ARE HOLDING, NEVER FROM WHICH TOOL RETURNED IT, ' +
+    'AND SORT IT BY ITS SHAPE. (1) A RENDERED SCHEDULE — the English in a ' +
     '`schedule_description`, such as "at 02:00, every day" — IS ALREADY IN ' +
     'THIS ZONE, because the system runs the cron expression behind it at that ' +
     'hour local to itself. Name this zone when repeating one and do NOT ' +
@@ -979,11 +995,21 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'A TIMESTAMP CARRYING NEITHER was written by the system and passed through ' +
     'unchanged, and NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN — ' +
     'this field included. Do NOT convert one and do NOT read it as UTC; say ' +
-    'the zone is unstated. `storage_scrub_history` and `boot_pool_status` are ' +
-    'the tools that pass a time through this way; WHETHER a given one of their ' +
-    'values carries a zone is not fixed — the API declares them as bare ' +
-    'strings and states no format — so READ THE VALUE and sort it into (2) or ' +
-    '(3) by what it actually carries. ' +
+    'the zone is unstated. (4) AN OBJECT CARRYING A `$date`, such as ' +
+    '`{"$date": 1756468800000}`, IS THE MIDDLEWARE\'S OWN DATE REPRESENTATION ' +
+    'FORWARDED UNREAD, and the number in it is MILLISECONDS SINCE THE EPOCH, ' +
+    'which is ABSOLUTE: CONVERT it into this zone exactly as (2). It is not ' +
+    '(3) — carrying no `Z` does not make it local, and reading it as (3) is ' +
+    'the one mistake this form is written out to stop. (5) ANYTHING ELSE — a ' +
+    'bare number, or a shape none of the above describes — IS NOT COVERED BY ' +
+    'THIS RULE: report it as what it is and say its zone is unstated, rather ' +
+    'than sorting it into the nearest form. Tools that pass a time through ' +
+    'without reading it are where (3) and (4) turn up — `alerts_list`, ' +
+    '`storage_scrub_history` and `boot_pool_status` AMONG THEM, named as ' +
+    'examples and not as the whole set. WHICH form a given one of their ' +
+    'values takes is not fixed: the API declares those fields as bare strings ' +
+    'and states no format, so READ THE VALUE and sort it by what it actually ' +
+    'carries. ' +
     '`timezone` is null where the system reported no timezone this tool could ' +
     'read — which is NOT UTC, and must not be treated as UTC; say the zone is ' +
     'unknown instead of assuming one. ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -908,12 +908,19 @@ function certificateConfigured(value: unknown): boolean | null {
  * - **A timestamp carrying `Z` or an explicit offset** is absolute, which is
  *   what every `toISOString` in the catalog produces. To be converted into this
  *   zone before anyone is told a wall-clock hour.
- * - **A timestamp carrying no zone at all** was written by the system and passed
+ * - **A timestamp carrying neither** was written by the system and passed
  *   through — `storage_scrub_history`'s scan times, `boot_pool_status`'s
  *   `created_at`. NOTHING in the catalog establishes what zone those are in,
  *   this tool included, so they are not to be converted either. Saying otherwise
  *   would assert a frame the sibling tool refuses to state, and would shift a
  *   string already written in local time by this offset a second time.
+ *
+ * The third bullet names tools and the first two do not, which looks like the
+ * defect above and is the other half of the same rule: the API declares both of
+ * those fields as bare strings and states no format, so what those two tools
+ * pass through MIGHT carry a zone and might not. Naming them tells a caller
+ * where to look, and the sorting is still done on the value — which is why the
+ * description says to read it rather than which group it lands in.
  *
  * One tool reporting the frame once is the deliverable; restating it inside every
  * tool that reports a time is a separate change and is not made here.
@@ -963,17 +970,20 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'DECIDE FROM THE VALUE YOU ARE HOLDING, NEVER FROM WHICH TOOL RETURNED IT — ' +
     'the catalog reports times in three forms and every tool that reports one ' +
     'uses these. (1) A RENDERED SCHEDULE — the English in a ' +
-    '`schedule_description`, "daily at 02:00" — IS ALREADY IN THIS ZONE, ' +
-    'because the system runs the cron expression behind it at that hour local ' +
-    'to itself. Name this zone when repeating one and do NOT convert it. (2) A ' +
-    'TIMESTAMP ENDING IN `Z`, OR CARRYING AN EXPLICIT `+HH:MM` OFFSET, IS ' +
-    'ABSOLUTE and is most of the times this catalog reports. CONVERT one INTO ' +
-    'this zone before stating a wall-clock hour. (3) A TIMESTAMP CARRYING NO ' +
-    'ZONE AT ALL was written by the system and passed through unchanged, and ' +
-    'NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN — this field ' +
-    'included. Do NOT convert one and do NOT read it as UTC; say the zone is ' +
-    'unstated. A scrub time from `storage_scrub_history` and a boot ' +
-    "environment's `created_at` are of this third kind. " +
+    '`schedule_description`, such as "at 02:00, every day" — IS ALREADY IN ' +
+    'THIS ZONE, because the system runs the cron expression behind it at that ' +
+    'hour local to itself. Name this zone when repeating one and do NOT ' +
+    'convert it. (2) A TIMESTAMP ENDING IN `Z`, OR CARRYING AN EXPLICIT ' +
+    '`+HH:MM` OFFSET, IS ABSOLUTE and is most of the times this catalog ' +
+    'reports. CONVERT one INTO this zone before stating a wall-clock hour. (3) ' +
+    'A TIMESTAMP CARRYING NEITHER was written by the system and passed through ' +
+    'unchanged, and NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN — ' +
+    'this field included. Do NOT convert one and do NOT read it as UTC; say ' +
+    'the zone is unstated. `storage_scrub_history` and `boot_pool_status` are ' +
+    'the tools that pass a time through this way; WHETHER a given one of their ' +
+    'values carries a zone is not fixed — the API declares them as bare ' +
+    'strings and states no format — so READ THE VALUE and sort it into (2) or ' +
+    '(3) by what it actually carries. ' +
     '`timezone` is null where the system reported no timezone this tool could ' +
     'read — which is NOT UTC, and must not be treated as UTC; say the zone is ' +
     'unknown instead of assuming one. ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -892,11 +892,14 @@ function certificateConfigured(value: unknown): boolean | null {
  * The timezone is why this tool exists, and it lands on the catalog's two kinds
  * of time differently:
  *
- * - **A rendered SCHEDULE is already in this timezone.** `snapshot_tasks_list`
- *   and `cloudsync_tasks_list` turn a cron expression into English — "daily at
- *   02:00" — and the system runs it at 02:00 LOCAL. Nothing in either tool says
- *   which local, so an assistant reporting it to a user in another timezone was
- *   off by the offset and confident.
+ * - **A rendered SCHEDULE is already in this timezone.** `snapshot_tasks_list`,
+ *   `cloudsync_tasks_list` and `automated_tasks_list` turn a cron expression
+ *   into English — "daily at 02:00" — through the one `describeSchedule` in
+ *   `tasks.ts`, and the system runs it at 02:00 LOCAL. Nothing in any of them
+ *   says which local, so an assistant reporting it to a user in another timezone
+ *   was off by the offset and confident. Every `schedule_description` in the
+ *   catalog comes from that one renderer, so the group is defined by it rather
+ *   than by a list that a fourth caller of it would silently fall out of.
  * - **A reported INSTANT is not.** `audit_log_query`, `tasks_recent_runs` and
  *   `snapshots_list` render ISO 8601 UTC, so those need CONVERTING into this
  *   timezone before anyone is told a wall-clock hour — the opposite operation.
@@ -956,10 +959,12 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'what follows here, is what that zone is the frame FOR. ' +
     'IT APPLIES TO THE CATALOG\'S TWO KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
     'GETTING THAT ROUND THE WRONG WAY IS WORSE THAN NOT READING IT AT ALL. ' +
-    'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE: the cron schedules ' +
-    '`snapshot_tasks_list` and `cloudsync_tasks_list` render into English — ' +
-    '"daily at 02:00" — run at that hour LOCAL to the system, so name this zone ' +
-    'when repeating one and do NOT convert it. A REPORTED INSTANT IS NOT: ' +
+    'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE: every `schedule_description` ' +
+    'in this catalog — `snapshot_tasks_list`, `cloudsync_tasks_list` and each ' +
+    'scheduled section of `automated_tasks_list` — is a cron expression ' +
+    'rendered into English, "daily at 02:00", and the system runs it at that ' +
+    'hour LOCAL to itself. Name this zone when repeating one, and do NOT ' +
+    'convert it. A REPORTED INSTANT IS NOT: ' +
     '`audit_log_query`, `tasks_recent_runs` and `snapshots_list` report ISO ' +
     '8601 UTC timestamps, so CONVERT those INTO this zone before stating a ' +
     'wall-clock time. ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -858,18 +858,30 @@ export const rebootInfo: ReadOnlyTool = {
 /**
  * Whether the web UI has a certificate configured, and nothing else about it.
  *
- * `ui_certificate` arrives as an open record or an explicit null, and the record
- * is not forwarded: `certificates_list` is the tool for certificate detail, and
- * a record passed through would carry whatever a later TrueNAS release puts in
- * it. What is left is the one fact this tool is in a position to state.
+ * The record is not forwarded: `certificates_list` is the tool for certificate
+ * detail, and a record passed through would carry whatever a later TrueNAS
+ * release puts in it. What is left is the one fact this tool is in a position to
+ * state.
  *
- * `recordOrNull` alone would answer null for both of the cases that matter, so
- * the explicit null is read first: a system that reported NO certificate has
- * said something, and it must not read as a system this tool could not
- * understand.
+ * TWO SHAPES ARE READ AS "CONFIGURED", AND THAT IS THE #91 DECISION RATHER THAN
+ * DEFENSIVENESS. The pinned surface — `DefaultApiDirectory`, the client's oldest
+ * — declares `ui_certificate` as an embedded record; a later directory in the
+ * same client declares it `number | null`, the certificate's id, beside a
+ * `ui_certificate_name`. So a system on a newer release sends a NUMBER for a web
+ * UI that does have a certificate, and reading only the record shape would
+ * answer null — "this could not be read" — for exactly the systems where the
+ * answer is yes. Both shapes say the same thing at this resolution, which is why
+ * this field is a boolean and not the certificate.
+ *
+ * The explicit null is read FIRST, before either shape: a system that reported
+ * NO certificate has said something, and `recordOrNull` alone would collapse it
+ * into the same null as a payload this tool could not understand.
  */
 function certificateConfigured(value: unknown): boolean | null {
   if (value === null) return false;
+  // The newer surface's certificate id. A non-finite number is not an id and
+  // falls through to the record reading, which answers null for it.
+  if (numberOrNull(value) !== null) return true;
   return recordOrNull(value) === null ? null : true;
 }
 
@@ -877,15 +889,24 @@ function certificateConfigured(value: unknown): boolean | null {
  * The timezone the rest of the catalog's times are relative to, with the web UI
  * and console settings that arrive beside it.
  *
- * The timezone is why this tool exists. `snapshot_tasks_list` and
- * `cloudsync_tasks_list` render cron schedules into English — "daily at 02:00" —
- * and those schedules run in the system's local time; `audit_log_query`,
- * `tasks_recent_runs`, `storage_scrub_history` and `snapshots_list` all report
- * times. Nothing in the catalog said what frame any of it sat in, so a user in a
- * different timezone from their NAS was told the wrong thing with full
- * confidence. One tool reporting the frame once is the deliverable; restating it
- * inside every tool that reports a time is a separate change and is not made
- * here.
+ * The timezone is why this tool exists, and it lands on the catalog's two kinds
+ * of time differently:
+ *
+ * - **A rendered SCHEDULE is already in this timezone.** `snapshot_tasks_list`
+ *   and `cloudsync_tasks_list` turn a cron expression into English — "daily at
+ *   02:00" — and the system runs it at 02:00 LOCAL. Nothing in either tool says
+ *   which local, so an assistant reporting it to a user in another timezone was
+ *   off by the offset and confident.
+ * - **A reported INSTANT is not.** `audit_log_query`, `tasks_recent_runs` and
+ *   `snapshots_list` render ISO 8601 UTC, and `storage_scrub_history` passes the
+ *   middleware's own string through. Those need CONVERTING into this timezone
+ *   before anyone is told a wall-clock hour, which is the opposite operation.
+ *
+ * Getting the two the wrong way round is worse than not having the timezone at
+ * all, so the description states which is which rather than saying "the catalog
+ * reports local times". One tool reporting the frame once is the deliverable;
+ * restating it inside every tool that reports a time is a separate change and is
+ * not made here.
  *
  * THIS TOOL STATES NO VERDICT, per the #47 decision in `CLAUDE.md` and for the
  * same reason `security_config` states none: a TLS protocol list is a fact, and
@@ -914,18 +935,25 @@ export const systemGeneralConfig: ReadOnlyTool = {
   description:
     "A TrueNAS system's general settings: its TIMEZONE, the web UI's network " +
     'and TLS configuration, and its console keyboard map. ' +
-    '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE FRAME EVERY OTHER ' +
-    "TOOL'S LOCAL TIMES AND SCHEDULES SIT IN. The schedules " +
+    '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE SYSTEM\'S LOCAL ' +
+    'TIME ZONE. It is the name the system holds, such as `America/Los_Angeles` ' +
+    'or `UTC`. NO OTHER TOOL IN THIS CATALOG REPORTS IT, so read it here before ' +
+    'telling anyone when something runs or when something happened — otherwise ' +
+    'a user in a different timezone from their NAS is told the wrong hour with ' +
+    'full confidence. ' +
+    'IT APPLIES TO THE CATALOG\'S TWO KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
+    'GETTING THAT ROUND THE WRONG WAY IS WORSE THAN NOT READING IT AT ALL. ' +
+    'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE: the cron schedules ' +
     '`snapshot_tasks_list` and `cloudsync_tasks_list` render into English — ' +
-    '"daily at 02:00" — run in this timezone, and so do the local times ' +
-    '`audit_log_query`, `tasks_recent_runs`, `storage_scrub_history` and ' +
-    '`snapshots_list` report. NONE OF THOSE TOOLS REPEATS THE TIMEZONE, so read ' +
-    'it here before telling anyone when something runs or when something ' +
-    'happened — a user in a different timezone from their NAS is otherwise told ' +
-    'the wrong hour with full confidence. It is the name the system holds, such ' +
-    'as `America/Los_Angeles` or `UTC`, and it is null where the system ' +
-    'reported no timezone this tool could read — which is NOT UTC, and must not ' +
-    'be treated as UTC. ' +
+    '"daily at 02:00" — run at that hour LOCAL to the system, so name this zone ' +
+    'when repeating one and do NOT convert it. A REPORTED INSTANT IS NOT: ' +
+    '`audit_log_query`, `tasks_recent_runs` and `snapshots_list` report ISO ' +
+    '8601 UTC timestamps, and `storage_scrub_history` passes through the time ' +
+    'the system itself wrote, so CONVERT those INTO this zone before stating a ' +
+    'wall-clock time. ' +
+    '`timezone` is null where the system reported no timezone this tool could ' +
+    'read — which is NOT UTC, and must not be treated as UTC; say the zone is ' +
+    'unknown instead of assuming one. ' +
     '`keyboard_map` is the keyboard layout the system is configured with, as ' +
     'the system spells it, and is null where it reported none this tool could ' +
     'read. ' +
@@ -962,13 +990,18 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'that is `certificates_list` — and a true says only that one is configured, ' +
     'never that it is valid, trusted or unexpired. ' +
     '`usage_collection` and `usage_collection_is_set` ARE READ TOGETHER OR NOT ' +
-    'AT ALL. `usage_collection` is whether anonymous usage statistics are sent ' +
-    'to iXsystems, and `usage_collection_is_set` is whether anyone has actually ' +
-    'chosen: a false `usage_collection` beside a false `usage_collection_is_set` ' +
-    'is a system nobody has answered the question on, which is a different ' +
-    "state from an administrator having switched it off, and it is the second " +
-    'field that tells them apart. Each is null where the system reported no ' +
-    'value this tool could read. ' +
+    'AT ALL, and neither is to be reported without the other. ' +
+    '`usage_collection` is whether anonymous usage statistics are sent to ' +
+    'iXsystems, and `usage_collection_is_set` is WHETHER ANYONE EVER CHOSE. A ' +
+    'true `usage_collection_is_set` is an administrator having answered the ' +
+    'question, so `usage_collection` beside it is a decision; a false one is a ' +
+    'system running on whatever the default is, and `usage_collection` beside ' +
+    'THAT is not a choice anyone made and must not be reported as one. Each is ' +
+    'null where the system reported no value this tool could read, and that ' +
+    'covers the explicit null the payload uses as well as a value of another ' +
+    'type — those collapse to one answer here, "not established", because ' +
+    '`usage_collection_is_set` is what carries the distinction they were ' +
+    'keeping. ' +
     'EVERY FIELD ABOVE IS NULL WHERE THE SYSTEM REPORTED NO VALUE THIS TOOL ' +
     'COULD READ, and a null is never a zero, never a false and never an empty ' +
     'list — it is "this was not established". FOR THE FOUR LISTS ' +
@@ -1017,7 +1050,7 @@ export const systemGeneralConfig: ReadOnlyTool = {
       ui_port: numberOrNull(settings['ui_port']),
       ui_https_port: numberOrNull(settings['ui_httpsport']),
       ui_https_redirect: booleanOrNull(settings['ui_httpsredirect']),
-      // `strictTextList` for all three lists rather than `textList`: a dropped
+      // `strictTextList` for all four lists rather than `textList`: a dropped
       // entry here would be a claim in each case. A protocol list one entry
       // shorter hides the old TLS version this field is read for; an address
       // list one entry shorter understates what the web UI listens on; an

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -889,33 +889,34 @@ function certificateConfigured(value: unknown): boolean | null {
  * The timezone the rest of the catalog's times are relative to, with the web UI
  * and console settings that arrive beside it.
  *
- * The timezone is why this tool exists, and it lands on the catalog's two kinds
- * of time differently:
+ * The timezone is why this tool exists, and what the description spends its
+ * length on is which of the catalog's times it applies to and in which
+ * direction. Getting that round the wrong way is worse than not reading the
+ * timezone at all.
  *
- * - **A rendered SCHEDULE is already in this timezone.** `snapshot_tasks_list`,
- *   `cloudsync_tasks_list` and `automated_tasks_list` turn a cron expression
- *   into English — "daily at 02:00" — through the one `describeSchedule` in
- *   `tasks.ts`, and the system runs it at 02:00 LOCAL. Nothing in any of them
- *   says which local, so an assistant reporting it to a user in another timezone
- *   was off by the offset and confident. Every `schedule_description` in the
- *   catalog comes from that one renderer, so the group is defined by it rather
- *   than by a list that a fourth caller of it would silently fall out of.
- * - **A reported INSTANT is not.** `audit_log_query`, `tasks_recent_runs` and
- *   `snapshots_list` render ISO 8601 UTC, so those need CONVERTING into this
- *   timezone before anyone is told a wall-clock hour — the opposite operation.
+ * **The rule is keyed on the VALUE, not on the tool that returned it**, and
+ * three drafts of this description got that wrong in the same way: each named
+ * the tools in each group, and each list was already incomplete when it was
+ * written — `describeSchedule` has three callers rather than the two the cron
+ * rendering started with, and `toISOString` is reached for in six files. A list
+ * of tool names cannot be right for long in a catalog that grows by a tool a
+ * ticket, and it is silently wrong rather than loudly so. The three forms are:
  *
- * Getting the two the wrong way round is worse than not having the timezone at
- * all, so the description states which is which rather than saying "the catalog
- * reports local times". One tool reporting the frame once is the deliverable;
- * restating it inside every tool that reports a time is a separate change and is
- * not made here.
+ * - **A rendered schedule** — the English a `schedule_description` holds — is
+ *   already local, because the system runs the cron expression behind it at that
+ *   hour local to itself. Not to be converted.
+ * - **A timestamp carrying `Z` or an explicit offset** is absolute, which is
+ *   what every `toISOString` in the catalog produces. To be converted into this
+ *   zone before anyone is told a wall-clock hour.
+ * - **A timestamp carrying no zone at all** was written by the system and passed
+ *   through — `storage_scrub_history`'s scan times, `boot_pool_status`'s
+ *   `created_at`. NOTHING in the catalog establishes what zone those are in,
+ *   this tool included, so they are not to be converted either. Saying otherwise
+ *   would assert a frame the sibling tool refuses to state, and would shift a
+ *   string already written in local time by this offset a second time.
  *
- * `storage_scrub_history` is in NEITHER group and the description says so
- * outright: it reports `started_at` and `finished_at` "as the system reports
- * them" and states no zone for either, so this tool must not tell a caller to
- * convert them. Doing so would assert a frame the sibling tool refuses to, and
- * an offsetless string already written in local time would be shifted by the
- * offset a second time.
+ * One tool reporting the frame once is the deliverable; restating it inside every
+ * tool that reports a time is a separate change and is not made here.
  *
  * `system_info` ALREADY RETURNS A `timezone`, off `system.info`, and this tool
  * is not a duplicate of it. What was missing was never the string — it was any
@@ -957,23 +958,22 @@ export const systemGeneralConfig: ReadOnlyTool = {
     'NAS is told the wrong hour with full confidence. `system_info` also ' +
     'returns a `timezone` and it is the same setting; what it does not say, and ' +
     'what follows here, is what that zone is the frame FOR. ' +
-    'IT APPLIES TO THE CATALOG\'S TWO KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
+    'IT APPLIES TO THE CATALOG\'S KINDS OF TIME IN OPPOSITE DIRECTIONS, AND ' +
     'GETTING THAT ROUND THE WRONG WAY IS WORSE THAN NOT READING IT AT ALL. ' +
-    'A RENDERED SCHEDULE IS ALREADY IN THIS ZONE: every `schedule_description` ' +
-    'in this catalog — `snapshot_tasks_list`, `cloudsync_tasks_list` and each ' +
-    'scheduled section of `automated_tasks_list` — is a cron expression ' +
-    'rendered into English, "daily at 02:00", and the system runs it at that ' +
-    'hour LOCAL to itself. Name this zone when repeating one, and do NOT ' +
-    'convert it. A REPORTED INSTANT IS NOT: ' +
-    '`audit_log_query`, `tasks_recent_runs` and `snapshots_list` report ISO ' +
-    '8601 UTC timestamps, so CONVERT those INTO this zone before stating a ' +
-    'wall-clock time. ' +
-    '`storage_scrub_history` IS IN NEITHER GROUP AND MUST NOT BE CONVERTED ON ' +
-    'THE STRENGTH OF THIS FIELD: it reports its times as the system wrote them ' +
-    'and states no zone for either, so nothing here establishes what frame they ' +
-    'are in — a string already written in local time would be shifted by this ' +
-    'offset a second time. Read what that tool returned before deciding it ' +
-    'needs anything done to it. ' +
+    'DECIDE FROM THE VALUE YOU ARE HOLDING, NEVER FROM WHICH TOOL RETURNED IT — ' +
+    'the catalog reports times in three forms and every tool that reports one ' +
+    'uses these. (1) A RENDERED SCHEDULE — the English in a ' +
+    '`schedule_description`, "daily at 02:00" — IS ALREADY IN THIS ZONE, ' +
+    'because the system runs the cron expression behind it at that hour local ' +
+    'to itself. Name this zone when repeating one and do NOT convert it. (2) A ' +
+    'TIMESTAMP ENDING IN `Z`, OR CARRYING AN EXPLICIT `+HH:MM` OFFSET, IS ' +
+    'ABSOLUTE and is most of the times this catalog reports. CONVERT one INTO ' +
+    'this zone before stating a wall-clock hour. (3) A TIMESTAMP CARRYING NO ' +
+    'ZONE AT ALL was written by the system and passed through unchanged, and ' +
+    'NOTHING IN THIS CATALOG ESTABLISHES WHAT ZONE IT IS IN — this field ' +
+    'included. Do NOT convert one and do NOT read it as UTC; say the zone is ' +
+    'unstated. A scrub time from `storage_scrub_history` and a boot ' +
+    "environment's `created_at` are of this third kind. " +
     '`timezone` is null where the system reported no timezone this tool could ' +
     'read — which is NOT UTC, and must not be treated as UTC; say the zone is ' +
     'unknown instead of assuming one. ' +

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -5,9 +5,11 @@ import {
   MAX_TIME_MS,
   MiddlewareDate,
   NO_REASON,
+  booleanOrNull,
   errorText,
   numberOrNull,
   recordOrNull,
+  strictTextList,
   textOrNull,
 } from '@/tools/common';
 
@@ -594,27 +596,6 @@ export const auditLogQuery: ReadOnlyTool = {
 };
 
 /**
- * The things the system listed beside one service, as names — or null where it
- * listed something this tool cannot read as one.
- *
- * All-or-nothing rather than per-entry: an entry that could not be read is
- * dropped from a list only by making the whole list null, because a list
- * silently missing one share reads as a share that is not audited, which is the
- * opposite of what is known about it. The same reading `audit_log_query` applies
- * to a filter it could not check.
- */
-function scopeNames(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  const names: string[] = [];
-  for (const entry of value) {
-    const name = textOrNull(entry);
-    if (name === null) return null;
-    names.push(name);
-  }
-  return names;
-}
-
-/**
  * The services the system keeps audit configuration for, with what it listed
  * beside each — or null where it sent no service configuration this tool could
  * read.
@@ -635,9 +616,9 @@ function scopeNames(value: unknown): string[] | null {
  * the fields of the result.
  *
  * A name the system sent that this tool cannot read nulls the whole list, on
- * the same all-or-nothing reading {@link scopeNames} takes of a scope and for
- * the same reason: a list quietly one service shorter reads as a service the
- * system does not audit, which is more than the read established.
+ * the same all-or-nothing reading `strictTextList` takes of a scope and for the
+ * same reason: a list quietly one service shorter reads as a service the system
+ * does not audit, which is more than the read established.
  *
  * Sorted by name, because the middleware sends a keyed object and the order of
  * its keys means nothing; leaving it alone would make the result differ between
@@ -648,7 +629,10 @@ function configuredServices(value: unknown): { service: string; scope: string[] 
   if (services === null) return null;
   const names = Object.keys(services);
   if (names.some((name) => name.length === 0)) return null;
-  return names.sort().map((service) => ({ service, scope: scopeNames(services[service]) }));
+  // `strictTextList` rather than `textList`: a scope one name shorter reads as
+  // a share that is not audited, which is the opposite of what the read
+  // established, so an entry this tool cannot read nulls the whole scope.
+  return names.sort().map((service) => ({ service, scope: strictTextList(services[service]) }));
 }
 
 /**
@@ -756,8 +740,8 @@ interface RebootReason {
  * system having said nothing about it.
  *
  * An entry that could not be read is kept as a pair of nulls rather than
- * dropped, which is the opposite of the all-or-nothing reading
- * {@link scopeNames} takes and is the same argument arriving at the other
+ * dropped, which is the opposite of the all-or-nothing reading `strictTextList`
+ * takes of an audit scope and is the same argument arriving at the other
  * answer. There, a list one name shorter understates what is audited and the
  * whole list is nulled to say so. Here, a list one reason shorter runs towards
  * EMPTY — and empty is this tool's one positive finding, "nothing is pending".
@@ -867,6 +851,189 @@ export const rebootInfo: ReadOnlyTool = {
       reboot_required: reasons === null ? null : reasons.length > 0,
       reasons,
       boot_id: textOrNull(payload['boot_id']),
+    };
+  },
+};
+
+/**
+ * Whether the web UI has a certificate configured, and nothing else about it.
+ *
+ * `ui_certificate` arrives as an open record or an explicit null, and the record
+ * is not forwarded: `certificates_list` is the tool for certificate detail, and
+ * a record passed through would carry whatever a later TrueNAS release puts in
+ * it. What is left is the one fact this tool is in a position to state.
+ *
+ * `recordOrNull` alone would answer null for both of the cases that matter, so
+ * the explicit null is read first: a system that reported NO certificate has
+ * said something, and it must not read as a system this tool could not
+ * understand.
+ */
+function certificateConfigured(value: unknown): boolean | null {
+  if (value === null) return false;
+  return recordOrNull(value) === null ? null : true;
+}
+
+/**
+ * The timezone the rest of the catalog's times are relative to, with the web UI
+ * and console settings that arrive beside it.
+ *
+ * The timezone is why this tool exists. `snapshot_tasks_list` and
+ * `cloudsync_tasks_list` render cron schedules into English — "daily at 02:00" —
+ * and those schedules run in the system's local time; `audit_log_query`,
+ * `tasks_recent_runs`, `storage_scrub_history` and `snapshots_list` all report
+ * times. Nothing in the catalog said what frame any of it sat in, so a user in a
+ * different timezone from their NAS was told the wrong thing with full
+ * confidence. One tool reporting the frame once is the deliverable; restating it
+ * inside every tool that reports a time is a separate change and is not made
+ * here.
+ *
+ * THIS TOOL STATES NO VERDICT, per the #47 decision in `CLAUDE.md` and for the
+ * same reason `security_config` states none: a TLS protocol list is a fact, and
+ * whether accepting TLSv1 is acceptable is a claim against a standard that lives
+ * outside this repository. So `ui_https_protocols` is reported as the system
+ * spelled it and no field here scores it.
+ *
+ * Three fields of the payload are DELIBERATELY not reported, and each is a
+ * different reason:
+ *
+ * - **`id`** is a middleware row id and means nothing outside the middleware —
+ *   the same omission `security_config` makes.
+ * - **`ui_certificate`** is an open record, reduced to
+ *   {@link certificateConfigured} rather than forwarded.
+ * - **`wizardshown` and `ds_auth`** are read by nothing here. `wizardshown` is
+ *   the setup wizard's own bookkeeping and answers no question about the system;
+ *   `ds_auth` is a boolean whose meaning the pinned surface states nowhere, and
+ *   reporting a field whose meaning was guessed is worse than leaving it out —
+ *   a caller cannot tell a guess from a reading.
+ *
+ * `system.advanced.config` — serial console, syslog, GPU isolation — is a
+ * separate surface and is not read here.
+ */
+export const systemGeneralConfig: ReadOnlyTool = {
+  name: 'system_general_config',
+  description:
+    "A TrueNAS system's general settings: its TIMEZONE, the web UI's network " +
+    'and TLS configuration, and its console keyboard map. ' +
+    '`timezone` IS THE FIELD THIS TOOL EXISTS FOR AND IS THE FRAME EVERY OTHER ' +
+    "TOOL'S LOCAL TIMES AND SCHEDULES SIT IN. The schedules " +
+    '`snapshot_tasks_list` and `cloudsync_tasks_list` render into English — ' +
+    '"daily at 02:00" — run in this timezone, and so do the local times ' +
+    '`audit_log_query`, `tasks_recent_runs`, `storage_scrub_history` and ' +
+    '`snapshots_list` report. NONE OF THOSE TOOLS REPEATS THE TIMEZONE, so read ' +
+    'it here before telling anyone when something runs or when something ' +
+    'happened — a user in a different timezone from their NAS is otherwise told ' +
+    'the wrong hour with full confidence. It is the name the system holds, such ' +
+    'as `America/Los_Angeles` or `UTC`, and it is null where the system ' +
+    'reported no timezone this tool could read — which is NOT UTC, and must not ' +
+    'be treated as UTC. ' +
+    '`keyboard_map` is the keyboard layout the system is configured with, as ' +
+    'the system spells it, and is null where it reported none this tool could ' +
+    'read. ' +
+    'THE `ui_` FIELDS ARE THE WEB UI\'S OWN CONFIGURATION, not the network ' +
+    "settings of the system as a whole — that is `network_config` — and not any " +
+    'statement about what is reachable right now. `ui_port` is the port the web ' +
+    'UI is configured to serve plain HTTP on and `ui_https_port` the port it ' +
+    'serves HTTPS on; `ui_https_redirect` is whether a plain HTTP request is ' +
+    'redirected to HTTPS. `ui_addresses` and `ui_v6_addresses` are the IPv4 and ' +
+    'IPv6 addresses it is configured to listen on, passed through exactly as ' +
+    'the system spelled them and NOT interpreted here — a wildcard such as ' +
+    '`0.0.0.0` or `::` is returned as itself. `ui_allowlist` is what the system ' +
+    'listed as permitted to reach the web UI, again passed through as spelled. ' +
+    'AN EMPTY `ui_allowlist` IS THE SYSTEM NAMING NO ENTRIES AND IS NOT ' +
+    'EVIDENCE THE WEB UI IS RESTRICTED; whether an empty list means every ' +
+    'address may reach it is middleware behaviour this tool does not read and ' +
+    'does not state. `ui_x_frame_options` is the framing policy the web UI ' +
+    'sends, as the system spelled it — `SAMEORIGIN`, `DENY` or `ALLOW_ALL` are ' +
+    'the declared values and any other is passed through. `ui_console_messages` ' +
+    'is whether the web UI is configured to display the system console\'s ' +
+    'messages. ' +
+    '`ui_https_protocols` is the TLS protocol versions the web UI is configured ' +
+    'to accept, as the system spelled them; `TLSv1`, `TLSv1.1`, `TLSv1.2` and ' +
+    '`TLSv1.3` are the declared values and any other is passed through. THIS ' +
+    'TOOL STATES NO VERDICT ABOUT THAT LIST — there is no field here saying ' +
+    'whether the set is acceptable, safe or compliant, because that is a claim ' +
+    'against a standard that lives outside this system and nothing has told ' +
+    'this tool which one. The list is the fact; any pass/fail reading of it is ' +
+    'yours and must be stated as being against a named standard. ' +
+    '`ui_certificate_configured` is whether the system reported a certificate ' +
+    'for the web UI: true where it named one, false where it reported none, and ' +
+    'null where it reported something this tool could not read as either. WHICH ' +
+    'certificate, who issued it and when it expires are NOT reported here — ' +
+    'that is `certificates_list` — and a true says only that one is configured, ' +
+    'never that it is valid, trusted or unexpired. ' +
+    '`usage_collection` and `usage_collection_is_set` ARE READ TOGETHER OR NOT ' +
+    'AT ALL. `usage_collection` is whether anonymous usage statistics are sent ' +
+    'to iXsystems, and `usage_collection_is_set` is whether anyone has actually ' +
+    'chosen: a false `usage_collection` beside a false `usage_collection_is_set` ' +
+    'is a system nobody has answered the question on, which is a different ' +
+    "state from an administrator having switched it off, and it is the second " +
+    'field that tells them apart. Each is null where the system reported no ' +
+    'value this tool could read. ' +
+    'EVERY FIELD ABOVE IS NULL WHERE THE SYSTEM REPORTED NO VALUE THIS TOOL ' +
+    'COULD READ, and a null is never a zero, never a false and never an empty ' +
+    'list — it is "this was not established". FOR THE FOUR LISTS ' +
+    '(`ui_https_protocols`, `ui_addresses`, `ui_v6_addresses`, `ui_allowlist`) ' +
+    'an EMPTY list and a NULL are different answers: empty is the system ' +
+    'reporting the list and naming nothing in it, null is no list this tool ' +
+    'could read. EACH LIST IS NULLED WHOLE RATHER THAN SHORTENED if any one ' +
+    'entry cannot be read, so a list that comes back is complete — a protocol ' +
+    'list quietly one entry short would hide exactly the old TLS version worth ' +
+    'knowing about, and an address list one entry short would understate what ' +
+    'the web UI listens on. ' +
+    'This tool does NOT report the setup wizard state or the directory-service ' +
+    'authentication flag the same payload carries, and it does not read ' +
+    '`system.advanced.config` — the serial console, syslog and GPU isolation ' +
+    'settings, which NO TOOL IN THIS CATALOG reports. It does not enumerate the ' +
+    'valid choices for any of these settings: the timezone, keyboard-map and ' +
+    'country lists the middleware offers are form values, not facts about this ' +
+    'system, and none of them is returned here. THIS TOOL ONLY READS. It does ' +
+    'not change the timezone, any web UI setting, the keyboard map or the usage ' +
+    'collection preference, and it does not restart the web UI — those are ' +
+    '`system.general.update` and `system.general.ui_restart`, and neither is in ' +
+    'this catalog. General settings that could not be read at all are an error ' +
+    'naming what the system said, not a result of nulls.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const answer = await firstValueFrom(system.client.api.call('system.general.config'));
+    // Guarded rather than reached into, for the reason `audit_config` gives: a
+    // system answering with something that is not a configuration would
+    // otherwise throw naming a property, and the caller would see the name of a
+    // field rather than the read that failed.
+    const settings = recordOrNull(answer);
+    if (settings === null) {
+      throw new Error('system.general.config did not answer with a general configuration');
+    }
+    // Named one at a time, so a field a later TrueNAS release adds to the
+    // general configuration does not appear in this result without a change
+    // here. Every one is read through a guard even where the client declares it
+    // required, which is the #91 decision: a declared type is a claim about what
+    // the middleware sends and not the value received.
+    return {
+      // First, because it is the field the tool exists for.
+      timezone: textOrNull(settings['timezone']),
+      keyboard_map: textOrNull(settings['kbdmap']),
+      ui_port: numberOrNull(settings['ui_port']),
+      ui_https_port: numberOrNull(settings['ui_httpsport']),
+      ui_https_redirect: booleanOrNull(settings['ui_httpsredirect']),
+      // `strictTextList` for all three lists rather than `textList`: a dropped
+      // entry here would be a claim in each case. A protocol list one entry
+      // shorter hides the old TLS version this field is read for; an address
+      // list one entry shorter understates what the web UI listens on; an
+      // allowlist one entry shorter says an address may not reach it. The #93
+      // direction rule — drop towards a claim and you must null.
+      ui_https_protocols: strictTextList(settings['ui_httpsprotocols']),
+      ui_addresses: strictTextList(settings['ui_address']),
+      ui_v6_addresses: strictTextList(settings['ui_v6address']),
+      ui_allowlist: strictTextList(settings['ui_allowlist']),
+      ui_x_frame_options: textOrNull(settings['ui_x_frame_options']),
+      ui_console_messages: booleanOrNull(settings['ui_consolemsg']),
+      ui_certificate_configured: certificateConfigured(settings['ui_certificate']),
+      // Both or neither: the second field is the only thing separating "an
+      // administrator switched this off" from "nobody has ever been asked".
+      usage_collection: booleanOrNull(settings['usage_collection']),
+      usage_collection_is_set: booleanOrNull(settings['usage_collection_is_set']),
     };
   },
 };


### PR DESCRIPTION
Adds `system_general_config`, a read-only tool over `system.general.config`.

Fixes #102

## What it reports

Fourteen fields, each read through a `common.ts` guard and named one at a time
so a field a later TrueNAS release adds cannot appear in a result without a
change here.

`timezone` leads, and most of the description is about it. The catalog renders
cron schedules into English and reports timestamps from a dozen tools, and
nothing in it said what frame any of that sat in — a user in a different
timezone from their NAS was told the wrong hour with full confidence.

Beside it: the web UI's ports, listen addresses, allowlist, HTTPS redirect,
framing policy and TLS protocol list; the console keyboard map; whether a web
UI certificate is configured; and the usage-collection pair.

## The decisions worth reading

**The timezone rule is keyed on the value's SHAPE, and it states no total.**
This took several rounds and every wrong version failed the same way, each one
level further up. The description first sorted the catalog's times into groups
named by tool, and every such list was already incomplete when written:
`describeSchedule` has three callers, `toISOString` is reached for in six files,
and two tools placed in the "already local" group also report absolute instants.
Sorting on the value fixed that — and then the fixed version said *"the catalog
reports times in three forms and every tool that reports one uses these"*, which
is a closed list of the same kind wearing a count instead of tool names, and it
was already wrong. `alerts_list` forwards `alert.datetime` unread, so the
middleware's own `{"$date": <epoch milliseconds>}` envelope can reach a caller —
this repository's own fixture uses exactly that shape for exactly that field. An
envelope is absolute, and the only rule matching it on its face was the one for
a string carrying no zone, *do not convert*: the answer backwards, in the case
the description opens by calling worse than not reading the timezone at all.

It now sorts by shape and ends open. (1) A rendered `schedule_description` is
already local and must not be converted. (2) A timestamp carrying `Z` or an
offset is absolute and must be converted into this zone. (3) A timestamp
carrying neither was passed through from the system, nothing in the catalog
establishes its frame, and it must not be converted either. (4) An object
carrying `$date` is the middleware's own representation forwarded unread, the
number is epoch milliseconds, it is absolute, and it is converted exactly as
(2) — said outright not to be (3), because carrying no `Z` is what makes it
look like one. (5) Anything else is reported as what it is with its frame
unstated, rather than sorted into the nearest form.

Rule (5) is what makes the set open by construction, which is the property the
earlier drafts kept claiming and not having. Tools are still named — under (3)
and (4), explicitly *"among them, named as examples and not as the whole set"* —
because the API declares those fields as bare strings and states no format, so
naming them tells a caller where to look while the sorting stays on the value.

**`system_info` already returns a `timezone`** and this tool is not a duplicate
of it. The string was always reachable; what was missing was any statement of
what it is the frame *for*.

**`ui_certificate` is reduced, not forwarded.** It is an open record, and
`certificates_list` is the tool for certificate detail — so it becomes
`ui_certificate_configured`, the one fact reading it establishes. Reducing it is
also what makes it survive the shape changing: `DefaultApiDirectory` declares it
an embedded record and a later directory in the same client declares it a bare
`number`, the certificate's id, so a guard written to the pinned shape alone
would have answered "could not be read" for every system on the newer release.
Both shapes are read as configured.

**Three fields are omitted.** `id` is a middleware row id. `ds_auth` is a
boolean the pinned surface documents nowhere, and reporting a guessed meaning is
worse than leaving it out — a caller cannot tell a guess from a reading.
`wizardshown` is the setup wizard's own bookkeeping. Both omissions are named in
the description so a later reader can tell them from fields nobody saw.

**`usage_collection` and `usage_collection_is_set` are reported together.** The
second is the only thing separating "an administrator switched this off" from
"nobody was ever asked".

**No verdict about the TLS protocol list**, per the #47 decision. The list is
the fact; whether accepting TLSv1 is acceptable is a claim against a standard
that lives outside this repository.

**All four `ui_` lists are nulled whole rather than shortened** when an entry
cannot be read — the #93 direction rule. A protocol list one entry short would
hide exactly the old TLS version the field is read for.

## One change outside the new tool

That all-or-nothing list guard existed twice already, as `audit_config`'s
`scopeNames` and `security_config`'s `complexityRuleset`, and this would have
been the third identical copy — the drift `common.ts` was cut to stop. Promoted
as `strictTextList` and both callers moved onto it. No behaviour changes; the
existing specs for both tools pass unmodified. `CLAUDE.md`'s #86 section now
names it and says which of the two list guards to reach for.

`CLAUDE.md`'s #93 section referred to `audit_config`'s `scopeNames` by name and
was updated for the same reason.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
locally — 1039 tests, coverage 99.7% statements / 99.38% branches against
floors of 97 and 96. Nothing in this diff needed anything this machine does not
have.

Reviewed locally with `local-review.py`, which ran the project's own reviewer in
a separate process — the same rubric and threshold as the required check — over
seven rounds. The last round found nothing at or above MEDIUM.

## What I did not change

Four LOW findings are left, deliberately:

- **`certificateConfigured` reads an empty record `{}` and a `0` as
  "configured".** The declared shapes are `record | null` and `number | null`,
  with `null` as the carrier for "no certificate" in both, so anything that is
  a record or a finite number is a certificate the system named. Treating `{}`
  or `0` as "none" would be this tool inventing a second absence marker beside
  the one the API states.
- **A `usage_collection` of `null` has no test of its own.** The pinned surface
  declares that field nullable, and the explicit null collapses into the same
  reported null as an unreadable value — which is deliberate and is what
  `usage_collection_is_set` exists to disambiguate. A test would assert the
  collapse rather than a distinction.
- **`network_config` still reads `default_routes` and `nameservers` through
  `textList`, not the newly promoted `strictTextList`.** A dropped route makes
  `gatewayReport` answer "no gateway in effect" on a system that has one, which
  is the direction rule in #93 pointing at `strictTextList` — so this is likely
  a real defect and it is in another tool, not in this one. Promoting a guard is
  not licence to change what a tool this ticket does not touch reports.
  Worth its own ticket.
- **The regression guard on the closed-set defect names a sentence rather than
  the property.** `system.spec.ts` asserts the description no longer contains
  *"the catalog reports times in three"*, which a reword to "four forms" would
  pass while reintroducing exactly the defect. The three positive assertions
  beside it — that tools are named as examples, and that the rules end on a case
  for a shape none of them describes — are what actually hold the property; the
  negative one is a guard against the specific wording that shipped. A general
  assertion would have to encode "no closed enumeration", which is not a thing a
  substring test can say.

Out of scope by the ticket's own text, and not done: restating the timezone
inside every tool that reports a timestamp, `system.advanced.config`, and the
`*_choices` methods. `alerts_list` reporting its `datetime` unread is named
above as the value form (4) exists for and is not changed here — normalizing it
would be a change to another tool's contract.
