### PR TITLE
docs(tools): correct the header comments the 4.x client bump made false

### DIFF
--- a/src/tools/certificates.ts
+++ b/src/tools/certificates.ts
@@ -7,15 +7,14 @@ import { textList, textOrNull } from '@/tools/common';
  * Certificates family: which certificates this system holds, and when each one
  * stops being valid.
  *
- * `certificate.query` answers all of it in one call, and unlike the interface
- * and network-configuration listings the pinned client TYPES the entity it
- * returns — `certificate.query` carries an `entity` in the client's own call
- * directory for the version this is written against, so `name`, `common`,
- * `san`, `from`, `until` and `expired` are read as declared fields rather than
- * guessed off a bare record the way `network.ts` has to read one. What is read
- * defensively here is the CONTENT of those fields, not their names: a date the
- * middleware formatted is still text this file has to parse, and `issuerName`
- * below is the one field with no declaration behind it at all.
+ * `certificate.query` answers all of it in one call and carries an `entity` in
+ * the client's own call directory for the version this is written against, so
+ * `name`, `common`, `san`, `from`, `until` and `expired` are read as declared
+ * fields — as the interface and network-configuration payloads are in
+ * `network.ts`. What is read defensively here is the CONTENT of those fields,
+ * not their names: a date the middleware formatted is still text this file has
+ * to parse, and `issuerName` below is the one field with no declaration behind
+ * it at all.
  *
  * The mapping is an allowlist, as in `pools.ts` and `network.ts`. A raw
  * certificate row carries the PEM certificate, its private key, the CSR, the

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1214,10 +1214,12 @@ const NOT_LISTED = 'the system did not list this pool';
 
 /**
  * A ZFS property as the middleware reports it. `pool.dataset.query` and
- * `pool.snapshot.query` both answer rows typed `Record<string, unknown>`, so the
- * parsed value has to be restated — as `storage.ts` and `snapshots.ts` each
- * restate it, and local here for the reason those files give: a tool file is
- * read on its own.
+ * `pool.snapshot.query` both declare the property object they answer with and
+ * both type its `parsed` value `unknown`, so the value still has to be restated
+ * to be read at all — as `storage.ts` and `snapshots.ts` each restate it, and
+ * local here for the reason `snapshots.ts` gives: families that happen to share
+ * ZFS's property shape read different payloads, and sharing two lines would
+ * couple them.
  */
 interface ZfsProperty {
   parsed?: unknown;

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -137,10 +137,12 @@ const MAX_LIMIT = 1000;
  */
 
 /**
- * A ZFS property as a snapshot row carries it. `pool.snapshot.query` answers
- * rows typed `Record<string, unknown>`, so every field of a property arrives as
- * `unknown` and is restated here — the same way `storage.ts` restates a
- * dataset's properties.
+ * A ZFS property as a snapshot row carries it. `pool.snapshot.query` declares
+ * the property object it answers with — `rawvalue` as a string, `parsed` as
+ * `unknown` — and both are restated `unknown` here, because a declared type is
+ * a claim about what the middleware sends rather than about the value received:
+ * the guards below are what decide whether either field is a number or a string
+ * at all. The same way `storage.ts` restates a dataset's properties.
  */
 interface SnapshotProperty {
   rawvalue?: unknown;
@@ -209,9 +211,9 @@ function stringOrNull(value: unknown): string | null {
  * One entry of a snapshot's `properties` map, or undefined where the row
  * carries no map to read it from.
  *
- * Guarded rather than asserted: `properties` arrives as `unknown` and a row
- * that sends something other than an object is exactly the case the assertion
- * would have got wrong.
+ * Guarded rather than asserted: the client declares `properties` a record, and
+ * a row that sends something other than an object is exactly the case an
+ * assertion resting on that declaration would have got wrong.
  */
 function snapshotProperty(properties: unknown, name: string): unknown {
   return typeof properties === 'object' && properties !== null

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -2,8 +2,11 @@ import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
 
-/** A ZFS property as the middleware reports it; the generated types flatten
- * these to `{}`, losing the parsed numeric value the tools surface. */
+/** A ZFS property as the middleware reports it. The client declares the property
+ * object on the dataset fields it names, but types its `parsed` value `unknown`
+ * — and the one property this file asks for that the client does NOT name
+ * reaches it through the row's index signature as `unknown` outright. Either
+ * way the value the tools surface has to be restated to be reached. */
 interface ZfsProperty {
   parsed?: unknown;
 }
@@ -69,8 +72,10 @@ export const listDatasets: ReadOnlyTool = {
       pool: dataset['pool'],
       type: dataset['type'],
       mountpoint: dataset['mountpoint'],
-      // The generated types erase the ZFS property object to `{}`, so the
-      // `parsed` field the middleware returns has to be re-stated here.
+      // The value the tools surface is the property's `parsed` field, which the
+      // client types `unknown` on the property object it declares. So it is
+      // reached through the restatement above and passed through as it arrived
+      // — this is the middleware's own value, not a number this file checked.
       used: (dataset['used'] as ZfsProperty | undefined)?.parsed,
       available: (dataset['available'] as ZfsProperty | undefined)?.parsed,
     }));
@@ -81,11 +86,13 @@ export const listDatasets: ReadOnlyTool = {
  * The numeric value of a ZFS property, or null where the middleware reported
  * none.
  *
- * Every property this tool reads is a byte count, and the generated types erase
- * the property object to `{}`, so `parsed` arrives as `unknown`: a value that
- * is not a finite number is not a byte count, whatever else it may be. Null
- * rather than a coerced zero, because a dataset whose usage could not be read
- * must not report as one using nothing.
+ * Every property this tool reads is a byte count, and `parsed` arrives as
+ * `unknown` whichever way it is reached — the client types that field `unknown`
+ * on the property object it declares, and the property named `referenced` is
+ * not a declared dataset field at all. A value that is not a finite number is
+ * not a byte count, whatever else it may be. Null rather than a coerced zero,
+ * because a dataset whose usage could not be read must not report as one using
+ * nothing.
  */
 function propertyBytes(property: unknown): number | null {
   const parsed = (property as ZfsProperty | undefined)?.parsed;
@@ -106,17 +113,20 @@ function propertyBytes(property: unknown): number | null {
  * property itself, or as its `parsed` value — on the evidence that the client
  * types this field `number | (0 | null)` on the dataset create and update
  * payloads: the API treats the two as one meaning on the side it does type.
- * The query response is typed `Record<string, unknown>` and settles nothing
- * either way, so this is a reading rather than a guarantee. Only a property
- * that is absent, that is not an object at all, or that carries no `parsed`
- * value is unreadable.
+ * The query response declares `quota` and `refquota` as property objects and
+ * types the `parsed` value inside each of them `unknown`, so it still settles
+ * nothing either way and this is a reading rather than a guarantee. Only a
+ * property that is absent, that is not an object at all, or that carries no
+ * `parsed` value is unreadable.
  */
 function quotaLimit(property: unknown): number | null {
   if (property === null) return 0;
-  // The row arrives as `unknown` and this is the only guard between it and the
-  // `in` below, which throws a TypeError on a primitive rather than answering
-  // false. A property the middleware sends as a bare number or string is not
-  // the object shape this tool reads, so it is unreadable rather than fatal.
+  // The property is read as `unknown` — the client declares it, but a declared
+  // type is a claim about what the middleware sends and not about the value
+  // received — and this is the only guard between it and the `in` below, which
+  // throws a TypeError on a primitive rather than answering false. A property
+  // the middleware sends as a bare number or string is not the object shape
+  // this tool reads, so it is unreadable rather than fatal.
   if (typeof property !== 'object') return null;
   if (!('parsed' in property)) return null;
   return (property as ZfsProperty).parsed === null ? 0 : propertyBytes(property);
@@ -199,12 +209,13 @@ export const quotaReport: ReadOnlyTool = {
         extra: {
           retrieve_children: true,
           // `referenced` is a core ZFS property and the one `refquota` caps.
-          // The client declares no dataset field at all — `pool.dataset.query`
-          // answers `Record<string, unknown>` — so asking for it by name is no
-          // less grounded than asking for `used`, and equally unconfirmed
-          // against a live middleware. One that does not return it leaves the
-          // refquota percentage null rather than computing a wrong one against
-          // `used`, which caps nothing of the sort.
+          // The client declares `used`, `quota` and `refquota` as dataset
+          // fields and does NOT declare `referenced`, which reaches this file
+          // through the row's index signature instead — so of the four names
+          // asked for here that one is the unconfirmed one, rather than all
+          // four being equally unconfirmed. A middleware that does not return
+          // it leaves the refquota percentage null rather than computing a
+          // wrong one against `used`, which caps nothing of the sort.
           properties: ['used', 'referenced', 'quota', 'refquota'],
         },
       }),

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -484,8 +484,9 @@ function jobError(run: LastRun | null): string | null {
  * the value received — so a row that carries something else reads as
  * unreadable here rather than as a string it is not. The cloud backup and
  * rsync sections reach the same kind of field through a row this file reads as
- * `unknown`, with no declaration to lean on even in principle. A task's
- * credential IS declared, with a `name` typed a string — but the middleware
+ * `unknown`, which puts whatever the client declares for those rows out of
+ * reach at that seam. A task's credential IS declared, with a `name` typed a
+ * string — but the middleware
  * also sends the id-only form, so a row that does not honour the type is the
  * case a direct read would have got wrong.
  */

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -473,18 +473,21 @@ function jobError(run: LastRun | null): string | null {
 }
 
 /**
- * One named string field of a record the pinned client's types do not describe
- * field by field, or null where the record or the field is not readable.
+ * One named string field of a record this file reads without leaning on the
+ * client's type for it, or null where the record or the field is not readable.
  *
- * Each of the three places this is used needs it for its own reason. A task's
- * `attributes` is an open record — the client types it `Record<string,
- * unknown>`, so `bucket` and `folder` arrive as `unknown`. `description` is not
- * declared on the row at all: the server sends it and the generated dump omits
- * it, the same way it omits a job's own `description`, which the client
- * corrects by hand for exactly that reason. A task's credential IS declared,
- * with a `name` typed a string — but the middleware also sends the id-only
- * form, so a row that does not honour the type is the case a direct read would
- * have got wrong.
+ * Each of the places this is used needs it for its own reason, and the reason
+ * is not that the client describes nothing: it declares a cloud sync task's
+ * `description`, and declares `bucket` and `folder` on the attributes object
+ * beside it. Every one of those is optional on its own declaration, and a
+ * declared type is a claim about what the middleware sends rather than about
+ * the value received — so a row that carries something else reads as
+ * unreadable here rather than as a string it is not. The cloud backup and
+ * rsync sections reach the same kind of field through a row this file reads as
+ * `unknown`, with no declaration to lean on even in principle. A task's
+ * credential IS declared, with a `name` typed a string — but the middleware
+ * also sends the id-only form, so a row that does not honour the type is the
+ * case a direct read would have got wrong.
  */
 function stringField(record: unknown, field: string): string | null {
   if (typeof record !== 'object' || record === null) return null;
@@ -574,9 +577,10 @@ export const cloudsyncTasksList: ReadOnlyTool = {
         description: stringField(task, 'description'),
         direction: task.direction,
         path: task.path,
-        // Named rather than passed through: `attributes` is an open record
-        // whose contents differ per provider, so a field a later TrueNAS
-        // release adds to it does not reach the caller without a change here.
+        // Named rather than passed through: `attributes` holds whatever the
+        // provider a task uses needs, and the client declares one object
+        // covering every provider, so a field a later TrueNAS release adds to
+        // it does not reach the caller without a change here.
         bucket: stringField(task.attributes, 'bucket'),
         folder: stringField(task.attributes, 'folder'),
         // The credential by id and name and nothing else — its `provider` holds
@@ -815,8 +819,9 @@ function mapCloudBackup(row: unknown): CloudBackupRow {
     id: numberOrNull(held['id']),
     description: textOrNull(held['description']),
     path: textOrNull(held['path']),
-    // Named rather than passed through: `attributes` is an open record whose
-    // contents differ per provider, as in `cloudsync_tasks_list`.
+    // Named rather than passed through, as in `cloudsync_tasks_list`:
+    // `attributes` holds whatever the provider a task uses needs, and it is
+    // reached here through a row this function reads as `unknown`.
     bucket: stringField(held['attributes'], 'bucket'),
     folder: stringField(held['attributes'], 'folder'),
     credential_id: credentialId(held['credentials']),


### PR DESCRIPTION
Closes #105.

## What this changes

Eleven comment sites across five tool files argued from a client that typed
their payloads as `Record<string, unknown>`. `@truenas/api-client` 4.0.1
declares them, so each of those sentences states something false about the
installed client — and, as the ticket puts it, a comment saying "the client
tells us nothing about this payload, so every field is read rather than
trusted" invites exactly the wrong conclusion: that the guard below it can go.

Comments and doc strings only. `git diff` touches no read, guard, normalization
or tool output.

Every corrected comment keeps a stated reason for the guard beneath it, per the
`CLAUDE.md` convention **Name a payload type off the call, never off the
entity**: a declared type is a claim about what the middleware sends, not the
value received, so it does not retire a guard. In most cases the reason
survives and only its premise moves — `parsed` is declared `unknown` on the
property objects the client now names, so a ZFS byte count still has to be
narrowed before it is reported.

| file | what was false |
|---|---|
| `storage.ts` (6 sites) | "the generated types flatten/erase the property object to `{}`"; "the query response is typed `Record<string, unknown>`"; "the row arrives as `unknown`"; and the `referenced` argument below |
| `snapshots.ts` (2) | "`pool.snapshot.query` answers rows typed `Record<string, unknown>`"; "`properties` arrives as `unknown`" |
| `reporting.ts` (1) | "`pool.dataset.query` and `pool.snapshot.query` both answer rows typed `Record<string, unknown>`" |
| `tasks.ts` (3) | "the client types [`attributes`] `Record<string, unknown>`, so `bucket` and `folder` arrive as `unknown`"; "`description` is not declared on the row at all"; "`attributes` is an open record" (twice) |
| `certificates.ts` (1) | "unlike the interface and network-configuration listings the pinned client TYPES the entity it returns … rather than guessed off a bare record the way `network.ts` has to read one" |

## One correction inverts rather than restates

`storage.ts`'s `datasets_quota_report` asks the middleware for `used`,
`referenced`, `quota` and `refquota`, on the stated ground that the client
declares no dataset field at all, so `referenced` is "no less grounded than
asking for `used`, and equally unconfirmed."

`PoolDatasetEntry` declares `used`, `quota` and `refquota` and does **not**
declare `referenced`, which reaches the file through the row's index signature
as `unknown`. So the four names are no longer equally unconfirmed — that one is
the unconfirmed one and the other three are not. The comment now says which,
and the fallback it describes (an absent `referenced` leaves the refquota
percentage null rather than computing a wrong one against `used`) is unchanged
and is doing the same work it always did.

## How the claims were checked

Against `app/node_modules/@truenas/api-client/dist/index.d.ts`, reading
`ApiCallDirectory$7` — the oldest supported directory, which is what
`DefaultApiDirectory` and therefore `ApiSurface` resolve to. Not from the list
in the ticket body, which was written against the pre-4.x tree; the dispatcher's
unblocking comment asked for exactly that re-derivation and it changed the
answer in both directions.

**Comments checked and deliberately left alone, because they are still true of
the installed client** — this is the half of the audit that produces no diff,
and it is worth naming so a later pass does not re-open it:

- `replication.ts:40` — `ReplicationEntry.state` is `{ [k: string]: unknown }`.
- `tasks.ts:374` — `CloudSyncEntry.job` is `{ [k: string]: unknown } | null`.
- `system.ts:367` — an audit entry's `event_data` is `{ [k: string]: unknown } | null`.
- `accounts.ts:82`, `accounts.ts:148` — `UserEntry.group` is `{ [k: string]: unknown }`.
- `nfs.ts:110/133/154` — `NFSGetNfs4ClientsEntry.info` and `.states` are records of `unknown`, exactly as the `#98` decision describes.
- `disks.ts:39` — `QueryOptions.extra` is still `Record<string, unknown>`.
- `pools.ts:33` — `PoolTopology` types every category `unknown[]`.
- `pools.ts:141`, `system.ts:83`, `boot.ts:84`, `common.ts:8`, `certificates.ts:140` — already written against the 4.x surface, or describing something the bump did not move. `issuer` is declared on no certificate entry in any of the eight directories.
- `vms.ts:89` and `reporting.ts:1810` say that reading a row "as a bare record" *would* compile whatever it was asked for. That is a counterfactual about the rejected alternative, not a claim about the installed client, and it argues for deriving the type off the call — which is what `CLAUDE.md` #91 requires. The ticket body predicted `reporting.ts:1813`'s argument no longer holds; on the tree as it stands it holds, and holds better than it did before the bump, so it is unchanged.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test:coverage` and `yarn build` all pass —
1039 tests across 33 files, no test expectation changed and no coverage
threshold key touched. `git -C app status --short` shows nothing new under
`app/`.

## Review

`local-review.py` ran the project's own reviewer in a separate process — the
same rubric, threshold and parser as the required check — and returned **exit
0, nothing at or above MEDIUM**, with three LOW findings. So this is the
check's own verdict rather than a subagent's fallback.

One LOW was fixed, in the second commit, under the narrow exception for a
finding that makes the diff itself wrong: `stringField`'s new comment said the
cloud backup and rsync sections have no declaration to lean on "even in
principle", and the client does declare `CloudBackupEntry.attributes` and
`RsyncTaskEntry.ssh_credentials`. Those rows are read through `rowFields`,
which takes an `unknown`, so the declarations exist and this file does not
reach them. Shipping a new false claim about client typing is precisely the
defect this PR removes, so it was not left standing. The fix is prose only and
was not re-reviewed, per the rule that the local loop ends at the clean round.

### What I did not change, and why

- **`certificates.ts:13` (LOW)** — the new header cites `network.ts` as the
  precedent for declared payloads, while `issuerName` at line 142 cites the
  same file as the precedent for reading a field off the row. One file invoked
  two ways reads oddly. Both citations are individually accurate — `network.ts`
  names its payload off the call *and* reads every field through a guard, which
  is the whole point of the #91 decision — so this is a wording improvement
  rather than a defect, and fixing it would open another review round.
- **`reporting.ts:1218` (LOW)** — the corrected comment justifies the local
  `ZfsProperty` restatement by `parsed` being declared `unknown`, but the
  interface also restates `rawvalue`, which the client declares `string` (on a
  snapshot property) and `string | null` (on a dataset property). The
  justification is incomplete rather than false: restating a declared `string`
  as `unknown` is the same "a declaration is not a guarantee" reading applied
  to a second field, and it is what lets one interface cover both payloads.
  Worth a sentence someday.

### One finding this audit turned up that is out of scope

`reporting.ts`'s `ZfsProperty` comment also carried the clause *"local here for
the reason those files give: a tool file is read on its own."* That reason was
retired by the `common.ts` decision (#86), which records that this exact
sentence *"is what produced the drift, and is no longer the rule."* Since the
sentence was being rewritten anyway, the clause now points at the reason
`snapshots.ts` actually gives — that two families sharing ZFS's property shape
read different payloads, and sharing two lines would couple them, which is a
live reason and not the retired one. Flagging it because it was made false by
#86 rather than by the client bump, so it sits just outside this ticket's
stated scope; no other instance of that retired clause survives in `src/tools/`.
