### PR TITLE
feat(tools): add alerts_dismiss and alerts_restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -727,12 +727,19 @@ call is made whatever the read said — including where the read failed, and whe
 it completed and listed no alert with that uuid. That is what keeps `execute` a
 pure function of (args, system), which is the property the confirmation token
 depends on: skipping the mutation for an alert the read no longer lists would be
-branching on state the token cannot bind. The three readings are reported as
-`lookup` (`FOUND` / `NOT_FOUND` / `UNREADABLE`) beside a `previously_dismissed`
-and a `changed` that are both null in the last two, and the description says
-outright that under those two the tool cannot say whether anything moved. The
-alternative — failing the call when the reporting read fails — would throw away
-an approval the user has already given for a mutation that is still safe.
+branching on state the token cannot bind. The alternative — failing the call
+when the reporting read fails — would throw away an approval the user has
+already given for a mutation that is still safe.
+
+**A three-valued account of a read does not enumerate a four-valued outcome, and
+the description has to say so.** `lookup` reports what the read did — `FOUND`,
+`NOT_FOUND`, `UNREADABLE` — while `previously_dismissed` and `changed` are null
+under the last two AND under `FOUND` where the alert stated no `dismissed` this
+tool could read as a boolean. Three values, four causes: the descriptions name
+the fourth explicitly and say that `lookup` alone does not tell them apart. A
+status field named for one half of an outcome will not partition the other half,
+and claiming it does is the house's most common review finding wearing a
+different hat.
 
 **Already-in-the-target-state is not an error, and saying which it was is the
 tool's job.** Most alerts on a running system are already dismissed; the plan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -706,6 +706,66 @@ so a tool that silently received every field looks identical to one that worked.
 The confirmation here was `QueryOptions<T>` in the pinned client's
 `dist/index.d.ts`, reached through `DefaultApiDirectory`.
 
+### A plan names the read `execute` makes, or the plan is not true (#119)
+
+`alerts_dismiss` and `alerts_restore` are the second and third mutating tools,
+and their plans return **two** steps — `alert.list`, then the mutation — where
+`snapshots_create` returns one. The difference is not the tool being more
+careful. It is where the read happens: `snapshots_create` reads at PLAN time
+(`assertDatasetExists`) and deliberately does not re-read at execute time, so its
+one step is the whole of what `execute` calls. These two must report whether the
+alert had ALREADY been dismissed, which is a fact only readable immediately
+before the call — so `execute` reads, and a plan naming only the mutation would
+be a plan that omits a call the user is approving.
+
+**A `PlanStep` is a call `execute` will make, not a summary of the change.** Ask
+what `execute` calls and name all of it; a read step says outright that it
+changes nothing.
+
+**The read is issued unconditionally and nothing branches on it.** The mutating
+call is made whatever the read said — including where the read failed, and where
+it completed and listed no alert with that uuid. That is what keeps `execute` a
+pure function of (args, system), which is the property the confirmation token
+depends on: skipping the mutation for an alert the read no longer lists would be
+branching on state the token cannot bind. The three readings are reported as
+`lookup` (`FOUND` / `NOT_FOUND` / `UNREADABLE`) beside a `previously_dismissed`
+and a `changed` that are both null in the last two, and the description says
+outright that under those two the tool cannot say whether anything moved. The
+alternative — failing the call when the reporting read fails — would throw away
+an approval the user has already given for a mutation that is still safe.
+
+**Already-in-the-target-state is not an error, and saying which it was is the
+tool's job.** Most alerts on a running system are already dismissed; the plan
+says which of the two it is about to do, and the result reports the state read
+immediately before the call. A mutating tool whose no-op is indistinguishable
+from its effect gives a caller nothing to act on.
+
+### The identifier a mutating tool takes is the one its method takes (#119)
+
+`alert.dismiss` and `alert.restore` take a `uuid`; the middleware's alert
+declares `uuid` and `id` as two separate required fields; and `alerts_list`
+reported only `id`, so **there was no way for a caller to name the alert the API
+wants**. The fix was to grow `alerts_list` a field, deliberately rather than as a
+side effect: it is reported BESIDE `id` and not instead of it, and the
+description states what it is for and that it is per-system.
+
+**Growing a read-only tool a field to make a mutating tool reachable is a change
+to that tool's contract**, so it is stated in that tool's description and tested
+there. What made it safe to do was #44's rule holding in the other direction:
+`system_health_report` composes `alertsList.handler` and re-reads every field
+through its own guard by name, so a field `alerts_list` grows does not reach the
+composite — checked rather than assumed before the field was added.
+
+**Do not key a tool on an identifier that is not per-system.** The ticket's live
+reading — the same `id` coming back from two different systems for one
+`CertificateExpired`/`freenas_default` condition — is why `id` is refused here: a
+tool keyed on it is ambiguous under the fan-out, which is the normal way these
+tools run. That reading was **not reproducible from this repository** (no live
+system in the test environment). What is confirmed is the surface: two declared
+fields, and a method whose parameter is the first of them. The description states
+the rule the surface supports — `uuid` is what these tools take, read it from the
+system being targeted — rather than an account of why the two differ.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `reporting_utilisation`, `reporting_disk_io`, `reporting_space_trends`,
   `reporting_app_vm_usage`, `services_status`, `ha_status`,
   `system_health_report`, `fleet_compliance_report`, `fleet_health_rollup`.
+  Mutating family, all of them two-phase plan/confirm and all
+  `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
+  `alerts_restore`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).
@@ -39,7 +42,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
 - **Plan/confirm** — mutating tools are two-phase: phase one returns a plan
   (the exact API calls to be made), phase two executes only with a single-use,
   expiring confirmation token bound to the plan's tool + arguments + targets.
-  Exercised end to end by `snapshots_create`.
+  Exercised end to end by `snapshots_create`, `alerts_dismiss` and
+  `alerts_restore`.
 - **Bounded file content** — an optional `SystemHandle.files` reader giving a
   tool the last N lines of a path on one system, over `core.download` and an
   adapter-supplied `ContentFetcher`. The line and byte bounds are enforced on

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,4 +126,6 @@ export {
   fleetComplianceReport,
   fleetHealthRollup,
   createSnapshot,
+  alertsDismiss,
+  alertsRestore,
 } from '@/tools/index';

--- a/src/tools/alerts.spec.ts
+++ b/src/tools/alerts.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { ToolCatalog } from '@/catalog/catalog';
+import { MutatingTool, SystemHandle } from '@/catalog/tool';
+import { ConfirmationService } from '@/execution/confirmation';
+import { ToolExecutor } from '@/execution/executor';
+import { Role } from '@/interfaces';
+import { SystemRegistry } from '@/registry/system-registry';
 import { fakeSystem, failingSystem } from '@/testing/fake-systems';
-import { alertSettings, alertsList } from '@/tools/index';
+import { alertsDismiss, alertSettings, alertsList, alertsRestore } from '@/tools/index';
 
 describe('alerts_list', () => {
   // Every property the middleware's Alert carries, so the assertions below show
@@ -28,6 +34,7 @@ describe('alerts_list', () => {
     const { ctx, call } = fakeSystem({ ['alert.list']: [alert({})] });
     expect(await alertsList.handler(ctx, {})).toEqual([
       {
+        uuid: 'u1',
         id: 'a1',
         klass: 'ZpoolCapacityWarning',
         level: 'WARNING',
@@ -46,6 +53,7 @@ describe('alerts_list', () => {
     });
     const [result] = (await alertsList.handler(ctx, {})) as Record<string, unknown>[];
     expect(Object.keys(result)).toEqual([
+      'uuid',
       'id',
       'klass',
       'level',
@@ -53,6 +61,15 @@ describe('alerts_list', () => {
       'datetime',
       'dismissed',
     ]);
+  });
+
+  it('reports the uuid the mutating pair takes, beside the id it does not', async () => {
+    // The two are separate required fields of the middleware's alert, and only
+    // `uuid` addresses one alert on one system — so both are reported and the
+    // description says which of them `alerts_dismiss` accepts.
+    const { ctx } = fakeSystem({ ['alert.list']: [alert({ uuid: 'u9', id: 'a9' })] });
+    const [row] = (await alertsList.handler(ctx, {})) as Record<string, unknown>[];
+    expect(row).toMatchObject({ uuid: 'u9', id: 'a9' });
   });
 
   it('returns dismissed alerts, distinguishable by the boolean', async () => {
@@ -324,5 +341,249 @@ describe('alert_settings', () => {
     await alertSettings.handler(ctx, {});
     expect(query).toHaveBeenCalledWith('alertservice.query');
     expect(call).toHaveBeenCalledWith('alertclasses.config');
+  });
+});
+
+describe('alerts_dismiss and alerts_restore', () => {
+  /** One alert as `alert.list` sends it, with the four fields these tools read. */
+  const alert = (over: Record<string, unknown> = {}) => ({
+    uuid: 'u1',
+    id: 'a1',
+    klass: 'ZpoolCapacityWarning',
+    level: 'WARNING',
+    formatted: 'Pool tank is 85% full.',
+    datetime: '2026-08-28T12:00:00+00:00',
+    dismissed: false,
+    ...over,
+  });
+
+  /** A system listing those alerts, whose dismiss and restore both succeed. */
+  const system = (alerts: unknown[] = [alert()]) =>
+    fakeSystem({
+      ['alert.list']: alerts,
+      ['alert.dismiss']: null,
+      ['alert.restore']: null,
+    });
+
+  /** The mutating step of a plan, which is the second of the two. */
+  const mutationStep = async (tool: MutatingTool, alerts: unknown[] = [alert()]) =>
+    (await tool.plan(system(alerts).ctx, { uuid: 'u1' }))[1];
+
+  const both: [string, MutatingTool][] = [
+    ['alerts_dismiss', alertsDismiss],
+    ['alerts_restore', alertsRestore],
+  ];
+
+  describe.each(both)('%s', (name, tool) => {
+    it('is a reversible mutating tool needing the full role', () => {
+      expect(tool).toMatchObject({
+        name,
+        mutating: true,
+        destructiveness: 'reversible',
+        requiredRole: Role.Full,
+      });
+    });
+
+    it('normalizes args: keeps the uuid and drops unknown keys', () => {
+      expect(tool.normalizeArgs?.({ uuid: 'u1', extra: 1, systems: 'all' })).toEqual({
+        uuid: 'u1',
+      });
+    });
+
+    it('requires a non-empty string uuid, in normalizeArgs and in plan', async () => {
+      const { ctx } = system();
+      for (const bad of [undefined, null, '', 7, ['u1']]) {
+        expect(() => tool.normalizeArgs?.({ uuid: bad })).toThrow(/"uuid" is required/);
+        await expect(tool.plan(ctx, { uuid: bad })).rejects.toThrow(/"uuid" is required/);
+      }
+    });
+
+    it('plans the read it makes as well as the mutation it makes', async () => {
+      const steps = await tool.plan(system().ctx, { uuid: 'u1' });
+      // Two steps because `execute` makes two calls. A plan naming only the
+      // mutation would not be a true account of what runs.
+      expect(steps.map((step) => step.method)).toEqual(['alert.list', tool.name.replace('alerts_', 'alert.')]);
+      expect(steps[0]).toMatchObject({ params: [] });
+      expect(steps[0].description).toMatch(/Changes nothing/);
+      expect(steps[1]).toMatchObject({ params: ['u1'] });
+    });
+
+    it('names the alert by level, class and message rather than only by uuid', async () => {
+      const step = await mutationStep(tool);
+      expect(step.description).toContain('level WARNING');
+      expect(step.description).toContain('class ZpoolCapacityWarning');
+      expect(step.description).toContain('message "Pool tank is 85% full."');
+      expect(step.description).toContain('uuid u1');
+    });
+
+    it('states a level, class or message the system reported as absent', async () => {
+      // Dropping one silently would read as an alert that has none, and the
+      // person approving the plan could not tell which.
+      const step = await mutationStep(tool, [
+        alert({ level: '', klass: null, formatted: null }),
+      ]);
+      expect(step.description).toContain('level (the system reported none)');
+      expect(step.description).toContain('class (the system reported none)');
+      expect(step.description).toContain('message (the system reported none)');
+    });
+
+    it('says so rather than claiming a change when the state cannot be read', async () => {
+      const step = await mutationStep(tool, [alert({ dismissed: 'yes' })]);
+      expect(step.description).toContain(
+        'Whether it is dismissed could not be read, so this may change nothing.',
+      );
+    });
+
+    it('fails the plan for a uuid no alert matches, naming the uuid supplied', async () => {
+      await expect(tool.plan(system([]).ctx, { uuid: 'gone' })).rejects.toThrow(
+        'No alert with uuid "gone" on this system',
+      );
+    });
+
+    it('does not accept the id alerts_list also reports', async () => {
+      // `id` is stable across systems for one condition, so a tool keyed on it
+      // would be ambiguous under the fan-out. Planning on one has to fail.
+      await expect(tool.plan(system().ctx, { uuid: 'a1' })).rejects.toThrow(
+        'No alert with uuid "a1" on this system',
+      );
+    });
+
+    it('executes exactly the two calls the plan named, in that order', async () => {
+      const { ctx, call } = system();
+      await tool.execute(ctx, { uuid: 'u1' });
+      expect(call.mock.calls).toEqual([
+        ['alert.list'],
+        [tool.name.replace('alerts_', 'alert.'), ['u1']],
+      ]);
+    });
+
+    it('still makes the call when the alert is no longer listed', async () => {
+      // It cleared between the plan and the confirmation. Skipping the call
+      // would be `execute` branching on state read at execution time.
+      const { ctx, call } = system([]);
+      expect(await tool.execute(ctx, { uuid: 'u1' })).toEqual({
+        uuid: 'u1',
+        lookup: 'NOT_FOUND',
+        lookup_error: null,
+        previously_dismissed: null,
+        changed: null,
+      });
+      expect(call).toHaveBeenCalledWith(tool.name.replace('alerts_', 'alert.'), ['u1']);
+    });
+
+    it('still makes the call when the state read fails, and names why', async () => {
+      const { ctx, call } = failingSystem(
+        { ['alert.dismiss']: null, ['alert.restore']: null },
+        { ['alert.list']: new Error('connection reset') },
+      );
+      expect(await tool.execute(ctx, { uuid: 'u1' })).toEqual({
+        uuid: 'u1',
+        lookup: 'UNREADABLE',
+        lookup_error: 'connection reset',
+        previously_dismissed: null,
+        changed: null,
+      });
+      expect(call).toHaveBeenCalledWith(tool.name.replace('alerts_', 'alert.'), ['u1']);
+    });
+
+    it('reports a prior state it could not read as null rather than as unchanged', async () => {
+      expect(
+        await tool.execute(system([alert({ dismissed: null })]).ctx, { uuid: 'u1' }),
+      ).toMatchObject({ lookup: 'FOUND', previously_dismissed: null, changed: null });
+    });
+
+    it('executes only against a confirmation token minted from its own plan', async () => {
+      const { ctx, call } = system();
+      const registry = new SystemRegistry();
+      registry.add(ctx.system as SystemHandle);
+      const catalog = new ToolCatalog();
+      catalog.register(tool);
+      const confirmations = new ConfirmationService();
+      const executor = new ToolExecutor({ catalog, registry, confirmations });
+
+      const first = await executor.execute(tool.name, { uuid: 'u1' });
+      expect(first.type).toBe('PLAN');
+      // The plan phase reads; nothing has mutated.
+      expect(call.mock.calls).toEqual([['alert.list']]);
+
+      await expect(
+        executor.execute(tool.name, { uuid: 'u1', confirmation_token: 'forged' }),
+      ).rejects.toThrow();
+      expect(call.mock.calls).toEqual([['alert.list']]);
+
+      const token = confirmations.mint(first.type === 'PLAN' ? first.key : '');
+      const confirmed = await executor.execute(tool.name, {
+        uuid: 'u1',
+        confirmation_token: token,
+      });
+      expect(confirmed.type).toBe('RESULTS');
+      expect(call).toHaveBeenCalledWith(tool.name.replace('alerts_', 'alert.'), ['u1']);
+    });
+  });
+
+  it('dismisses an alert that was not dismissed, and reports that it changed', async () => {
+    expect(await alertsDismiss.execute(system().ctx, { uuid: 'u1' })).toEqual({
+      uuid: 'u1',
+      lookup: 'FOUND',
+      lookup_error: null,
+      previously_dismissed: false,
+      changed: true,
+    });
+  });
+
+  it('accepts an already-dismissed alert and reports that nothing changed', async () => {
+    const alerts = [alert({ dismissed: true })];
+    expect(await alertsDismiss.execute(system(alerts).ctx, { uuid: 'u1' })).toEqual({
+      uuid: 'u1',
+      lookup: 'FOUND',
+      lookup_error: null,
+      previously_dismissed: true,
+      changed: false,
+    });
+    expect((await mutationStep(alertsDismiss, alerts)).description).toContain(
+      'It is already dismissed, so this changes nothing and is not an error.',
+    );
+  });
+
+  it('restores a dismissed alert, and reports that it changed', async () => {
+    const alerts = [alert({ dismissed: true })];
+    expect(await alertsRestore.execute(system(alerts).ctx, { uuid: 'u1' })).toEqual({
+      uuid: 'u1',
+      lookup: 'FOUND',
+      lookup_error: null,
+      previously_dismissed: true,
+      changed: true,
+    });
+    expect((await mutationStep(alertsRestore, alerts)).description).toContain(
+      'It is dismissed, so this will restore it.',
+    );
+  });
+
+  it('accepts an alert that was never dismissed and reports that nothing changed', async () => {
+    expect(await alertsRestore.execute(system().ctx, { uuid: 'u1' })).toEqual({
+      uuid: 'u1',
+      lookup: 'FOUND',
+      lookup_error: null,
+      previously_dismissed: false,
+      changed: false,
+    });
+    expect((await mutationStep(alertsRestore)).description).toContain(
+      'It is not dismissed, so this changes nothing and is not an error.',
+    );
+  });
+
+  it('says it will dismiss an alert that is not dismissed', async () => {
+    expect((await mutationStep(alertsDismiss)).description).toContain(
+      'It is not dismissed, so this will dismiss it.',
+    );
+  });
+
+  it('takes the uuid alerts_list reports, on the same system', async () => {
+    // The pairing that makes the mutation reachable at all: `alerts_list` is
+    // where a caller gets the identifier these tools want.
+    const { ctx } = system();
+    const [row] = (await alertsList.handler(ctx, {})) as Record<string, unknown>[];
+    const steps = await alertsDismiss.plan(ctx, { uuid: row['uuid'] });
+    expect(steps[1].params).toEqual([row['uuid']]);
   });
 });

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -19,10 +19,9 @@ export const alertsList: ReadOnlyTool = {
     'PER-SYSTEM: it names one alert on the one system it was read from, so a ' +
     'uuid read from one system must not be passed to a tool call targeting ' +
     'another. `id` is the alert\'s own class-and-key identifier, is what ' +
-    '`klass` groups with, and IS NOT THAT ARGUMENT — it does not name a single ' +
-    "system's alert instance, and the same `id` can come back from two " +
-    'different systems for the same condition, so acting on it would be ' +
-    'ambiguous.',
+    '`klass` groups with, and IS NOT THAT ARGUMENT: nothing states that it ' +
+    "names one system's alert instance, so acting on it would be ambiguous " +
+    'wherever the same condition is raised on more than one system.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
@@ -525,12 +524,17 @@ export const alertsDismiss: MutatingTool = alertStateTool({
     'true where that state was the other one and the call did not reject, and ' +
     'false where the alert was already dismissed and this call therefore moved ' +
     'nothing. BOTH ARE NULL WHERE THE PRIOR STATE COULD NOT BE ESTABLISHED, ' +
-    'WHICH IS NOT "NOTHING CHANGED": `lookup` says which — `FOUND` is the state ' +
-    'reported, `NOT_FOUND` is a read that completed and listed no alert with ' +
-    'this uuid (it cleared between the plan and the confirmation), and ' +
-    '`UNREADABLE` is a read that failed, with `lookup_error` naming why. THE ' +
+    'WHICH IS NOT "NOTHING CHANGED". `lookup` says what the read did: `FOUND` ' +
+    'is a read that named this alert, `NOT_FOUND` a read that completed and ' +
+    'listed no alert with this uuid (it cleared between the plan and the ' +
+    'confirmation), and `UNREADABLE` a read that failed, with `lookup_error` ' +
+    'naming why. IT HAS THREE VALUES AND THE NULL PAIR HAS FOUR CAUSES: the two ' +
+    'above, and ALSO `FOUND` where the alert reported no `dismissed` this tool ' +
+    'could read as a boolean — an alert that was there and did not state ' +
+    'whether it had been dismissed. So `lookup` alone does not tell them apart, ' +
+    'and `FOUND` beside a null `previously_dismissed` is that fourth case. THE ' +
     'DISMISSAL IS ATTEMPTED IN ALL THREE CASES, because what runs must be what ' +
-    'was approved; under `NOT_FOUND` and `UNREADABLE` this tool cannot say ' +
+    'was approved; wherever `previously_dismissed` is null this tool cannot say ' +
     'whether anything was dismissed, only that the call did not reject. ' +
     '`alerts_restore` is the exact inverse and un-dismisses an alert this tool ' +
     'dismissed. It changes no data, no configuration and no storage, it starts ' +
@@ -563,12 +567,18 @@ export const alertsRestore: MutatingTool = alertStateTool({
     'call, `changed` is true where the alert was dismissed and the call did not ' +
     'reject, and false where it was not dismissed and this call therefore moved ' +
     'nothing. BOTH ARE NULL WHERE THE PRIOR STATE COULD NOT BE ESTABLISHED, ' +
-    'WHICH IS NOT "NOTHING CHANGED": `lookup` says which — `FOUND` is the state ' +
-    'reported, `NOT_FOUND` is a read that completed and listed no alert with ' +
-    'this uuid (it cleared between the plan and the confirmation), and ' +
-    '`UNREADABLE` is a read that failed, with `lookup_error` naming why. THE ' +
+    'WHICH IS NOT "NOTHING CHANGED". `lookup` says what the read did: `FOUND` ' +
+    'is a read that named this alert, `NOT_FOUND` a read that completed and ' +
+    'listed no alert with this uuid (it cleared between the plan and the ' +
+    'confirmation), and `UNREADABLE` a read that failed, with `lookup_error` ' +
+    'naming why. IT HAS THREE VALUES AND THE NULL PAIR HAS FOUR CAUSES: the two ' +
+    'above, and ALSO `FOUND` where the alert reported no `dismissed` this tool ' +
+    'could read as a boolean — an alert that was there and did not state ' +
+    'whether it had been dismissed. So `lookup` alone does not tell them apart, ' +
+    'and `FOUND` beside a null `previously_dismissed` is that fourth case. THE ' +
     'RESTORE IS ATTEMPTED IN ALL THREE CASES, because what runs must be what was ' +
-    'approved; under `NOT_FOUND` and `UNREADABLE` this tool cannot say whether ' +
-    'anything was restored, only that the call did not reject. It changes no ' +
+    'approved; wherever `previously_dismissed` is null this tool cannot say ' +
+    'whether anything was restored, only that the call did not reject. It ' +
+    'changes no ' +
     'data, no configuration and no storage, and it starts no job.',
 });

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -18,8 +18,8 @@ export const alertsList: ReadOnlyTool = {
     'identifier `alerts_dismiss` and `alerts_restore` take, and IT IS ' +
     'PER-SYSTEM: it names one alert on the one system it was read from, so a ' +
     'uuid read from one system must not be passed to a tool call targeting ' +
-    'another. `id` is the alert\'s own class-and-key identifier, is what ' +
-    '`klass` groups with, and IS NOT THAT ARGUMENT: nothing states that it ' +
+    'another. `id` is a second identifier the middleware reports on the same ' +
+    'alert, and IS NOT THAT ARGUMENT: nothing states that it ' +
     "names one system's alert instance, so acting on it would be ambiguous " +
     'wherever the same condition is raised on more than one system.',
   inputSchema: { type: 'object', properties: {} },

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -1,6 +1,7 @@
+import type { CallResponse } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { ApiSurface, MutatingTool, ReadOnlyTool, ToolContext } from '@/catalog/tool';
 import { booleanOrNull, errorText, recordOrNull, textOrNull } from '@/tools/common';
 
 /**
@@ -13,13 +14,27 @@ export const alertsList: ReadOnlyTool = {
   description:
     'Active alerts a TrueNAS system has raised: severity level, alert class, ' +
     'the message, when it fired, and whether it has been dismissed. Dismissed ' +
-    'alerts are still active conditions and are included.',
+    'alerts are still active conditions and are included. `uuid` is the ' +
+    'identifier `alerts_dismiss` and `alerts_restore` take, and IT IS ' +
+    'PER-SYSTEM: it names one alert on the one system it was read from, so a ' +
+    'uuid read from one system must not be passed to a tool call targeting ' +
+    'another. `id` is the alert\'s own class-and-key identifier, is what ' +
+    '`klass` groups with, and IS NOT THAT ARGUMENT — it does not name a single ' +
+    "system's alert instance, and the same `id` can come back from two " +
+    'different systems for the same condition, so acting on it would be ' +
+    'ambiguous.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
   async handler({ system }) {
     const alerts = await firstValueFrom(system.client.api.call('alert.list'));
     return alerts.map((alert) => ({
+      // The identifier `alert.dismiss` and `alert.restore` take, added by #119
+      // so that a caller can name the alert those tools want. It is reported
+      // beside `id` rather than instead of it: the two are separate required
+      // fields of the middleware's own alert, and only this one addresses an
+      // alert on one system.
+      uuid: alert.uuid,
       id: alert.id,
       // The middleware's own class identifier, e.g. `ZpoolCapacityWarning`.
       klass: alert.klass,
@@ -278,3 +293,282 @@ export const alertSettings: ReadOnlyTool = {
     };
   },
 };
+
+/**
+ * `alerts_dismiss` and `alerts_restore`: the mutating pair, and the first
+ * mutation in the catalog that is not a snapshot.
+ *
+ * They flip one boolean on one notification record. No data, configuration or
+ * storage changes, no job runs, and `alert.restore` is the exact inverse of
+ * `alert.dismiss` in the same API — so `destructiveness: 'reversible'` is a
+ * literal statement here rather than a judgement about how hard the undo is.
+ *
+ * THE IDENTIFIER IS `uuid` AND NOT `id`. `alert.dismiss` and `alert.restore`
+ * both take a `uuid`, and the middleware's alert declares `uuid` and `id` as two
+ * separate required fields. `alerts_list` reported only `id` until #119, so
+ * there was no way for a caller to name the alert the API wants; it now reports
+ * both. The ticket's live reading — the same `id` coming back from two
+ * different systems for one `CertificateExpired`/`freenas_default` condition —
+ * is why `id` is not accepted here: a tool keyed on it would be ambiguous under
+ * the fan-out, which is the normal way these tools run. That reading was not
+ * reproducible from this repository (there is no live system in the test
+ * environment), so what is CONFIRMED is the surface — two declared fields, and a
+ * method whose parameter is the first of them — and what is not is the account
+ * of why they differ.
+ *
+ * WHAT THE PLAN NAMES IS WHAT `execute` CALLS, INCLUDING THE READ. Both plans
+ * return two steps, `alert.list` then the mutation, because `execute` makes both
+ * calls: the read is what lets the result say whether the alert had already been
+ * dismissed, which `snapshots_create` needs no equivalent of. `snapshots_create`
+ * reads at PLAN time and deliberately does not re-read at execute time, so its
+ * one plan step is the whole of what it calls; a plan here that named only the
+ * mutation would be a plan that is not true. The read is issued unconditionally
+ * and nothing branches on it — the mutating call is made whatever it says — so
+ * `execute` is still a pure function of (args, system) in the sense the
+ * confirmation token depends on.
+ *
+ * ALREADY-DISMISSED IS NOT AN ERROR. Most alerts on a running system are
+ * already dismissed, and dismissing one again is a no-op the middleware accepts.
+ * The plan says which of the two it is about to do, and the result reports the
+ * state read immediately before the call, so a caller can tell "this call
+ * dismissed it" from "it was dismissed already".
+ */
+
+/** The one argument either tool takes. */
+interface AlertTarget {
+  uuid: string;
+}
+
+/**
+ * The caller's argument, or the error naming what is missing.
+ *
+ * Strict, as `snapshots_create`'s `dataset` is: an identifier that is not a
+ * non-empty string cannot be read as anything else without acting on an alert
+ * nobody named.
+ */
+function parseTarget(args: Record<string, unknown>): AlertTarget {
+  const uuid = args['uuid'];
+  if (typeof uuid !== 'string' || uuid.length === 0) {
+    throw new Error('"uuid" is required');
+  }
+  return { uuid };
+}
+
+/** One alert as `alert.list` sends it, named off the call rather than the entity (#91). */
+type AlertRow = CallResponse<ApiSurface, 'alert.list'>[number];
+
+/** The two methods this pair calls, which differ only in direction. */
+type AlertStateMethod = 'alert.dismiss' | 'alert.restore';
+
+/** The alert carrying this uuid, or null where the system listed none that did. */
+async function findAlert(ctx: ToolContext, uuid: string): Promise<AlertRow | null> {
+  const alerts = await firstValueFrom(ctx.system.client.api.call('alert.list'));
+  return alerts.find((alert) => alert.uuid === uuid) ?? null;
+}
+
+/**
+ * The alert in the terms `alerts_list` shows it, for the human approving the
+ * plan. A uuid is not a thing anyone recognises, so the plan step has to name
+ * the level, the class and the message.
+ *
+ * Each of the three is stated as absent rather than dropped where the system
+ * reported none: a plan that silently omits the message reads as an alert
+ * without one, and the person approving cannot tell which.
+ */
+function describeAlert(alert: AlertRow): string {
+  const level = textOrNull(alert.level);
+  const klass = textOrNull(alert.klass);
+  const formatted = textOrNull(alert.formatted);
+  const none = '(the system reported none)';
+  return (
+    `level ${level ?? none}, class ${klass ?? none}, ` +
+    `message ${formatted === null ? none : `"${formatted}"`}`
+  );
+}
+
+/** What one of the pair is, beyond the wording it presents itself with. */
+interface AlertStateAction {
+  name: string;
+  description: string;
+  method: AlertStateMethod;
+  /** The `dismissed` state this tool moves an alert to. */
+  target: boolean;
+  /** Imperative for the plan step — `Dismiss`, `Restore`. */
+  verb: string;
+}
+
+/**
+ * What the plan says the call will do, given the state the alert is in now.
+ *
+ * Three cases and not two: an alert whose `dismissed` could not be read as a
+ * boolean is neither already there nor about to move, and saying either would
+ * be a claim the read did not establish.
+ */
+function effectSentence(action: AlertStateAction, current: boolean | null): string {
+  if (current === null) {
+    return 'Whether it is dismissed could not be read, so this may change nothing.';
+  }
+  if (current === action.target) {
+    return `It is ${current ? 'already dismissed' : 'not dismissed'}, so this changes ` +
+      'nothing and is not an error.';
+  }
+  return `It is ${current ? 'dismissed' : 'not dismissed'}, so this will ` +
+    `${action.verb.toLowerCase()} it.`;
+}
+
+/**
+ * One of the pair. Written once because the two differ only in the method they
+ * call, the state they move an alert to and the words they say — the eleven
+ * copies of `textOrNull` behind `common.ts` are what a second hand-written copy
+ * of this would become.
+ */
+function alertStateTool(action: AlertStateAction): MutatingTool {
+  return {
+    name: action.name,
+    description: action.description,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        uuid: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "The alert's `uuid` as `alerts_list` reports it, on the system " +
+            'being targeted. Not its `id`, which does not name one system\'s alert.',
+        },
+      },
+      required: ['uuid'],
+    },
+    requiredRole: Role.Full,
+    mutating: true,
+    destructiveness: 'reversible',
+    normalizeArgs(rawArgs) {
+      return { uuid: parseTarget(rawArgs).uuid };
+    },
+    async plan(ctx, rawArgs) {
+      const { uuid } = parseTarget(rawArgs);
+      const alert = await findAlert(ctx, uuid);
+      // The failure names the identifier the caller supplied, because that is
+      // the only part of it the caller can check. `assertDatasetExists` fails
+      // the same way for `snapshots_create`.
+      if (alert === null) {
+        throw new Error(`No alert with uuid "${uuid}" on this system`);
+      }
+      return [
+        {
+          method: 'alert.list',
+          params: [],
+          description:
+            'Read this system\'s alerts, to report whether the alert was already ' +
+            'in the state this call moves it to. Changes nothing.',
+        },
+        {
+          method: action.method,
+          params: [uuid],
+          description:
+            `${action.verb} the alert with ${describeAlert(alert)} (uuid ${uuid}). ` +
+            effectSentence(action, booleanOrNull(alert.dismissed)),
+        },
+      ];
+    },
+    async execute(ctx, rawArgs) {
+      const { uuid } = parseTarget(rawArgs);
+      // Caught rather than thrown: this read exists to describe the outcome,
+      // and letting it fail the call would lose an approval the user has
+      // already given for a mutation that is still perfectly safe to make.
+      // The result then says the prior state could not be established.
+      let alert: AlertRow | null = null;
+      let lookupError: string | null = null;
+      try {
+        alert = await findAlert(ctx, uuid);
+      } catch (reason) {
+        lookupError = errorText(reason);
+      }
+      // Unconditional, whatever the read said. Skipping the call for an alert
+      // the read no longer lists would be `execute` branching on state read at
+      // execution time, which is what the confirmation token cannot bind.
+      await firstValueFrom(ctx.system.client.api.call(action.method, [uuid]));
+      const previous = alert === null ? null : booleanOrNull(alert.dismissed);
+      return {
+        uuid,
+        lookup: lookupError !== null ? 'UNREADABLE' : alert === null ? 'NOT_FOUND' : 'FOUND',
+        lookup_error: lookupError,
+        previously_dismissed: previous,
+        changed: previous === null ? null : previous !== action.target,
+      };
+    },
+  };
+}
+
+export const alertsDismiss: MutatingTool = alertStateTool({
+  name: 'alerts_dismiss',
+  method: 'alert.dismiss',
+  target: true,
+  verb: 'Dismiss',
+  description:
+    'Dismisses one active alert on one TrueNAS system: the acknowledgement an ' +
+    'operator makes in the UI, and nothing more. Two-phase: called without a ' +
+    'confirmation_token it returns a plan for user approval; called with one it ' +
+    'dismisses the alert. DISMISSING AN ALERT DOES NOT FIX WHAT RAISED IT — the ' +
+    'condition is still active, `alerts_list` still reports the alert with ' +
+    '`dismissed: true`, and the middleware may raise it again. `uuid` is the ' +
+    'alert\'s `uuid` as `alerts_list` reports it, ON THE SYSTEM BEING TARGETED: ' +
+    'it names one alert on one system, so read it from that system rather than ' +
+    'reusing one read elsewhere. The `id` `alerts_list` also reports is NOT this ' +
+    'argument and must not be passed as it. Planning against a uuid no alert on ' +
+    'that system matches FAILS, naming the uuid supplied, so an approved plan is ' +
+    'always a plan about an alert that existed when it was made. DISMISSING AN ' +
+    'ALREADY-DISMISSED ALERT IS NOT AN ERROR, and is the ordinary case — most ' +
+    'alerts on a running system are already dismissed. The plan says which of ' +
+    'the two it is about to do, and the result reports it: `previously_dismissed` ' +
+    'is the alert\'s state as read immediately before the call, `changed` is ' +
+    'true where that state was the other one and the call did not reject, and ' +
+    'false where the alert was already dismissed and this call therefore moved ' +
+    'nothing. BOTH ARE NULL WHERE THE PRIOR STATE COULD NOT BE ESTABLISHED, ' +
+    'WHICH IS NOT "NOTHING CHANGED": `lookup` says which — `FOUND` is the state ' +
+    'reported, `NOT_FOUND` is a read that completed and listed no alert with ' +
+    'this uuid (it cleared between the plan and the confirmation), and ' +
+    '`UNREADABLE` is a read that failed, with `lookup_error` naming why. THE ' +
+    'DISMISSAL IS ATTEMPTED IN ALL THREE CASES, because what runs must be what ' +
+    'was approved; under `NOT_FOUND` and `UNREADABLE` this tool cannot say ' +
+    'whether anything was dismissed, only that the call did not reject. ' +
+    '`alerts_restore` is the exact inverse and un-dismisses an alert this tool ' +
+    'dismissed. It changes no data, no configuration and no storage, it starts ' +
+    'no job, and it silences nothing for the future — `alert_settings` reports ' +
+    'the per-class policies that do that, and no tool here changes them.',
+});
+
+export const alertsRestore: MutatingTool = alertStateTool({
+  name: 'alerts_restore',
+  method: 'alert.restore',
+  target: false,
+  verb: 'Restore',
+  description:
+    'Un-dismisses one active alert on one TrueNAS system, the exact inverse of ' +
+    '`alerts_dismiss`: the alert goes back to reporting `dismissed: false`, as ' +
+    'though it had never been acknowledged. Two-phase: called without a ' +
+    'confirmation_token it returns a plan for user approval; called with one it ' +
+    'restores the alert. RESTORING AN ALERT CHANGES NOTHING ABOUT THE CONDITION ' +
+    'THAT RAISED IT — a dismissed alert was already an active condition that ' +
+    '`alerts_list` reported, and this only clears the acknowledgement. `uuid` is ' +
+    'the alert\'s `uuid` as `alerts_list` reports it, ON THE SYSTEM BEING ' +
+    'TARGETED: it names one alert on one system, so read it from that system ' +
+    'rather than reusing one read elsewhere. The `id` `alerts_list` also reports ' +
+    'is NOT this argument and must not be passed as it. Planning against a uuid ' +
+    'no alert on that system matches FAILS, naming the uuid supplied, so an ' +
+    'approved plan is always a plan about an alert that existed when it was ' +
+    'made. RESTORING AN ALERT THAT WAS NEVER DISMISSED IS NOT AN ERROR. The plan ' +
+    'says which of the two it is about to do, and the result reports it: ' +
+    '`previously_dismissed` is the alert\'s state as read immediately before the ' +
+    'call, `changed` is true where the alert was dismissed and the call did not ' +
+    'reject, and false where it was not dismissed and this call therefore moved ' +
+    'nothing. BOTH ARE NULL WHERE THE PRIOR STATE COULD NOT BE ESTABLISHED, ' +
+    'WHICH IS NOT "NOTHING CHANGED": `lookup` says which — `FOUND` is the state ' +
+    'reported, `NOT_FOUND` is a read that completed and listed no alert with ' +
+    'this uuid (it cleared between the plan and the confirmation), and ' +
+    '`UNREADABLE` is a read that failed, with `lookup_error` naming why. THE ' +
+    'RESTORE IS ATTEMPTED IN ALL THREE CASES, because what runs must be what was ' +
+    'approved; under `NOT_FOUND` and `UNREADABLE` this tool cannot say whether ' +
+    'anything was restored, only that the call did not reject. It changes no ' +
+    'data, no configuration and no storage, and it starts no job.',
+});

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the forty-nine sketch tools', () => {
+  it('registers the fifty-one sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -54,7 +54,15 @@ describe('createDefaultCatalog', () => {
       'fleet_compliance_report',
       'fleet_health_rollup',
       'snapshots_create',
+      'alerts_dismiss',
+      'alerts_restore',
     ]);
+  });
+
+  it('does not advertise the mutating alert pair to a read-only credential', () => {
+    const readOnly = createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name);
+    expect(readOnly).not.toContain('alerts_dismiss');
+    expect(readOnly).not.toContain('alerts_restore');
   });
 
   it('advertises fleet_health_rollup to a read-only credential', () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,6 @@
 import { ToolCatalog } from '@/catalog/catalog';
 import { directoryServicesStatus, usersList } from '@/tools/accounts';
-import { alertSettings, alertsList } from '@/tools/alerts';
+import { alertsDismiss, alertSettings, alertsList, alertsRestore } from '@/tools/alerts';
 import { appEngineStatus, appsList, appsUpdateSummary } from '@/tools/apps';
 import { iscsiList, nvmeofList } from '@/tools/block';
 import { bootPoolStatus } from '@/tools/boot';
@@ -40,7 +40,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-eight read-only tools plus one mutating tool. */
+/** The sketch's catalog: forty-eight read-only tools plus three mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -92,12 +92,16 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(fleetComplianceReport);
   catalog.register(fleetHealthRollup);
   catalog.register(createSnapshot);
+  catalog.register(alertsDismiss);
+  catalog.register(alertsRestore);
   return catalog;
 }
 
 export {
+  alertsDismiss,
   alertSettings,
   alertsList,
+  alertsRestore,
   appEngineStatus,
   appsList,
   appsUpdateSummary,


### PR DESCRIPTION
Adds `alerts_dismiss` and `alerts_restore`, and grows `alerts_list` the field
that makes them reachable.

Fixes #119

## What changed

- **`alerts_dismiss` / `alerts_restore`** in `src/tools/alerts.ts`, both
  `mutating: true`, `destructiveness: 'reversible'`, `requiredRole: Role.Full`,
  both two-phase plan/confirm. They are written once behind a small factory:
  they differ only in the method they call, the `dismissed` state they move an
  alert to, and the words they say, and a second hand-written copy is how the
  eleven copies of `textOrNull` behind `common.ts` started.
- **`alerts_list` now reports `uuid`**, beside `id` rather than instead of it,
  and its description states what `uuid` is for and that it is per-system.
- Registration, both barrels, the `createDefaultCatalog` exact-list test
  (forty-nine → fifty-one, in registration order), the README listing, and two
  `## Decisions` entries in `CLAUDE.md`.

## The identifier, which is the part the ticket said to settle first

`alert.dismiss` and `alert.restore` take a `uuid`. The middleware's alert
declares `uuid` and `id` as two separate required fields
(`Alert$2`, `dist/index.d.ts:1344`), and `alerts_list` reported only `id` — so
there was **no way for a caller to name the alert the API wants**. `alerts_list`
now reports both.

**The ticket's live reading was not reproducible here.** There is no live system
in this environment, so the observation that one `id` came back from two
machines for the same `CertificateExpired`/`freenas_default` condition is
carried as the ticket's, in a code comment, and is not asserted anywhere a
caller reads. What the descriptions state is what the surface supports: `uuid`
is the argument, read it from the system being targeted; nothing states that
`id` names one system's alert instance, so acting on it would be ambiguous
wherever a condition is raised on more than one system. If someone can re-read
this against two registered systems, that confirmation is still worth having —
it would let the description say *why* rather than *that*.

**Adding a field to `alerts_list` changes an existing tool's contract**, so it
was checked rather than assumed: `system_health_report` composes
`alertsList.handler` and `alertEntries` (`reporting.ts:2367`) re-reads `level`,
`klass`, `formatted` and `dismissed` by name through its own guards, so the new
field does not reach it or `fleet_health_rollup` behind it. That is #44 holding
in the direction it was written for.

## The plan names two steps, not one

`snapshots_create` reads at plan time and deliberately does not re-read at
execute time, so its one plan step is the whole of what it calls. These two must
report whether the alert had *already* been dismissed, which is only readable
immediately before the call — so `execute` reads, and both plans name
`alert.list` **and** the mutation. A `PlanStep` is a call `execute` will make; a
plan naming only the mutation would omit a call the user is approving.

The read is issued unconditionally and nothing branches on it. The mutating call
is made whatever the read said, including where the read failed and where it
listed no alert with that uuid — skipping it would be `execute` branching on
state read at execution time, which is what the confirmation token cannot bind.
The reporting read is caught rather than thrown, because failing the call would
throw away an approval already given for a mutation that is still safe.

`lookup` reports what the read did (`FOUND` / `NOT_FOUND` / `UNREADABLE`), and
the descriptions say outright that it has three values while the null
`previously_dismissed` / `changed` pair has **four** causes — the fourth being
`FOUND` on an alert that stated no readable `dismissed`. That was a review
finding on round 1 and it was right.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (1081 passing) and
`yarn test:coverage` all run clean locally; `alerts.ts` is at 100% statements
and branches and the global floors are met. `yarn build` succeeds. Nothing in
CI's `ci.yml` was skipped.

`./scripts/local-review.py 119` ran the project's own reviewer — the same
rubric, threshold and parser as the required check, in a separate process. Round
1 returned one MEDIUM and four LOWs; round 2 returned nothing at or above
MEDIUM.

## What I did not change

Three LOWs from the clean round, left for this PR's reviewer rather than fixed,
because each fix is a new diff and reviewing it starts another round:

- **`findAlert` calls `.find` on the `alert.list` response with no
  `Array.isArray` guard**, where several other families guard first. It is not
  wrong in outcome — a non-array makes `plan` fail and makes `execute` report
  `UNREADABLE` with the `TypeError`'s text, which is the honest answer — but the
  message is ugly, and `alerts_list`'s own unguarded `.map` has the same shape.
  Worth fixing as one change across the family rather than in this diff.
- **~940 characters of the `lookup` contract prose are duplicated verbatim
  between the two descriptions**, which the file's own factory comment argues
  against. The round-1 MEDIUM had to be fixed in both places, which is the cost
  landing already. The factory takes each description whole on purpose — the
  two are not symmetrical enough to generate — but the shared *tail* could be a
  constant the two concatenate.
- **No test pins that a rejecting `alert.dismiss` / `alert.restore` propagates**
  rather than being caught the way the read is. The distinction is deliberate
  and only the read is caught, so a test naming it would be worth having.

One further LOW from round 1 *was* fixed, because it made the diff contradict
itself: the `alerts_list` description asserted the same `id` comes back from two
systems, two paragraphs from a decision record saying that reading is not
reproducible here.
