### PR TITLE
perf(tools): narrow the app family's app.query to the fields it reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,6 +661,51 @@ readable in the client, and **where two directories declare one field
 differently, a reduction that both shapes satisfy is worth more than a guard
 that matches the pinned one exactly.**
 
+### `select` narrows the read; only the allowlist bounds the result (#115)
+
+Every `app.query` call in `src/tools/` now passes a `select` naming the fields
+its mapping reads — six for `apps_list`, four for `apps_update_summary`, three
+for `reporting_app_vm_usage`. Three different lists on one method, because the
+list belongs to the CALL SITE's mapping rather than to the method: a shared one
+would ask each path for fields it has no mapping for, which is the cost this is
+removing.
+
+**It does not retire the allowlist, and reading it as a replacement is a
+credential-boundary regression.** The client's own types state why: middleware
+honours `select` on its CURRENT api version, and a client talking to a newer
+appliance over an older one gets the version-adaptation step filling in every
+non-required field's default — so a projected row comes back PADDED. Measured by
+the client's authors on a 27.0.0 appliance: over `/api/v26.0.0`, 25 of 44 query
+methods returned unrequested fields; over `/api/v27.0.0`, none did. The client's
+`MAX_SUPPORTED_VERSION` lags on purpose. An `app.query` row's `config` holds
+install-time values that routinely include an API key or a claim token, and
+padding can put it back on the wire. `select` is a bandwidth measure and the
+allowlist is the boundary; the second is not optional because the first is
+present.
+
+Two things that follow for any later projection:
+
+- **Write the options object INLINE.** The client infers the result type from
+  the options *literal* (`const O extends QueryListOptions<…>`), so a `select`
+  hoisted to a `const` widens and the rows degrade from `Pick<E, …>` to
+  `Partial<E>`. Imprecise rather than unsound — but the precision is what makes
+  the compiler catch a mapping reading a field the `select` forgot, which is the
+  only thing keeping the two in step. Same reason `reporting_app_vm_usage`
+  inlines its `virt.instance.query` filter.
+- **A projected field can be ABSENT from the row rather than null on it**, which
+  is a shape no unprojected read produces. `undefined` serializes to no key, so
+  a mapping that passes it through answers with an object missing fields the
+  description promises — see `boot.ts` on why an unread section spells its
+  fields out. `apps_list` uses `?? null` and not the `common.ts` guards on
+  purpose: the guards would additionally change what a malformed value reports,
+  and that is a change to what the tool says rather than to what it reads.
+
+**Confirm `select` against the declared type before relying on it, never against
+a passing test.** An unrecognised query parameter is dropped rather than refused,
+so a tool that silently received every field looks identical to one that worked.
+The confirmation here was `QueryOptions<T>` in the pinned client's
+`dist/index.d.ts`, reached through `DefaultApiDirectory`.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/src/tools/apps.spec.ts
+++ b/src/tools/apps.spec.ts
@@ -49,9 +49,55 @@ describe('apps_list', () => {
         image_updates_available: false,
       },
     ]);
-    // The tool reads the app list and nothing else, with no filters and no
-    // options: unlike disks_list there is no `extra` the rows depend on.
-    expect(query.mock.calls).toEqual([['app.query']]);
+    // The tool reads the app list and nothing else. No filters — every
+    // installed app is the subject — and the only option is the projection
+    // below, which names exactly the six fields the mapping above reads.
+    expect(query.mock.calls).toEqual([
+      [
+        'app.query',
+        [],
+        {
+          select: [
+            'name',
+            'version',
+            'latest_version',
+            'state',
+            'upgrade_available',
+            'image_updates_available',
+          ],
+        },
+      ],
+    ]);
+  });
+
+  it('asks for no field it does not report, and reports every field it asks for', async () => {
+    // The two halves of "names the fields its mapping reads", checked against
+    // each other rather than against a list restated in this test: a `select`
+    // that grew a field the mapping drops is bytes bought for nothing, and one
+    // that lost a field the mapping reads is a null the caller cannot explain.
+    const { ctx, query } = fakeSystem({ ['app.query']: [app({})] });
+    const [result] = (await appsList.handler(ctx, {})) as Record<string, unknown>[];
+    const [, , options] = query.mock.calls[0] as [string, unknown[], { select: string[] }];
+    expect([...options.select].sort()).toEqual(Object.keys(result).sort());
+  });
+
+  it('reads a field the projection asked for and the row does not carry as null', async () => {
+    // The failure mode `select` introduces: middleware honours it on its
+    // current api version, so a field named here can be ABSENT from the row
+    // rather than null on it. `undefined` serializes to no key, so without the
+    // fallback the caller would get an object missing fields the description
+    // promises — which reads as a different shape rather than as a null.
+    const { ctx } = fakeSystem({ ['app.query']: [{}] });
+    expect(await appsList.handler(ctx, {})).toEqual([
+      {
+        name: null,
+        version: null,
+        latest_version: null,
+        state: null,
+        upgrade_available: null,
+        image_updates_available: null,
+      },
+    ]);
   });
 
   it('surfaces neither the install-time config nor a field a later release adds', async () => {
@@ -294,6 +340,48 @@ describe('apps_update_summary', () => {
       ],
     });
     expect(call.mock.calls).toEqual([['app.upgrade_summary', ['plex']]]);
+  });
+
+  it('asks the listing for four fields, which is fewer than apps_list reads', async () => {
+    // Not the same projection as `apps_list`, and deliberately so: this tool
+    // reports neither `latest_version` from the listing nor
+    // `image_updates_available` at all, and it needs `human_version`, which
+    // `apps_list` drops. A `select` shared between the two would ask each path
+    // for fields it has no mapping for.
+    const { ctx, query } = fakeSystem({
+      ['app.query']: [app({})],
+      ['app.upgrade_summary']: summary({}),
+    });
+    await appsUpdateSummary.handler(ctx, {});
+    expect(query.mock.calls).toEqual([
+      ['app.query', [], { select: ['name', 'version', 'human_version', 'upgrade_available'] }],
+    ]);
+  });
+
+  it('reads a row carrying none of the projected fields as unknown, not as up to date', async () => {
+    // Same failure mode as `apps_list`'s, landing somewhere it matters more: a
+    // row whose `upgrade_available` is ABSENT rather than false must stay in
+    // the list saying so. Dropping it would report one fewer application as
+    // having an update waiting than the read established.
+    const { ctx, call } = perApp([{}], {});
+    expect(await appsUpdateSummary.handler(ctx, {})).toEqual({
+      unavailable: null,
+      entries: [
+        {
+          app: null,
+          unavailable:
+            'the system did not report whether an update is waiting for this application, so no ' +
+            'update summary was read',
+          installed_version: null,
+          installed_human_version: null,
+          upgrade_version: null,
+          upgrade_human_version: null,
+          latest_version: null,
+          latest_human_version: null,
+        },
+      ],
+    });
+    expect(call).not.toHaveBeenCalled();
   });
 
   it('reports neither the changelog nor the other versions available', async () => {

--- a/src/tools/apps.spec.ts
+++ b/src/tools/apps.spec.ts
@@ -82,11 +82,12 @@ describe('apps_list', () => {
   });
 
   it('reads a field the projection asked for and the row does not carry as null', async () => {
-    // The failure mode `select` introduces: middleware honours it on its
-    // current api version, so a field named here can be ABSENT from the row
-    // rather than null on it. `undefined` serializes to no key, so without the
-    // fallback the caller would get an object missing fields the description
-    // promises — which reads as a different shape rather than as a null.
+    // The failure mode `select` introduces: middleware that honours it returns
+    // the named fields and no others, so a name the release answering does not
+    // carry comes back ABSENT from the row rather than null on it. `undefined`
+    // serializes to no key, so without the fallback the caller would get an
+    // object missing fields the description promises — which reads as a
+    // different shape rather than as a null.
     const { ctx } = fakeSystem({ ['app.query']: [{}] });
     expect(await appsList.handler(ctx, {})).toEqual([
       {

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -68,10 +68,22 @@ export const appsList: ReadOnlyTool = {
     'running state, and whether an update is waiting. Apps that are not ' +
     'running are included — `state` distinguishes STOPPED from CRASHED, and ' +
     'from the transient DEPLOYING and STOPPING. `upgrade_available` means a ' +
-    'newer catalog version exists (`latest_version` names it, and is null ' +
-    'when the system does not know of one); `image_updates_available` is the ' +
-    'separate question of whether the containers the app already runs have ' +
-    'newer images, which is the only kind of update a custom app can have.',
+    'newer catalog version exists (`latest_version` names it); ' +
+    '`image_updates_available` is the separate question of whether the ' +
+    'containers the app already runs have newer images, which is the only ' +
+    'kind of update a custom app can have. EVERY FIELD IS NULL WHERE THE ' +
+    'SYSTEM REPORTED NO VALUE FOR IT, and A NULL IS NEVER TO BE READ AS THE ' +
+    'NEGATIVE. A null `upgrade_available` or `image_updates_available` means ' +
+    'NOTHING WAS ESTABLISHED about that kind of update; it is not the claim ' +
+    'that none is waiting, which is FALSE. `latest_version` is null both ' +
+    'where the system knows of no newer version and where it reported none, ' +
+    'and this tool does not tell those two apart. A null `name`, `version` ' +
+    'or `state` is the system having reported no value under that name, and ' +
+    'a null `state` is NOT an app that is stopped. An app is never left out ' +
+    'of the list for carrying one, so a null never shortens this list. THERE ' +
+    'IS NO PARTIAL ANSWER HERE: the listing either succeeds or this tool ' +
+    'fails, so a null is always about one field of one app rather than about ' +
+    'a read that did not happen.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -50,6 +50,15 @@ import { booleanOrNull, errorText, recordOrNull, textOrNull } from '@/tools/comm
  * claim token, so naming the output fields is what keeps them out of the tool
  * result and so out of the conversation, exactly as in `disks.ts`. Trimming is
  * the point of the tool rather than a nicety, on both counts.
+ *
+ * The query also names those fields, so the size job now starts at the wire
+ * rather than at the mapping (#115). THAT DOES NOT RETIRE THE ALLOWLIST, and
+ * the reason is in the client's own types: middleware honours `select` on its
+ * CURRENT api version, and a client talking to a newer appliance over an older
+ * version gets every non-required field's default filled back in. So a
+ * projected row can arrive padded — with `config` on it — and the allowlist is
+ * what keeps it out of the result either way. `select` narrows the read; only
+ * the mapping bounds what a caller sees.
  */
 
 export const appsList: ReadOnlyTool = {
@@ -67,19 +76,47 @@ export const appsList: ReadOnlyTool = {
   requiredRole: Role.ReadOnly,
   mutating: false,
   async handler({ system }) {
-    const apps = await firstValueFrom(system.client.api.query('app.query'));
+    // The options object is written INLINE, as the filter in
+    // `reporting_app_vm_usage` is: the client infers the result type from the
+    // options *literal*, so a `select` hoisted to a `const` widens and the rows
+    // degrade from `Pick<AppEntry, …>` to `Partial<AppEntry>`. Imprecise rather
+    // than unsound, but it would stop the compiler catching a field this
+    // mapping reads and the select forgot.
+    const apps = await firstValueFrom(
+      system.client.api.query('app.query', [], {
+        select: [
+          'name',
+          'version',
+          'latest_version',
+          'state',
+          'upgrade_available',
+          'image_updates_available',
+        ],
+      }),
+    );
     return apps.map((app) => ({
-      name: app.name,
+      // `?? null` on every field, because a projection is the one read where a
+      // field this tool names can be absent from the row rather than null on
+      // it — a `select` middleware does not honour, or a field a later release
+      // drops. `undefined` serializes to no key at all, so without it a caller
+      // would get an object missing fields the description promises instead of
+      // nulls it can see are absent, which is the reason `boot.ts` spells out
+      // an unread section's fields rather than leaving them off.
+      //
+      // It is `?? null` and not `textOrNull`: this ticket is bandwidth, and a
+      // guard would additionally change what a malformed value reports, which
+      // is a change to what the tool says.
+      name: app.name ?? null,
       // The catalog version of the app as installed. `human_version` is the
       // middleware's display string for the same thing and is deliberately
       // not surfaced: it splices the upstream software's version onto this
       // one, so the two read as disagreeing, and only `version` is comparable
       // with `latest_version`.
-      version: app.version,
-      latest_version: app.latest_version,
-      state: app.state,
-      upgrade_available: app.upgrade_available,
-      image_updates_available: app.image_updates_available,
+      version: app.version ?? null,
+      latest_version: app.latest_version ?? null,
+      state: app.state ?? null,
+      upgrade_available: app.upgrade_available ?? null,
+      image_updates_available: app.image_updates_available ?? null,
     }));
   },
 };
@@ -236,8 +273,20 @@ export const appEngineStatus: ReadOnlyTool = {
   },
 };
 
-/** An application as `app.query` reports it. */
-type AppEntry = ApiSurface['call']['app.query']['entity'];
+/**
+ * An application as `app.query` reports it, narrowed to the fields
+ * {@link candidateOf} reads — which are the fields the call's `select` names.
+ *
+ * The two are kept in step by the compiler rather than by hand: the handler
+ * passes these rows straight to `candidateOf`, so a `select` that stops naming
+ * one of them stops type-checking. The other direction — a `select` naming more
+ * than this reads — is wasted bytes rather than a wrong answer, and nothing
+ * catches it.
+ */
+type AppEntry = Pick<
+  ApiSurface['call']['app.query']['entity'],
+  'name' | 'version' | 'human_version' | 'upgrade_available'
+>;
 
 /**
  * One application's waiting update, or the stated reason none was read.
@@ -426,7 +475,18 @@ export const appsUpdateSummary: ReadOnlyTool = {
   async handler({ system }) {
     let candidates: Candidate[];
     try {
-      const rows = await firstValueFrom(system.client.api.query('app.query'));
+      // Four fields, which is fewer than `apps_list` reads: the mapping here
+      // deliberately does not report the changelog or the other versions
+      // available, so this call has no business asking for them. A `select`
+      // derived from a list shared with `apps_list` would ask for two fields
+      // nothing on this path reads.
+      //
+      // Written inline for the reason `apps_list` gives above.
+      const rows = await firstValueFrom(
+        system.client.api.query('app.query', [], {
+          select: ['name', 'version', 'human_version', 'upgrade_available'],
+        }),
+      );
       if (!Array.isArray(rows)) return { unavailable: NOT_A_LIST, entries: null };
       // Chosen inside the `try` with the read that produced them, so a row that
       // cannot be reached into at all — a null or an undefined in the list — is

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -109,11 +109,17 @@ export const appsList: ReadOnlyTool = {
     return apps.map((app) => ({
       // `?? null` on every field, because a projection is the one read where a
       // field this tool names can be absent from the row rather than null on
-      // it — a `select` middleware does not honour, or a field a later release
-      // drops. `undefined` serializes to no key at all, so without it a caller
+      // it: middleware HONOURING the select returns those fields and no
+      // others, so a name that is not a field on the release answering — one a
+      // later release drops, or renames — comes back as no key at all. Not
+      // honouring it is the opposite failure and needs no fallback: an
+      // unrecognised parameter is dropped rather than refused, and the row
+      // arrives whole.
+      //
+      // `undefined` serializes to no key, so without the fallback a caller
       // would get an object missing fields the description promises instead of
-      // nulls it can see are absent, which is the reason `boot.ts` spells out
-      // an unread section's fields rather than leaving them off.
+      // nulls it can see are absent — the reason `boot.ts` spells out an
+      // unread section's fields rather than leaving them off.
       //
       // It is `?? null` and not `textOrNull`: this ticket is bandwidth, and a
       // guard would additionally change what a malformed value reports, which
@@ -487,11 +493,13 @@ export const appsUpdateSummary: ReadOnlyTool = {
   async handler({ system }) {
     let candidates: Candidate[];
     try {
-      // Four fields, which is fewer than `apps_list` reads: the mapping here
-      // deliberately does not report the changelog or the other versions
-      // available, so this call has no business asking for them. A `select`
-      // derived from a list shared with `apps_list` would ask for two fields
-      // nothing on this path reads.
+      // Four fields, and NOT the six `apps_list` asks for. The lists overlap
+      // without either containing the other: `candidateOf` never reads
+      // `latest_version` or `image_updates_available` — the newest catalog
+      // version this tool reports comes from `app.upgrade_summary` rather than
+      // from the listing — and it does read `human_version`, which `apps_list`
+      // deliberately drops. A `select` shared between the two paths would ask
+      // each of them for fields it has no mapping for.
       //
       // Written inline for the reason `apps_list` gives above.
       const rows = await firstValueFrom(

--- a/src/tools/reporting-app-vm-usage.spec.ts
+++ b/src/tools/reporting-app-vm-usage.spec.ts
@@ -178,9 +178,9 @@ describe('reporting_app_vm_usage', () => {
   });
 
   it('reads an app row carrying none of the projected fields as nulls, not as absent keys', async () => {
-    // A `select` middleware does not honour, or a field a later release drops,
-    // both arrive as a row without the key. The row still has to answer with
-    // every field the description promises.
+    // A projection honoured against a release that does not carry one of the
+    // names — dropped or renamed since — arrives as a row without the key.
+    // The entry still has to answer with every field the description promises.
     const [entry] = await entries({ apps: [{}], vms: [], instances: [] });
     expect(entry).toEqual({
       kind: 'app',

--- a/src/tools/reporting-app-vm-usage.spec.ts
+++ b/src/tools/reporting-app-vm-usage.spec.ts
@@ -162,6 +162,39 @@ describe('reporting_app_vm_usage', () => {
     });
   });
 
+  it('asks the app listing for the three fields it reports, and nothing else', async () => {
+    // Neither figure this tool reports is readable from an app row, so an app
+    // contributes an identifier, a name and a state and nothing more — while
+    // the row it comes from is the bulkiest in the catalog. The other two
+    // listings are unprojected: a VM row's `status` and `devices` are read, and
+    // narrowing them is not this ticket's subject.
+    const fake = usageSystem();
+    await reported(fake);
+    expect(fake.query.mock.calls).toContainEqual([
+      'app.query',
+      [],
+      { select: ['id', 'name', 'state'] },
+    ]);
+  });
+
+  it('reads an app row carrying none of the projected fields as nulls, not as absent keys', async () => {
+    // A `select` middleware does not honour, or a field a later release drops,
+    // both arrive as a row without the key. The row still has to answer with
+    // every field the description promises.
+    const [entry] = await entries({ apps: [{}], vms: [], instances: [] });
+    expect(entry).toEqual({
+      kind: 'app',
+      source: 'app',
+      id: null,
+      name: null,
+      state: null,
+      cpu_percent: null,
+      cpu_unavailable: expect.stringContaining('subscription'),
+      memory_used_bytes: null,
+      memory_unavailable: expect.stringContaining('subscription'),
+    });
+  });
+
   it('reads a running libvirt VM by its own id, so two VMs do not share one figure', async () => {
     const fake = usageSystem({
       apps: [],

--- a/src/tools/reporting.ts
+++ b/src/tools/reporting.ts
@@ -1815,8 +1815,13 @@ const NO_MEMORY_FIGURE = 'the system answered with no memory figure this tool co
  * as bare records the field names below would compile whatever they were asked
  * for, so a regenerated client that renames one would turn its value into a null
  * with no build error and with hand-written fixtures that still pass.
+ *
+ * The app row is narrowed to the three fields {@link fromApp} reads, matching
+ * the `select` its listing now names (#115). The narrowing is what keeps the two
+ * in step: drop a field from that `select` and this stops compiling, because the
+ * rows no longer satisfy `fromApp`.
  */
-type AppEntry = ApiSurface['call']['app.query']['entity'];
+type AppEntry = Pick<ApiSurface['call']['app.query']['entity'], 'id' | 'name' | 'state'>;
 type VmEntry = ApiSurface['call']['vm.query']['entity'];
 type VirtInstanceEntry = ApiSurface['call']['virt.instance.query']['entity'];
 
@@ -2038,7 +2043,15 @@ export const reportingAppVmUsage: ReadOnlyTool = {
     // All three listings are issued before any is awaited, and each is caught:
     // see `listing` for why none of them may fail the tool.
     const [apps, vms, instances] = await Promise.all([
-      listing('app', () => firstValueFrom(system.client.api.query('app.query'))),
+      // Three fields, which is every one `fromApp` reads — neither figure this
+      // tool reports is readable from an app row at all, so the rest of a row
+      // that is the catalog's bulkiest never needs to cross the wire. Written
+      // inline for the same reason the `virt.instance.query` filter below is.
+      listing('app', () =>
+        firstValueFrom(
+          system.client.api.query('app.query', [], { select: ['id', 'name', 'state'] }),
+        ),
+      ),
       listing('vm', () => firstValueFrom(system.client.api.query('vm.query'))),
       listing('virt_instance', () =>
         firstValueFrom(


### PR DESCRIPTION
Closes #115.

All three `app.query` calls in `src/tools/` were issued unprojected: each read
back the whole row — the app's full chart metadata, its rendered portals,
`active_workloads` (every container, port and volume) and the install-time
`config` — in order to map four to six named fields out of it. Each call now
passes a `select` naming exactly what its own mapping reads.

| call site | tool | fields |
|---|---|---|
| `apps.ts` | `apps_list` | `name`, `version`, `latest_version`, `state`, `upgrade_available`, `image_updates_available` |
| `apps.ts` | `apps_update_summary` | `name`, `version`, `human_version`, `upgrade_available` |
| `reporting.ts` | `reporting_app_vm_usage` | `id`, `name`, `state` |

Three lists rather than one shared list. They overlap without either containing
another: `apps_update_summary` never reads `latest_version` or
`image_updates_available` and does read `human_version`, which `apps_list`
drops; `reporting_app_vm_usage` reads neither figure it reports from an app row
at all, so three fields is the whole of its interest in the catalog's bulkiest
record. A shared list would ask each path for fields it has no mapping for,
which is the cost this change exists to remove.

## The fourth acceptance criterion, run first

**`select` is confirmed on the pinned surface by the declared type, not by a
passing test.** `QueryOptions<T>` (`dist/index.d.ts:44`) declares
`select?: QueryFilterField<T>[]` — "Return only these fields." `app.query`
takes it at `dist/index.d.ts:10024`, inside `ApiCallDirectory$7`, which is what
`DefaultApiDirectory` resolves to (`dist/index.d.ts:30369`). The criterion is
right that a test could not have established this: an unrecognised query
parameter is dropped rather than refused, so a tool silently receiving every
field looks identical to one that worked.

The projection is also load-bearing at the type level, which is what keeps each
`select` in step with its mapping. With an inline options literal the client
returns `Pick<AppEntry, …>` rather than `AppEntry`, so a `select` that stops
naming a field its mapping reads stops compiling. The options object is written
inline for exactly that reason — hoisted to a `const` it widens, the rows
degrade to `Partial<AppEntry>`, and the check is lost. This is the same reason
`reporting_app_vm_usage` already inlines its `virt.instance.query` filter.

## What this does NOT do, and the reason is not incidental

**The allowlist mappings all stay, and `select` does not retire them.** The
client's own types state why: middleware honours `select` on its *current* API
version, and a client talking to a newer appliance over an older one gets the
version-adaptation step filling in every non-required field's default — so a
projected row can come back **padded**. Measured by the client's authors on a
27.0.0 appliance, same box and credentials: over `/api/v26.0.0`, 25 of 44 query
methods returned unrequested fields; over `/api/v27.0.0`, none did. The client's
`MAX_SUPPORTED_VERSION` lags on purpose.

Two things follow, and the second is the one worth being explicit about:

1. **The bandwidth win is real but not guaranteed.** It depends on the
   negotiated version matching the appliance. On a system where it does not,
   this change is a no-op on the wire rather than a regression.
2. **`config` holds install-time values that routinely include an API key or a
   claim token.** Padding can put it back on the wire. `select` narrows the
   read; only the mapping bounds what a caller sees. Treating the projection as
   a replacement for the allowlist would be a credential-boundary regression,
   so this is recorded as a decision in `CLAUDE.md` rather than left for a
   later cycle to infer.

## `apps_list` gained `?? null`, and its description gained what a null means

A projection is the one read where a field the tool names can be **absent from
the row** rather than null on it: middleware honouring the select returns those
fields and no others, so a name the answering release does not carry — dropped
or renamed since — comes back as no key at all. `undefined` serializes to no
key, so passing it through would answer with an object missing fields the
description promises, which is the shape `boot.ts` spells its unread sections
out to avoid.

It is `?? null` and not the `common.ts` guards deliberately. The guards would
additionally change what a *malformed* value reports, and that is a change to
what the tool says rather than to what it reads — out of scope by this ticket's
own Scope section.

Round 1's review found the consequence, correctly rated MEDIUM: `?? null` made
every field nullable while the description defined a null only for
`latest_version` and called `upgrade_available` a boolean, so a null read as
false — the claim that no update is waiting. The description now states what a
null means on each field, says outright that a null `upgrade_available` or
`image_updates_available` is **not** `FALSE`, states the two answers
`latest_version`'s null now covers, and says there is no partial answer here
(this listing either succeeds or the tool fails, so a null is always about one
field of one app).

## Acceptance criteria

- [x] Every `app.query` call in `src/tools/` names the fields its mapping reads
      — all three, tabulated above.
- [x] A field named in a `select` and absent from the response reads as null
      rather than throwing, with a test covering it — three tests, one per call
      site: `apps_list` and `reporting_app_vm_usage` map a `{}` row to a full
      set of nulls, and `apps_update_summary` keeps such a row in `entries`
      saying its update state was not read rather than dropping it, which would
      report one fewer app as having an update waiting than the read
      established.
- [x] The tool results are unchanged — see the note below on the one expectation
      that did change, which is not a result one.
- [x] Whether `select` is honoured on the pinned surface is confirmed against
      the client's declared type — above.
- [x] `yarn lint && yarn typecheck && yarn test && yarn test:coverage` clean.
      1045 tests, 33 files; `apps.ts` and `reporting.ts` both at 100%
      statements and branches. Every gating job in `.github/workflows/ci.yml`
      was run locally.

## One existing expectation changed, and it is not a result one

Reporting this rather than quietly folding it in, per the dispatcher's note on
#115.

`apps.spec.ts` asserted `expect(query.mock.calls).toEqual([['app.query']])`,
with the comment "no filters and no options". That is a **call-shape**
assertion, and changing the call shape is this ticket's entire subject — the
criterion it sits under is about tool *results* being byte-identical, which
they are. It now asserts the projected call. No expectation about any tool's
output was modified anywhere; `reporting-app-vm-usage.spec.ts`'s expectations
are untouched, as are `apps.spec.ts`'s result assertions.

If that reading of the criterion is wrong, the finding is that the criterion
and the change are incompatible as written — a `select` cannot be added to a
call whose exact arguments a test pins.

## Review

Two local rounds against the shared reviewer, $4.93 total. Round 1 returned the
MEDIUM described above; round 2 came back clean at MEDIUM and above, with two
LOWs.

**Both LOWs were fixed** rather than carried, because both were factually wrong
statements in comments this PR introduced — not polish:

- The `?? null` comment gave "a `select` middleware does not honour" as a cause
  of an absent field. That is the opposite failure — an unrecognised parameter
  is dropped rather than refused, so the row arrives whole. Left in, it would
  have taught the next reader the mechanism backwards.
- `apps_update_summary`'s select comment justified its four fields by the
  changelog and other-versions list, which are `app.upgrade_summary` fields and
  were never on an `app.query` row.

Both fixes are comment-only; no executable line changed, and all four gates were
re-run after them.

## Not changed, and offered as a finding

The round-2 review also noted that `system_jobs_list` (`tasks.ts`) is this
repository's other `select` projection and maps `job.id` and `job.method` raw,
so it does not follow the absent-field rule this PR writes into `CLAUDE.md`.
That is accurate and it predates this ticket — `tasks.ts` is outside the app
family and outside this ticket's scope, so it is left alone. It is worth a
ticket of its own: the same projection means a name that release does not carry
would drop the key from a `system_jobs_list` entry rather than null it.
