### PR TITLE
feat(tools): add scheduled_task_set_enabled, turning a scheduled task on or off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,15 @@ Two things that rule does not decide on its own:
   The tests went back into `tasks.spec.ts`. A spec that is merely long is not a
   spec that has to split, and the default above — a new tool's tests go in its
   module's spec — is what governs until the number says otherwise.
+
+  **The number said otherwise at #121.** `tasks.spec.ts` was 1,352 lines and
+  that tool's block is around 460, so the merged file would be about 1,810 and
+  the exception is met where #97's was not. The block took
+  `scheduled-task-set-enabled.spec.ts`; the four listing tools stayed in
+  `tasks.spec.ts`, because the split is by tool and re-homing tests a ticket did
+  not touch is a separate change. So a module can be part-split, and that is not
+  a half-finished state to tidy — the next tool over the line takes its own spec
+  the same way.
 - **The catalog-wide test is not any tool's.** The exact-list assertion over
   `createDefaultCatalog()` is about `src/tools/index.ts`, so it lives in
   `index.spec.ts` under the same rule as everything else. Registering a tool
@@ -830,6 +839,64 @@ value (true, null temperature), and the whole read failing (`disks` null,
 asleep both land in the middle case and are NOT distinguishable from this
 payload — which the description states outright rather than leaving a caller to
 infer a cold disk.
+
+### A tool named for a category may not accept a member of another one (#121)
+
+`scheduled_task_set_enabled` switches one scheduled task on or off across six
+kinds — periodic snapshot, cloud sync, replication, cron, rsync and cloud
+backup — and it does **not** accept an init/shutdown script. That is the #97
+naming rule one level down, and it is worth stating because the API does not
+stop it: `InitShutdownScriptUpdate` declares `enabled?: boolean` exactly as the
+other six do, checked rather than assumed. An init/shutdown script runs at a
+point in the system's lifecycle, carries no cron fields and reports no
+`schedule` at all, which is precisely why `automated_tasks_list` is not called
+`scheduled_tasks_list`. Accepting one here would put the promise that tool's
+name refuses back into a `kind` enum. **The reachable surface is not the scope —
+ask what the tool's own name has already promised**, and where the two disagree
+the missing kind is a tool whose name fits, not an argument to add.
+
+**One tool over six kinds is not the #97 section decision, and the test is
+different.** `automated_tasks_list` returns four sections because a caller
+reaching three of them gets a confident answer with a category silently absent:
+the missing kind is the finding. Nothing is missing from a mutation. What makes
+this one tool is that the six calls are literally the same call — `(id, {
+enabled })` in, the updated entity out — so six tools would be six copies of one
+`plan`/`execute` pair differing in two strings, which is what `common.ts` was cut
+to stop. **Ask whether the kinds differ in what the caller is TOLD (sections) or
+only in which method is dialled (one tool with a discriminator).**
+
+**The discriminator is required, and that is a safety property rather than
+ergonomics.** Task ids are per-table integers, so id `3` exists under every kind
+and names a different task under each; a tool taking an id alone would be
+ambiguous in the one direction that matters, disabling the wrong task silently.
+Every enum value names the tool its ids come from, in the description and in the
+plan's failure — because a caller that reached the failure with the right id and
+the wrong kind can check the id and cannot check the kind.
+
+**A mutating tool's outcome is read from what came back, never from what was
+asked.** These methods answer with the updated entity, so `resulting_enabled` is
+read off the response through the same guard the row was read with, and
+`changed` is `previously_enabled !== resulting_enabled` — two readings or null.
+A `changed` derived from the request instead would report a call the system
+accepted and did not apply as having changed something. `confirmed` is the
+separate fact that the response agrees with the request, and **`confirmed: false`
+is not a success**: the call did not reject and the task is not in the state that
+was asked for. `alerts_dismiss` has no equivalent because `alert.dismiss` answers
+nothing — where a method returns the entity, reading it back is owed.
+
+**A filter is bandwidth; the check on the response is the control.** The read
+passes `[['id', '=', id]]` and then finds the row by id anyway. An unrecognised
+query parameter is dropped rather than refused (the same mechanism #115 states
+for `select`), so a filter that did not apply comes back as the whole table and
+is indistinguishable from one that matched everything — and the first row of that
+is a different task. **Never act on the first row of a filtered read.**
+
+**A cron job's `command` is reported by `automated_tasks_list` and is not
+repeated in a plan.** It is the operator's own text and may hold a credential
+someone inlined; the description and the user identify the job for approval
+without it, and a plan is shown to a person and then recorded. Passing a field
+through in a listing whose description warns about it is not the same act as
+putting it in a mutating tool's approval text.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_health_report`, `fleet_compliance_report`, `fleet_health_rollup`.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
-  `alerts_restore`.
+  `alerts_restore`, `scheduled_task_set_enabled`.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,4 +129,5 @@ export {
   createSnapshot,
   alertsDismiss,
   alertsRestore,
+  scheduledTaskSetEnabled,
 } from '@/tools/index';

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-two sketch tools', () => {
+  it('registers the fifty-three sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -57,6 +57,7 @@ describe('createDefaultCatalog', () => {
       'snapshots_create',
       'alerts_dismiss',
       'alerts_restore',
+      'scheduled_task_set_enabled',
     ]);
   });
 
@@ -64,6 +65,12 @@ describe('createDefaultCatalog', () => {
     const readOnly = createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name);
     expect(readOnly).not.toContain('alerts_dismiss');
     expect(readOnly).not.toContain('alerts_restore');
+  });
+
+  it('does not advertise scheduled_task_set_enabled to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'scheduled_task_set_enabled',
+    );
   });
 
   it('advertises fleet_health_rollup to a read-only credential', () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,12 +35,13 @@ import {
 import {
   automatedTasksList,
   cloudsyncTasksList,
+  scheduledTaskSetEnabled,
   snapshotTasksList,
   tasksRecentRuns,
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-nine read-only tools plus three mutating tools. */
+/** The sketch's catalog: forty-nine read-only tools plus four mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -95,6 +96,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(createSnapshot);
   catalog.register(alertsDismiss);
   catalog.register(alertsRestore);
+  catalog.register(scheduledTaskSetEnabled);
   return catalog;
 }
 
@@ -135,6 +137,7 @@ export {
   reportingDiskIo,
   reportingSpaceTrends,
   reportingUtilisation,
+  scheduledTaskSetEnabled,
   scrubHistory,
   securityConfig,
   servicesStatus,

--- a/src/tools/scheduled-task-set-enabled.spec.ts
+++ b/src/tools/scheduled-task-set-enabled.spec.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it } from 'vitest';
+import { Role } from '@/interfaces';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { scheduledTaskSetEnabled } from '@/tools/index';
+
+/**
+ * `scheduled_task_set_enabled`'s tests live here rather than in
+ * `tasks.spec.ts`, which is the #87 split exception and is CHECKED rather than
+ * felt: `tasks.spec.ts` was 1,352 lines before this ticket and this block is
+ * several hundred more, so the merged file crosses the 1,500-line trigger where
+ * #97's fourth tool did not. The split is by tool, so the filename says exactly
+ * what is in it; the four listing tools stay where they are.
+ */
+
+/** The kinds, with the two methods each and a row shaped the way its table is. */
+const kinds = [
+  {
+    kind: 'periodic_snapshot',
+    noun: 'periodic snapshot task',
+    listedBy: 'snapshot_tasks_list',
+    read: 'pool.snapshottask.query',
+    update: 'pool.snapshottask.update',
+    row: {
+      id: 3,
+      dataset: 'tank/media',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['dataset "tank/media"'],
+  },
+  {
+    kind: 'cloud_sync',
+    noun: 'cloud sync task',
+    listedBy: 'cloudsync_tasks_list',
+    read: 'cloudsync.query',
+    update: 'cloudsync.update',
+    row: {
+      id: 3,
+      description: 'Nightly Backblaze',
+      path: '/mnt/tank/media',
+      direction: 'PUSH',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['description "Nightly Backblaze"', 'path "/mnt/tank/media"', 'direction "PUSH"'],
+  },
+  {
+    kind: 'replication',
+    noun: 'replication task',
+    listedBy: 'replication_status',
+    read: 'replication.query',
+    update: 'replication.update',
+    row: {
+      id: 3,
+      name: 'media to backup',
+      target_dataset: 'backup/media',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['name "media to backup"', 'target dataset "backup/media"'],
+  },
+  {
+    kind: 'cron',
+    noun: 'cron job',
+    listedBy: 'automated_tasks_list',
+    read: 'cronjob.query',
+    update: 'cronjob.update',
+    row: {
+      id: 3,
+      description: 'prune logs',
+      user: 'root',
+      command: 'curl -u admin:hunter2 https://example.test/ping',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['description "prune logs"', 'user "root"'],
+  },
+  {
+    kind: 'rsync',
+    noun: 'rsync task',
+    listedBy: 'automated_tasks_list',
+    read: 'rsynctask.query',
+    update: 'rsynctask.update',
+    row: {
+      id: 3,
+      desc: 'offsite copy',
+      path: '/mnt/tank/docs',
+      direction: 'PUSH',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['description "offsite copy"', 'path "/mnt/tank/docs"', 'direction "PUSH"'],
+  },
+  {
+    kind: 'cloud_backup',
+    noun: 'cloud backup task',
+    listedBy: 'automated_tasks_list',
+    read: 'cloud_backup.query',
+    update: 'cloud_backup.update',
+    row: {
+      id: 3,
+      description: 'restic to B2',
+      path: '/mnt/tank/vault',
+      password: 'repository-passphrase',
+      enabled: true,
+      schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+    },
+    named: ['description "restic to B2"', 'path "/mnt/tank/vault"'],
+  },
+] as const;
+
+type Kind = (typeof kinds)[number];
+
+/**
+ * A system listing that kind's row and answering its update with the row as it
+ * would be after the change — which is what these methods actually answer with.
+ */
+const system = (spec: Kind, rows: unknown = [spec.row], updated?: unknown) =>
+  fakeSystem({
+    [spec.read]: rows,
+    [spec.update]: updated === undefined ? { ...spec.row, enabled: false } : updated,
+  });
+
+/** The args for the ordinary case: switch that kind's task 3 off. */
+const off = (spec: Kind) => ({ kind: spec.kind, id: 3, enabled: false });
+
+describe('scheduled_task_set_enabled', () => {
+  it('is a reversible mutating tool needing the full role', () => {
+    expect(scheduledTaskSetEnabled).toMatchObject({
+      name: 'scheduled_task_set_enabled',
+      mutating: true,
+      destructiveness: 'reversible',
+      requiredRole: Role.Full,
+    });
+  });
+
+  it('advertises exactly the six kinds it can reach, and not init/shutdown scripts', () => {
+    const schema = scheduledTaskSetEnabled.inputSchema as {
+      properties: { kind: { enum: string[] } };
+      required: string[];
+    };
+    expect(schema.properties.kind.enum).toEqual([
+      'periodic_snapshot',
+      'cloud_sync',
+      'replication',
+      'cron',
+      'rsync',
+      'cloud_backup',
+    ]);
+    // An init/shutdown script is not scheduled — it runs at a point in the
+    // system's lifecycle — so a tool named for scheduled tasks must not accept
+    // one, whatever its update type declares.
+    expect(schema.properties.kind.enum).not.toContain('init_shutdown_script');
+    expect(schema.required).toEqual(['kind', 'id', 'enabled']);
+  });
+
+  it('names each kind, the tool that lists its ids, and the init/shutdown gap', () => {
+    const description = scheduledTaskSetEnabled.description;
+    for (const spec of kinds) {
+      expect(description).toContain(`\`${spec.kind}\``);
+      expect(description).toContain(`\`${spec.listedBy}\``);
+    }
+    expect(description).toContain('INIT/SHUTDOWN SCRIPTS ARE NOT COVERED');
+    expect(description).toContain('ONLY THE `enabled` FIELD IS SENT');
+  });
+
+  it('normalizes args: keeps the three and drops unknown keys', () => {
+    expect(
+      scheduledTaskSetEnabled.normalizeArgs?.({
+        kind: 'cron',
+        id: 3,
+        enabled: true,
+        extra: 1,
+        systems: 'all',
+      }),
+    ).toEqual({ kind: 'cron', id: 3, enabled: true });
+  });
+
+  describe('argument validation', () => {
+    const ctx = system(kinds[0]).ctx;
+
+    it('requires a kind it knows, naming the ones it does', async () => {
+      for (const bad of [undefined, null, '', 'init_shutdown_script', 'CRON', 7]) {
+        expect(() =>
+          scheduledTaskSetEnabled.normalizeArgs?.({ kind: bad, id: 3, enabled: false }),
+        ).toThrow(/"kind" is required and must be one of .*periodic_snapshot/);
+        await expect(
+          scheduledTaskSetEnabled.plan(ctx, { kind: bad, id: 3, enabled: false }),
+        ).rejects.toThrow(/"kind" is required/);
+      }
+    });
+
+    it('requires a whole-number id', async () => {
+      for (const bad of [undefined, null, '3', 3.5, Number.NaN]) {
+        expect(() =>
+          scheduledTaskSetEnabled.normalizeArgs?.({
+            kind: 'periodic_snapshot',
+            id: bad,
+            enabled: false,
+          }),
+        ).toThrow(/"id" is required and must be a whole number/);
+        await expect(
+          scheduledTaskSetEnabled.plan(ctx, { kind: 'periodic_snapshot', id: bad, enabled: false }),
+        ).rejects.toThrow(/"id" is required/);
+      }
+    });
+
+    it('requires a boolean enabled and coerces nothing into one', async () => {
+      // Coercing "false" to true would switch ON a backup task the caller
+      // asked to switch off.
+      for (const bad of [undefined, null, 'false', 0, 1]) {
+        expect(() =>
+          scheduledTaskSetEnabled.normalizeArgs?.({
+            kind: 'periodic_snapshot',
+            id: 3,
+            enabled: bad,
+          }),
+        ).toThrow(/"enabled" is required and must be a boolean/);
+        await expect(
+          scheduledTaskSetEnabled.plan(ctx, { kind: 'periodic_snapshot', id: 3, enabled: bad }),
+        ).rejects.toThrow(/"enabled" is required/);
+      }
+    });
+
+    it('executes nothing when an argument is unreadable', async () => {
+      const { call } = system(kinds[0]);
+      await expect(
+        scheduledTaskSetEnabled.execute(ctx, { kind: 'cron', id: 3, enabled: 'yes' }),
+      ).rejects.toThrow(/"enabled" is required/);
+      expect(call).not.toHaveBeenCalled();
+    });
+  });
+
+  describe.each(kinds.map((spec) => [spec.kind, spec] as const))('%s', (_name, spec) => {
+    it('plans the read it makes as well as the mutation it makes', async () => {
+      const steps = await scheduledTaskSetEnabled.plan(system(spec).ctx, off(spec));
+      // Two steps because `execute` makes two calls. A plan naming only the
+      // mutation would not be a true account of what runs.
+      expect(steps.map((step) => step.method)).toEqual([spec.read, spec.update]);
+      expect(steps[0]).toMatchObject({ params: [[['id', '=', 3]]] });
+      expect(steps[0].description).toMatch(/Changes nothing/);
+    });
+
+    it('sends only the enabled field, and sends the state that was asked for', async () => {
+      const [, mutation] = await scheduledTaskSetEnabled.plan(system(spec).ctx, off(spec));
+      expect(mutation.params).toEqual([3, { enabled: false }]);
+      const [, on] = await scheduledTaskSetEnabled.plan(system(spec).ctx, {
+        kind: spec.kind,
+        id: 3,
+        enabled: true,
+      });
+      expect(on.params).toEqual([3, { enabled: true }]);
+      expect(mutation.description).toContain('Only the enabled flag is sent');
+    });
+
+    it('names the task in human terms, with its schedule in words', async () => {
+      const [, mutation] = await scheduledTaskSetEnabled.plan(system(spec).ctx, off(spec));
+      expect(mutation.description).toContain(`Disable the ${spec.noun}`);
+      for (const part of spec.named) {
+        expect(mutation.description).toContain(part);
+      }
+      expect(mutation.description).toContain('schedule at 02:00, every day');
+      expect(mutation.description).toContain('(id 3)');
+    });
+
+    it('fails when no task of that kind has that id, naming the kind searched', async () => {
+      const { ctx } = system(spec, [{ ...spec.row, id: 4 }]);
+      await expect(scheduledTaskSetEnabled.plan(ctx, off(spec))).rejects.toThrow(
+        new RegExp(
+          `No ${spec.noun} with id 3 on this system — the kind searched was ` +
+            `"${spec.kind}", whose ids come from \`${spec.listedBy}\``,
+        ),
+      );
+    });
+
+    it('executes the read and then the update the plan named', async () => {
+      const { ctx, query, call } = system(spec);
+      await scheduledTaskSetEnabled.execute(ctx, off(spec));
+      expect(query).toHaveBeenCalledWith(spec.read, [['id', '=', 3]]);
+      expect(call).toHaveBeenCalledWith(spec.update, [3, { enabled: false }]);
+    });
+  });
+
+  describe('the outcome it reports', () => {
+    const cloudSync = kinds[1];
+
+    it('reports a task it actually changed', async () => {
+      const { ctx } = system(cloudSync);
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toEqual({
+        kind: 'cloud_sync',
+        id: 3,
+        requested_enabled: false,
+        lookup: 'FOUND',
+        lookup_error: null,
+        previously_enabled: true,
+        resulting_enabled: false,
+        changed: true,
+        confirmed: true,
+      });
+    });
+
+    it('reports a task already in the requested state as changing nothing', async () => {
+      const already = { ...cloudSync.row, enabled: false };
+      const { ctx } = system(cloudSync, [already], already);
+      const result = await scheduledTaskSetEnabled.execute(ctx, off(cloudSync));
+      expect(result).toMatchObject({
+        previously_enabled: false,
+        resulting_enabled: false,
+        changed: false,
+        confirmed: true,
+      });
+    });
+
+    it('says so in the plan when the task is already in the requested state', async () => {
+      const already = { ...cloudSync.row, enabled: false };
+      const [, mutation] = await scheduledTaskSetEnabled.plan(
+        system(cloudSync, [already], already).ctx,
+        off(cloudSync),
+      );
+      expect(mutation.description).toContain(
+        'It is already disabled, so this changes nothing and is not an error.',
+      );
+    });
+
+    it('says in the plan which way the switch will move', async () => {
+      const [, disabling] = await scheduledTaskSetEnabled.plan(
+        system(cloudSync).ctx,
+        off(cloudSync),
+      );
+      expect(disabling.description).toContain('It is enabled, so this will disable it.');
+      const offRow = { ...cloudSync.row, enabled: false };
+      const [, enabling] = await scheduledTaskSetEnabled.plan(
+        system(cloudSync, [offRow], { ...offRow, enabled: true }).ctx,
+        { kind: 'cloud_sync', id: 3, enabled: true },
+      );
+      expect(enabling.description).toContain('It is disabled, so this will enable it.');
+    });
+
+    it('refuses to claim a direction when the prior state is unreadable', async () => {
+      const unreadable = { ...cloudSync.row, enabled: 'yes' };
+      const [, mutation] = await scheduledTaskSetEnabled.plan(
+        system(cloudSync, [unreadable]).ctx,
+        off(cloudSync),
+      );
+      expect(mutation.description).toContain(
+        'Whether it is enabled could not be read, so this may change nothing.',
+      );
+    });
+
+    it('reports FOUND with a null prior state when the task stated no enabled', async () => {
+      const { ctx } = system(cloudSync, [{ ...cloudSync.row, enabled: 'yes' }]);
+      // The fourth cause of a null `previously_enabled`, which `lookup` alone
+      // does not separate from the other three.
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        lookup: 'FOUND',
+        previously_enabled: null,
+        resulting_enabled: false,
+        changed: null,
+      });
+    });
+
+    it('reports NOT_FOUND and still makes the update the plan named', async () => {
+      const { ctx, call } = system(cloudSync, []);
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        lookup: 'NOT_FOUND',
+        lookup_error: null,
+        previously_enabled: null,
+        resulting_enabled: false,
+        changed: null,
+        confirmed: true,
+      });
+      // Unconditional: skipping it would be `execute` branching on state read
+      // after the plan was approved.
+      expect(call).toHaveBeenCalledWith('cloudsync.update', [3, { enabled: false }]);
+    });
+
+    it('reports UNREADABLE with the reason, and still makes the update', async () => {
+      const { ctx, call } = failingSystem(
+        { ['cloudsync.update']: { ...cloudSync.row, enabled: false } },
+        { ['cloudsync.query']: new Error('websocket closed') },
+      );
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        lookup: 'UNREADABLE',
+        lookup_error: 'websocket closed',
+        previously_enabled: null,
+        changed: null,
+      });
+      expect(call).toHaveBeenCalledWith('cloudsync.update', [3, { enabled: false }]);
+    });
+
+    it('does not report success when the response disagrees with the request', async () => {
+      // The method answers with the updated task, so a response still reporting
+      // the old state is the system not having applied the change.
+      const { ctx } = system(cloudSync, [cloudSync.row], { ...cloudSync.row, enabled: true });
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        requested_enabled: false,
+        previously_enabled: true,
+        resulting_enabled: true,
+        changed: false,
+        confirmed: false,
+      });
+    });
+
+    it('establishes nothing about the result when the response states no enabled', async () => {
+      const { ctx } = system(cloudSync, [cloudSync.row], { ...cloudSync.row, enabled: 'yes' });
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        previously_enabled: true,
+        resulting_enabled: null,
+        changed: null,
+        confirmed: null,
+      });
+    });
+
+    it('establishes nothing about the result when the response is not a record', async () => {
+      const { ctx } = system(cloudSync, [cloudSync.row], true);
+      expect(await scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).toMatchObject({
+        resulting_enabled: null,
+        changed: null,
+        confirmed: null,
+      });
+    });
+
+    it('fails the call when the update itself rejects', async () => {
+      const { ctx } = failingSystem(
+        { ['cloudsync.query']: [cloudSync.row] },
+        { ['cloudsync.update']: { reason: 'task is locked' } },
+      );
+      await expect(scheduledTaskSetEnabled.execute(ctx, off(cloudSync))).rejects.toEqual({
+        reason: 'task is locked',
+      });
+    });
+  });
+
+  describe('the id it acts on', () => {
+    const cloudSync = kinds[1];
+
+    it('re-checks the id on the response rather than trusting the filter', async () => {
+      // An unrecognised query parameter is dropped rather than refused, so a
+      // filter that did not apply comes back as the whole table — and its first
+      // row is a different task.
+      const whole = [{ ...cloudSync.row, id: 1 }, { ...cloudSync.row, id: 2 }, cloudSync.row];
+      const [, mutation] = await scheduledTaskSetEnabled.plan(
+        system(cloudSync, whole).ctx,
+        off(cloudSync),
+      );
+      expect(mutation.params).toEqual([3, { enabled: false }]);
+      expect(mutation.description).toContain('(id 3)');
+    });
+
+    it('treats an answer that is not a list as no task of that kind', async () => {
+      const { ctx } = system(cloudSync, 7);
+      await expect(scheduledTaskSetEnabled.plan(ctx, off(cloudSync))).rejects.toThrow(
+        /No cloud sync task with id 3/,
+      );
+    });
+
+    it('skips a listed row that is not a record', async () => {
+      const { ctx } = system(cloudSync, [null, 'a row', cloudSync.row]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(cloudSync));
+      expect(mutation.description).toContain('description "Nightly Backblaze"');
+    });
+
+    it('skips a listed row whose own id is not a number', async () => {
+      const { ctx } = system(cloudSync, [{ ...cloudSync.row, id: '3' }]);
+      await expect(scheduledTaskSetEnabled.plan(ctx, off(cloudSync))).rejects.toThrow(
+        /No cloud sync task with id 3/,
+      );
+    });
+  });
+
+  describe('what the plan says about the task', () => {
+    const cloudSync = kinds[1];
+
+    it('states a field the system reported none of rather than dropping it', async () => {
+      const { ctx } = system(cloudSync, [
+        { ...cloudSync.row, description: '', path: null, direction: 7 },
+      ]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(cloudSync));
+      expect(mutation.description).toContain('description (the system reported none)');
+      expect(mutation.description).toContain('path (the system reported none)');
+      expect(mutation.description).toContain('direction (the system reported none)');
+    });
+
+    it('says a schedule it cannot render is one it cannot render, not one that is absent', async () => {
+      const { ctx } = system(cloudSync, [
+        { ...cloudSync.row, schedule: { minute: '*/7', hour: '*', dom: '*', month: '*', dow: '*' } },
+      ]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(cloudSync));
+      expect(mutation.description).toContain(
+        'schedule (not rendered in words here; `cloudsync_tasks_list` reports its cron fields)',
+      );
+    });
+
+    it('says the same for a task carrying no readable schedule at all', async () => {
+      const { ctx } = system(cloudSync, [{ ...cloudSync.row, schedule: null }]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(cloudSync));
+      expect(mutation.description).toContain('schedule (not rendered in words here');
+    });
+
+    it("renders a periodic snapshot task's daily window, which only it carries", async () => {
+      const snapshots = kinds[0];
+      const { ctx } = system(snapshots, [
+        {
+          ...snapshots.row,
+          schedule: {
+            minute: '0',
+            hour: '2',
+            dom: '*',
+            month: '*',
+            dow: '*',
+            begin: '09:00',
+            end: '17:00',
+          },
+        },
+      ]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(snapshots));
+      expect(mutation.description).toContain(
+        'schedule at 02:00, every day, between 09:00 and 17:00',
+      );
+    });
+
+    it("does not repeat a cron job's command, which can hold an inlined secret", async () => {
+      const cron = kinds[3];
+      const [, mutation] = await scheduledTaskSetEnabled.plan(system(cron).ctx, off(cron));
+      expect(mutation.description).not.toContain('hunter2');
+      expect(mutation.description).not.toContain('curl');
+    });
+
+    it("does not repeat a cloud backup task's repository passphrase", async () => {
+      const backup = kinds[5];
+      const [, mutation] = await scheduledTaskSetEnabled.plan(system(backup).ctx, off(backup));
+      expect(mutation.description).not.toContain('repository-passphrase');
+    });
+  });
+});

--- a/src/tools/scheduled-task-set-enabled.spec.ts
+++ b/src/tools/scheduled-task-set-enabled.spec.ts
@@ -164,6 +164,17 @@ describe('scheduled_task_set_enabled', () => {
     expect(description).toContain('ONLY THE `enabled` FIELD IS SENT');
   });
 
+  it('does not let `changed: false` claim the task was already in the requested state', () => {
+    // `changed` compares the two READINGS, so false covers the unapplied call
+    // as well as the no-op — the case at "does not report success when the
+    // response disagrees with the request" below. A description partitioning it
+    // on `changed` alone reads a still-enabled backup task as already off.
+    const description = scheduledTaskSetEnabled.description;
+    expect(description).toContain('WHICH IS TWO OUTCOMES AND NOT ONE');
+    expect(description).toContain('the call did not apply');
+    expect(description).toContain('`changed` must not be read without it');
+  });
+
   it('normalizes args: keeps the three and drops unknown keys', () => {
     expect(
       scheduledTaskSetEnabled.normalizeArgs?.({
@@ -500,6 +511,19 @@ describe('scheduled_task_set_enabled', () => {
       const { ctx } = system(cloudSync, [{ ...cloudSync.row, schedule: null }]);
       const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(cloudSync));
       expect(mutation.description).toContain('schedule (not rendered in words here');
+    });
+
+    it('points at no tool for a replication task, because none reports its cron fields', async () => {
+      // `replication_status` lists the id this tool takes and reports no
+      // `schedule` whatever, so the pointer the other five kinds carry would
+      // send the approver to a field that is not there.
+      const replication = kinds[2];
+      const { ctx } = system(replication, [{ ...replication.row, schedule: null }]);
+      const [, mutation] = await scheduledTaskSetEnabled.plan(ctx, off(replication));
+      expect(mutation.description).toContain(
+        'schedule (not rendered in words here, and no tool in this catalog reports its cron fields)',
+      );
+      expect(mutation.description).not.toContain('`replication_status` reports its cron fields');
     });
 
     it("renders a periodic snapshot task's daily window, which only it carries", async () => {

--- a/src/tools/scheduled-task-set-enabled.spec.ts
+++ b/src/tools/scheduled-task-set-enabled.spec.ts
@@ -240,7 +240,9 @@ describe('scheduled_task_set_enabled', () => {
       // Two steps because `execute` makes two calls. A plan naming only the
       // mutation would not be a true account of what runs.
       expect(steps.map((step) => step.method)).toEqual([spec.read, spec.update]);
-      expect(steps[0]).toMatchObject({ params: [[['id', '=', 3]]] });
+      // Two positional params, because `api.query(method, filters)` dispatches
+      // `[filters ?? [], options ?? {}]` — the plan names the call that runs.
+      expect(steps[0]).toMatchObject({ params: [[['id', '=', 3]], {}] });
       expect(steps[0].description).toMatch(/Changes nothing/);
     });
 

--- a/src/tools/scheduled-task-set-enabled.spec.ts
+++ b/src/tools/scheduled-task-set-enabled.spec.ts
@@ -223,10 +223,13 @@ describe('scheduled_task_set_enabled', () => {
     });
 
     it('executes nothing when an argument is unreadable', async () => {
-      const { call } = system(kinds[0]);
+      // The spy and the context have to come from the SAME fake system, or the
+      // assertion is about a system `execute` never saw and cannot fail.
+      const { ctx: own, query, call } = system(kinds[3]);
       await expect(
-        scheduledTaskSetEnabled.execute(ctx, { kind: 'cron', id: 3, enabled: 'yes' }),
+        scheduledTaskSetEnabled.execute(own, { kind: 'cron', id: 3, enabled: 'yes' }),
       ).rejects.toThrow(/"enabled" is required/);
+      expect(query).not.toHaveBeenCalled();
       expect(call).not.toHaveBeenCalled();
     });
   });

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
+import { MutatingTool, PlanStep, ReadOnlyTool, ToolContext } from '@/catalog/tool';
 import {
   booleanOrNull,
   errorText,
@@ -37,6 +37,12 @@ import {
  * once — scrubs, replication, cloud sync, app upgrades, updates — because every
  * long-running operation on TrueNAS is a job and they all land in the same
  * place.
+ *
+ * `scheduled_task_set_enabled` is the one tool here that changes anything, and
+ * it is the only one that acts on a kind another family lists: reading a task
+ * and then switching it off is one question, and which file the listing lives
+ * in is not part of it. It is written beside the schedule rendering above
+ * because a plan naming a task has to name it the way its listing tool does.
  */
 
 /**
@@ -1305,5 +1311,489 @@ export const tasksRecentRuns: ReadOnlyTool = {
       });
     }
     return rows;
+  },
+};
+
+/**
+ * `scheduled_task_set_enabled`: turning one scheduled task on or off, and the
+ * fourth mutating tool in the catalog.
+ *
+ * ONE TOOL OVER SIX KINDS, and unlike `automated_tasks_list` the reason is that
+ * the shape really is identical rather than that the missing kind is the
+ * finding. All six methods take `(id, { enabled })` and answer with the updated
+ * entity, so six tools would be six copies of one `plan`/`execute` pair
+ * differing in two strings — the eleven copies of `textOrNull` behind
+ * `common.ts` are what that becomes.
+ *
+ * THE KIND IS A REQUIRED ARGUMENT AND IS NEVER INFERRED. Task ids are
+ * per-table integers, so id `3` exists in all six tables and names six
+ * different things; a tool taking only an id would be ambiguous in the one way
+ * that matters, silently disabling the wrong task. Every kind's enum value
+ * names the tool its ids come from, in the description and in the failure.
+ *
+ * INIT/SHUTDOWN SCRIPTS ARE NOT A KIND HERE, and that is the #97 naming rule
+ * rather than a limit of the API — `InitShutdownScriptUpdate` carries `enabled`
+ * exactly as the six below do, and was checked. An init/shutdown script is not
+ * scheduled: it runs at a point in the system's lifecycle, carries no cron
+ * fields and reports no `schedule` at all, which is why `automated_tasks_list`
+ * is not called `scheduled_tasks_list`. Accepting one under a tool named
+ * `scheduled_task_set_enabled` would put that promise back one level down. It
+ * needs a tool whose name does not claim a schedule, which is its own ticket.
+ *
+ * ONLY `enabled` IS SENT. These are partial updates, so a tool that round-trips
+ * more of the row than it was asked to change can silently revert a concurrent
+ * edit — and every one of these update types declares fields this repository
+ * has no business writing.
+ *
+ * WHAT THE PLAN NAMES IS WHAT `execute` CALLS, INCLUDING THE READ, which is
+ * `alerts_dismiss`'s seam (#119) reached for the same reason: the prior state
+ * is only readable immediately before the call, and a plan naming only the
+ * mutation would omit a call the user is approving. The read is issued
+ * unconditionally and nothing branches on it, so `execute` stays a pure
+ * function of (args, system).
+ */
+
+/**
+ * One kind of scheduled task, and everything that differs between them.
+ *
+ * The two methods are literal strings inside {@link TaskKind.read} and
+ * {@link TaskKind.update} rather than fields the caller passes to `api.query`,
+ * so the client's own parameter and response types apply at each call site —
+ * the same reason `storage.ts` inlines its filters. `readMethod` and
+ * `updateMethod` restate them for the plan, which shows the caller what will
+ * run.
+ */
+interface TaskKind {
+  /** The `kind` argument's value, which is also what the failure names. */
+  kind: string;
+  /** What one of these is, in words, for the plan and for the failure. */
+  noun: string;
+  /** The catalog tool whose rows carry the `id` this tool takes. */
+  listedBy: string;
+  /** The middleware method the plan's read step names. */
+  readMethod: string;
+  /** The middleware method the plan's mutation step names. */
+  updateMethod: string;
+  /** Whatever the listing method answered with, unread. */
+  read(ctx: ToolContext, id: number): Promise<unknown>;
+  /** The updated entity the update method answered with, unread. */
+  update(ctx: ToolContext, id: number, enabled: boolean): Promise<unknown>;
+  /**
+   * The task in the terms its listing tool names it, label by label. A null
+   * value is stated as absent rather than dropped, as `describeAlert`'s three
+   * fields are: a plan that silently omits the description reads as a task
+   * without one, and the person approving cannot tell which.
+   */
+  label(row: Record<string, unknown>): [string, string | null][];
+}
+
+/**
+ * The task's schedule with its daily window where it has one, ready for
+ * {@link describeSchedule}.
+ *
+ * The window is read for every kind rather than only for the two that carry
+ * one: a kind whose schedule has no `begin` reads it as null, and
+ * {@link windowPhrase} renders nothing for a half window — so one reading
+ * covers all six without claiming a restriction a task does not have.
+ */
+function taskSchedule(row: Record<string, unknown>): (CronFields & Partial<DailyWindow>) | null {
+  const cron = cronOf(row['schedule']);
+  if (cron === null) return null;
+  return { ...cronFieldsOf(cron), begin: fieldOrNull(cron.begin), end: fieldOrNull(cron.end) };
+}
+
+/** What a label the system named no value for is stated as. */
+const NONE_REPORTED = '(the system reported none)';
+
+/**
+ * The schedule for the plan, in words.
+ *
+ * A schedule this tool does not render in words is stated as exactly that,
+ * never as one the system reported none of: `describeSchedule` answers null for
+ * both a missing field and a shape it will not put into English, and the two
+ * are a limit of this tool rather than a task without a schedule. The listing
+ * tool reports the cron fields exactly either way, so the caller is pointed at
+ * it.
+ */
+function schedulePhrase(spec: TaskKind, row: Record<string, unknown>): string {
+  const schedule = taskSchedule(row);
+  const words = schedule === null ? null : describeSchedule(schedule);
+  return `schedule ${words ?? `(not rendered in words here; \`${spec.listedBy}\` reports its cron fields)`}`;
+}
+
+/**
+ * The task in the terms its listing tool shows it, for the human approving the
+ * plan.
+ *
+ * An integer is not a thing anyone recognises, so the plan step names the task
+ * the way the tool that listed it does — its description or name, its dataset
+ * or path, and its schedule in the same English `tasks.ts` already produces.
+ */
+function describeTask(spec: TaskKind, row: Record<string, unknown>, id: number): string {
+  const labelled = spec
+    .label(row)
+    .map(([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`);
+  return `the ${spec.noun} with ${[...labelled, schedulePhrase(spec, row)].join(', ')} (id ${id})`;
+}
+
+/**
+ * The six kinds, in the order their listing tools are registered in.
+ *
+ * `cronjob.update`, `initshutdownscript.update` and the four below it are all
+ * on `DefaultApiDirectory` — checked there rather than on a later directory,
+ * since that is the surface these tools are written against (#91).
+ */
+const TASK_KINDS: TaskKind[] = [
+  {
+    kind: 'periodic_snapshot',
+    noun: 'periodic snapshot task',
+    listedBy: 'snapshot_tasks_list',
+    readMethod: 'pool.snapshottask.query',
+    updateMethod: 'pool.snapshottask.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('pool.snapshottask.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('pool.snapshottask.update', [id, { enabled }])),
+    label: (row) => [['dataset', textOrNull(row['dataset'])]],
+  },
+  {
+    kind: 'cloud_sync',
+    noun: 'cloud sync task',
+    listedBy: 'cloudsync_tasks_list',
+    readMethod: 'cloudsync.query',
+    updateMethod: 'cloudsync.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('cloudsync.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('cloudsync.update', [id, { enabled }])),
+    label: (row) => [
+      ['description', textOrNull(row['description'])],
+      ['path', textOrNull(row['path'])],
+      ['direction', textOrNull(row['direction'])],
+    ],
+  },
+  {
+    kind: 'replication',
+    noun: 'replication task',
+    listedBy: 'replication_status',
+    readMethod: 'replication.query',
+    updateMethod: 'replication.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('replication.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('replication.update', [id, { enabled }])),
+    label: (row) => [
+      ['name', textOrNull(row['name'])],
+      ['target dataset', textOrNull(row['target_dataset'])],
+    ],
+  },
+  {
+    kind: 'cron',
+    noun: 'cron job',
+    listedBy: 'automated_tasks_list',
+    readMethod: 'cronjob.query',
+    updateMethod: 'cronjob.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('cronjob.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('cronjob.update', [id, { enabled }])),
+    // The `command` is deliberately NOT among these. `automated_tasks_list`
+    // passes it through and says so, but it is whatever the operator typed and
+    // can hold a password someone inlined — and a plan is shown to a person and
+    // then recorded. The description and the user identify the job without
+    // repeating it, and the listing tool is where the command is read.
+    label: (row) => [
+      ['description', textOrNull(row['description'])],
+      ['user', textOrNull(row['user'])],
+    ],
+  },
+  {
+    kind: 'rsync',
+    noun: 'rsync task',
+    listedBy: 'automated_tasks_list',
+    readMethod: 'rsynctask.query',
+    updateMethod: 'rsynctask.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('rsynctask.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('rsynctask.update', [id, { enabled }])),
+    // `desc` is the middleware's own name for this one, reported under the
+    // sibling label so that one word means one thing across the six kinds — as
+    // `mapRsyncTask` already does for the listing.
+    label: (row) => [
+      ['description', textOrNull(row['desc'])],
+      ['path', textOrNull(row['path'])],
+      ['direction', textOrNull(row['direction'])],
+    ],
+  },
+  {
+    kind: 'cloud_backup',
+    noun: 'cloud backup task',
+    listedBy: 'automated_tasks_list',
+    readMethod: 'cloud_backup.query',
+    updateMethod: 'cloud_backup.update',
+    read: (ctx, id) =>
+      firstValueFrom(ctx.system.client.api.query('cloud_backup.query', [['id', '=', id]])),
+    update: (ctx, id, enabled) =>
+      firstValueFrom(ctx.system.client.api.call('cloud_backup.update', [id, { enabled }])),
+    label: (row) => [
+      ['description', textOrNull(row['description'])],
+      ['path', textOrNull(row['path'])],
+    ],
+  },
+];
+
+/** The kinds by name, which is also what the argument is validated against. */
+const TASK_KINDS_BY_NAME = new Map(TASK_KINDS.map((spec) => [spec.kind, spec]));
+
+/**
+ * The three arguments this tool takes, with the kind already resolved to the
+ * definition behind it — so nothing downstream has to look one up again and
+ * decide what to do if it is not there.
+ */
+interface TaskSwitch {
+  spec: TaskKind;
+  id: number;
+  enabled: boolean;
+}
+
+/**
+ * The caller's arguments, or the error naming what is wrong with them.
+ *
+ * Strict on all three, as `snapshots_create` is about `recursive` and for a
+ * sharper version of the same reason: coercing `"false"` to true would switch
+ * ON a backup task the caller asked to switch off, and a kind read loosely
+ * would act on a different table's id `3`. There is nothing here a wrong
+ * reading answers a narrower question — it answers a different one.
+ *
+ * `id` must be a whole number: the middleware holds these under integer
+ * primary keys, and `3.5` is not one of them.
+ */
+function parseSwitch(args: Record<string, unknown>): TaskSwitch {
+  const kind = args['kind'];
+  const spec = typeof kind === 'string' ? TASK_KINDS_BY_NAME.get(kind) : undefined;
+  if (spec === undefined) {
+    throw new Error(
+      `"kind" is required and must be one of ${TASK_KINDS.map((one) => one.kind).join(', ')}`,
+    );
+  }
+  const id = args['id'];
+  if (typeof id !== 'number' || !Number.isInteger(id)) {
+    throw new Error('"id" is required and must be a whole number');
+  }
+  const enabled = args['enabled'];
+  if (typeof enabled !== 'boolean') {
+    throw new Error('"enabled" is required and must be a boolean');
+  }
+  return { spec, id, enabled };
+}
+
+/**
+ * The row the system listed under this id, or null where it listed none that
+ * did.
+ *
+ * The id is checked on the RESPONSE and not only asked for in the filter. An
+ * unrecognised query parameter is dropped rather than refused, so a filter that
+ * did not apply comes back as the whole table and looks exactly like one that
+ * matched everything — and the first row of that is a different task, which is
+ * the one mistake this tool must not make. The filter is still sent, for the
+ * same reason `select` is sent in `tasks_recent_runs`: it bounds what crosses
+ * the wire, and it is not what decides.
+ */
+function rowWithId(rows: unknown, id: number): Record<string, unknown> | null {
+  if (!Array.isArray(rows)) return null;
+  for (const row of rows) {
+    const held = recordOrNull(row);
+    if (held !== null && numberOrNull(held['id']) === id) return held;
+  }
+  return null;
+}
+
+/**
+ * What the plan says the call will do, given the state the task is in now.
+ *
+ * Three cases and not two, as `alerts_dismiss`'s is: a task whose `enabled`
+ * could not be read as a boolean is neither already there nor about to move,
+ * and saying either would be a claim the read did not establish.
+ */
+function switchSentence(current: boolean | null, target: boolean): string {
+  if (current === null) {
+    return 'Whether it is enabled could not be read, so this may change nothing.';
+  }
+  if (current === target) {
+    return `It is already ${current ? 'enabled' : 'disabled'}, so this changes nothing and is not an error.`;
+  }
+  return `It is ${current ? 'enabled' : 'disabled'}, so this will ${target ? 'enable' : 'disable'} it.`;
+}
+
+/** The filter both `plan` and `execute` read the task with, as the method takes it. */
+function readParams(id: number): unknown {
+  return [[['id', '=', id]]];
+}
+
+export const scheduledTaskSetEnabled: MutatingTool = {
+  name: 'scheduled_task_set_enabled',
+  description:
+    'Turns one scheduled task on this TrueNAS system on or off, and changes ' +
+    'nothing else about it. Two-phase: called without a confirmation_token it ' +
+    'returns a plan for user approval; called with one it switches the task. ' +
+    'THE TASK IS NAMED BY `kind` AND `id` TOGETHER, AND `id` ALONE IS NEVER ' +
+    'ENOUGH: task ids are per-table integers, so id 3 exists under every kind ' +
+    'and means a different task under each. `kind` is one of ' +
+    '`periodic_snapshot`, whose ids come from `snapshot_tasks_list`; ' +
+    '`cloud_sync`, from `cloudsync_tasks_list`; `replication`, from ' +
+    '`replication_status`; `cron`, from the `cron_jobs` section of ' +
+    '`automated_tasks_list`; `rsync`, from its `rsync_tasks` section; and ' +
+    '`cloud_backup`, from its `cloud_backup_tasks` section. Every one of those ' +
+    'listing tools reports the `id` this tool takes, so no second lookup is ' +
+    'needed. INIT/SHUTDOWN SCRIPTS ARE NOT COVERED: they are not scheduled — ' +
+    'they run at a point in the system\'s lifecycle — and no tool here ' +
+    'switches one on or off. `enabled` is the state to move the task to, true ' +
+    'or false, and is required: there is no toggle, because a toggle acts on a ' +
+    'state read after the plan was approved. ONLY THE `enabled` FIELD IS SENT. ' +
+    'The schedule, paths, retention, credentials and every other setting are ' +
+    'left exactly as they are, and this tool cannot change them, cannot create ' +
+    'or delete a task, and cannot run one now. THE PLAN NAMES THE TASK IN ' +
+    'HUMAN TERMS — its description or name, its dataset or path, and its ' +
+    'schedule in words — beside the kind and the id, so that what is approved ' +
+    'is recognisable. A cron job\'s `command` is NOT repeated in the plan, ' +
+    'because it is whatever an operator typed and can contain a secret; ' +
+    '`automated_tasks_list` is where it is reported. PLANNING AGAINST AN id NO ' +
+    'TASK OF THAT KIND HAS FAILS, naming the id, the kind searched and the ' +
+    'tool that lists it — so an approved plan is always a plan about a task ' +
+    'that existed when it was made, and a failure here is very often the wrong ' +
+    '`kind` rather than a missing task. SWITCHING A TASK TO THE STATE IT IS ' +
+    'ALREADY IN IS NOT AN ERROR, and the result says which of the two ' +
+    'happened. `requested_enabled` is what was asked for. ' +
+    '`previously_enabled` is the task\'s state as read immediately before the ' +
+    'call. `resulting_enabled` is the state read back off the response the ' +
+    'update itself answered with, which is the updated task. `changed` is true ' +
+    'where those two disagree and false where they are the same — so false is ' +
+    '"it was already in that state", not "the call failed". ALL THREE OF ' +
+    '`previously_enabled`, `resulting_enabled` AND `changed` ARE NULL WHERE ' +
+    'THE STATE BEHIND THEM COULD NOT BE ESTABLISHED, WHICH IS NOT "NOTHING ' +
+    'CHANGED", and `changed` is null whenever either of the other two is. ' +
+    '`confirmed` is whether `resulting_enabled` is what was requested: true is ' +
+    'the system reporting back the state that was asked for, FALSE IS THE ' +
+    'SYSTEM REPORTING THE OTHER STATE AND IS NOT A SUCCESS — the call did not ' +
+    'reject and the task is not in the requested state — and null is a ' +
+    'response that stated no `enabled` this tool could read, under which ' +
+    'nothing here establishes what the task is now set to. `lookup` says what ' +
+    'the read before the call did: `FOUND` is a read that named this task, ' +
+    '`NOT_FOUND` a read that completed and listed no task of that kind with ' +
+    'that id (it was deleted between the plan and the confirmation), and ' +
+    '`UNREADABLE` a read that failed, with `lookup_error` naming why. IT HAS ' +
+    'THREE VALUES AND `previously_enabled` HAS FOUR CAUSES FOR ITS NULL: the ' +
+    'two above, and ALSO `FOUND` where the task stated no `enabled` this tool ' +
+    'could read as a boolean. So `lookup` alone does not tell them apart, and ' +
+    '`FOUND` beside a null `previously_enabled` is that fourth case. THE ' +
+    'UPDATE IS ATTEMPTED IN ALL THREE CASES, because what runs must be what ' +
+    'was approved. DISABLING A TASK IS CHEAP TO DO AND EXPENSIVE TO FORGET: a ' +
+    'disabled backup, replication or snapshot task stops protecting anything ' +
+    'and announces that nowhere — the listing tools report it as ' +
+    '`enabled: false` and nothing raises an alert. This tool is the exact ' +
+    'inverse of itself with `enabled` flipped.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      kind: {
+        type: 'string',
+        enum: TASK_KINDS.map((spec) => spec.kind),
+        description:
+          'Which kind of scheduled task the id names. `periodic_snapshot` ' +
+          '(ids from `snapshot_tasks_list`), `cloud_sync` (from ' +
+          '`cloudsync_tasks_list`), `replication` (from `replication_status`), ' +
+          '`cron`, `rsync` and `cloud_backup` (from the matching sections of ' +
+          '`automated_tasks_list`). Required: an id alone names a different ' +
+          'task under every kind.',
+      },
+      id: {
+        type: 'integer',
+        description:
+          "The task's `id` as its listing tool reports it, on the system being " +
+          'targeted. It is unique only within its own kind.',
+      },
+      enabled: {
+        type: 'boolean',
+        description:
+          'The state to move the task to: true switches it on, false switches ' +
+          'it off. Required — this is not a toggle.',
+      },
+    },
+    required: ['kind', 'id', 'enabled'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    const { spec, id, enabled } = parseSwitch(rawArgs);
+    return { kind: spec.kind, id, enabled };
+  },
+  async plan(ctx, rawArgs): Promise<PlanStep[]> {
+    const { spec, id, enabled } = parseSwitch(rawArgs);
+    const row = rowWithId(await spec.read(ctx, id), id);
+    // The failure names the kind as well as the id, because a caller that
+    // reached here with the right id and the wrong kind sees an id it can
+    // check and a kind it cannot. `assertDatasetExists` fails the same way for
+    // `snapshots_create`, with one fewer thing to get wrong.
+    if (row === null) {
+      throw new Error(
+        `No ${spec.noun} with id ${id} on this system — the kind searched was ` +
+          `"${spec.kind}", whose ids come from \`${spec.listedBy}\``,
+      );
+    }
+    return [
+      {
+        method: spec.readMethod,
+        params: readParams(id),
+        description:
+          `Read this system's ${spec.noun} with id ${id}, to report whether it was ` +
+          'already in the state this call moves it to. Changes nothing.',
+      },
+      {
+        method: spec.updateMethod,
+        params: [id, { enabled }],
+        description:
+          `${enabled ? 'Enable' : 'Disable'} ${describeTask(spec, row, id)}. ` +
+          `Only the enabled flag is sent. ${switchSentence(booleanOrNull(row['enabled']), enabled)}`,
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const { spec, id, enabled } = parseSwitch(rawArgs);
+    // Caught rather than thrown: this read exists to describe the outcome, and
+    // letting it fail the call would lose an approval the user has already
+    // given for a mutation that is still safe to make. The result then says the
+    // prior state could not be established.
+    let row: Record<string, unknown> | null = null;
+    let lookupError: string | null = null;
+    try {
+      row = rowWithId(await spec.read(ctx, id), id);
+    } catch (reason) {
+      lookupError = errorText(reason);
+    }
+    // Unconditional, whatever the read said. Skipping the update for a task the
+    // read no longer lists would be `execute` branching on state read at
+    // execution time, which is what the confirmation token cannot bind.
+    const updated = await spec.update(ctx, id, enabled);
+    const previous = row === null ? null : booleanOrNull(row['enabled']);
+    // The method answers with the updated task, so what it says about `enabled`
+    // is the state that actually resulted — read back through the same guard
+    // rather than echoing what was asked for.
+    const resulting = booleanOrNull(recordOrNull(updated)?.['enabled']);
+    return {
+      kind: spec.kind,
+      id,
+      requested_enabled: enabled,
+      lookup: lookupError !== null ? 'UNREADABLE' : row === null ? 'NOT_FOUND' : 'FOUND',
+      lookup_error: lookupError,
+      previously_enabled: previous,
+      resulting_enabled: resulting,
+      // Both readings or nothing. A `changed` derived from the request rather
+      // than from the response would report a call the system did not apply as
+      // having changed something.
+      changed: previous === null || resulting === null ? null : previous !== resulting,
+      confirmed: resulting === null ? null : resulting === enabled,
+    };
   },
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1370,6 +1370,19 @@ interface TaskKind {
   noun: string;
   /** The catalog tool whose rows carry the `id` this tool takes. */
   listedBy: string;
+  /**
+   * The catalog tool that reports this kind's cron fields, or null where no
+   * tool here reports them.
+   *
+   * It is {@link TaskKind.listedBy} for five of the six and null for
+   * `replication`: `replication_status` answers about a task's state and its
+   * last run and carries no `schedule` at all, so the fallback in
+   * {@link schedulePhrase} pointing at it would send the person approving the
+   * plan to a field that is not there. Listing a kind's id and reporting its
+   * schedule are two different promises, and only the first is what `listedBy`
+   * makes.
+   */
+  cronFieldsListedBy: string | null;
   /** The middleware method the plan's read step names. */
   readMethod: string;
   /** The middleware method the plan's mutation step names. */
@@ -1411,14 +1424,25 @@ const NONE_REPORTED = '(the system reported none)';
  * A schedule this tool does not render in words is stated as exactly that,
  * never as one the system reported none of: `describeSchedule` answers null for
  * both a missing field and a shape it will not put into English, and the two
- * are a limit of this tool rather than a task without a schedule. The listing
- * tool reports the cron fields exactly either way, so the caller is pointed at
- * it.
+ * are a limit of this tool rather than a task without a schedule.
+ *
+ * Where a tool here does report the cron fields exactly, the caller is pointed
+ * at it — and that is {@link TaskKind.cronFieldsListedBy} rather than
+ * {@link TaskKind.listedBy}, because for `replication` no tool does. A pointer
+ * naming a tool that answers nothing about the schedule is worse than no
+ * pointer: it reads as the exact account being one call away, and the approver
+ * who makes that call finds no such field and cannot tell a tool that omits it
+ * from a task that has none.
  */
 function schedulePhrase(spec: TaskKind, row: Record<string, unknown>): string {
   const schedule = taskSchedule(row);
   const words = schedule === null ? null : describeSchedule(schedule);
-  return `schedule ${words ?? `(not rendered in words here; \`${spec.listedBy}\` reports its cron fields)`}`;
+  if (words !== null) return `schedule ${words}`;
+  return `schedule ${
+    spec.cronFieldsListedBy === null
+      ? '(not rendered in words here, and no tool in this catalog reports its cron fields)'
+      : `(not rendered in words here; \`${spec.cronFieldsListedBy}\` reports its cron fields)`
+  }`;
 }
 
 /**
@@ -1452,6 +1476,7 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'periodic_snapshot',
     noun: 'periodic snapshot task',
     listedBy: 'snapshot_tasks_list',
+    cronFieldsListedBy: 'snapshot_tasks_list',
     readMethod: 'pool.snapshottask.query',
     updateMethod: 'pool.snapshottask.update',
     read: (ctx, id) =>
@@ -1464,6 +1489,7 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'cloud_sync',
     noun: 'cloud sync task',
     listedBy: 'cloudsync_tasks_list',
+    cronFieldsListedBy: 'cloudsync_tasks_list',
     readMethod: 'cloudsync.query',
     updateMethod: 'cloudsync.update',
     read: (ctx, id) =>
@@ -1480,6 +1506,9 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'replication',
     noun: 'replication task',
     listedBy: 'replication_status',
+    // The one kind whose listing tool reports no schedule: `replication_status`
+    // answers what the task's last run did, not when the next one is due.
+    cronFieldsListedBy: null,
     readMethod: 'replication.query',
     updateMethod: 'replication.update',
     read: (ctx, id) =>
@@ -1495,6 +1524,7 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'cron',
     noun: 'cron job',
     listedBy: 'automated_tasks_list',
+    cronFieldsListedBy: 'automated_tasks_list',
     readMethod: 'cronjob.query',
     updateMethod: 'cronjob.update',
     read: (ctx, id) =>
@@ -1515,6 +1545,7 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'rsync',
     noun: 'rsync task',
     listedBy: 'automated_tasks_list',
+    cronFieldsListedBy: 'automated_tasks_list',
     readMethod: 'rsynctask.query',
     updateMethod: 'rsynctask.update',
     read: (ctx, id) =>
@@ -1534,6 +1565,7 @@ const TASK_KINDS: TaskKind[] = [
     kind: 'cloud_backup',
     noun: 'cloud backup task',
     listedBy: 'automated_tasks_list',
+    cronFieldsListedBy: 'automated_tasks_list',
     readMethod: 'cloud_backup.query',
     updateMethod: 'cloud_backup.update',
     read: (ctx, id) =>
@@ -1681,8 +1713,11 @@ export const scheduledTaskSetEnabled: MutatingTool = {
     '`previously_enabled` is the task\'s state as read immediately before the ' +
     'call. `resulting_enabled` is the state read back off the response the ' +
     'update itself answered with, which is the updated task. `changed` is true ' +
-    'where those two disagree and false where they are the same — so false is ' +
-    '"it was already in that state", not "the call failed". ALL THREE OF ' +
+    'where those two disagree and false where they are the same, WHICH IS TWO ' +
+    'OUTCOMES AND NOT ONE: either the task was already in the requested state, ' +
+    'or the call did not apply and left it in the other one. `confirmed` is ' +
+    'what tells those two apart, and `changed` must not be read without it. ' +
+    'ALL THREE OF ' +
     '`previously_enabled`, `resulting_enabled` AND `changed` ARE NULL WHERE ' +
     'THE STATE BEHIND THEM COULD NOT BE ESTABLISHED, WHICH IS NOT "NOTHING ' +
     'CHANGED", and `changed` is null whenever either of the other two is. ' +

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1437,11 +1437,15 @@ function describeTask(spec: TaskKind, row: Record<string, unknown>, id: number):
 }
 
 /**
- * The six kinds, in the order their listing tools are registered in.
+ * The six kinds, in the order the `kind` enum advertises them: the three with a
+ * listing tool of their own first, then the three `automated_tasks_list` covers
+ * in the order its sections are returned in. It is not the order
+ * `createDefaultCatalog` registers those tools in, and nothing depends on
+ * either — the enum is a set, and the order is only what a caller reads.
  *
- * `cronjob.update`, `initshutdownscript.update` and the four below it are all
- * on `DefaultApiDirectory` — checked there rather than on a later directory,
- * since that is the surface these tools are written against (#91).
+ * Every one of the six update methods is on `DefaultApiDirectory`, checked
+ * there rather than on a later directory, since that is the surface these tools
+ * are written against (#91).
  */
 const TASK_KINDS: TaskKind[] = [
   {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1626,9 +1626,18 @@ function switchSentence(current: boolean | null, target: boolean): string {
   return `It is ${current ? 'enabled' : 'disabled'}, so this will ${target ? 'enable' : 'disable'} it.`;
 }
 
-/** The filter both `plan` and `execute` read the task with, as the method takes it. */
+/**
+ * The params the read step actually reaches the middleware with.
+ *
+ * The empty options object is not padding: `api.query(method, filters)`
+ * dispatches `[filters ?? [], options ?? {}]`, so the call carries two
+ * positional params whether or not the caller passed the second. A plan step
+ * naming only the filter would be showing the user a call one argument shorter
+ * than the one that runs — which is the same defect as a plan naming only the
+ * mutation, one level down.
+ */
 function readParams(id: number): unknown {
-  return [[['id', '=', id]]];
+  return [[['id', '=', id]], {}];
 }
 
 export const scheduledTaskSetEnabled: MutatingTool = {


### PR DESCRIPTION
Adds `scheduled_task_set_enabled`, the fourth mutating tool in the catalog: one tool that turns one scheduled task on or off, across every task kind whose update method takes an `enabled` field.

Fixes #121

## What it does

One `MutatingTool` over **six kinds** — `periodic_snapshot`, `cloud_sync`, `replication`, `cron`, `rsync`, `cloud_backup` — because all six methods are literally the same call: `(id, { enabled })` in, the updated entity out. Six tools would be six copies of one `plan`/`execute` pair differing in two strings, which is what `common.ts` was cut to stop.

- **`destructiveness: 'reversible'`, `requiredRole: Role.Full`, `mutating: true`.** The inverse is this tool with the flag flipped, which is as literal as reversibility gets.
- **Only the `enabled` field is sent.** These are partial updates, so round-tripping more of the row than was asked for can silently revert a concurrent edit.
- **The kind is a required argument and is never inferred.** Task ids are per-table integers, so id `3` exists under every kind and names a different task under each. Each enum value names the tool its ids come from — `snapshot_tasks_list`, `cloudsync_tasks_list`, `replication_status`, and the three sections of `automated_tasks_list` — in the description and in the plan's failure, because a caller that reached the failure with the right id and the wrong kind can check the id and cannot check the kind.

## The ticket's unconfirmed half, settled

The ticket left it open whether rsync, cloud backup and init/shutdown update types carry `enabled`. Checked against `DefaultApiDirectory` in the pinned client: **all three do.**

- **rsync and cloud backup are in.** `RsyncTaskUpdate.enabled?: boolean`, `CloudBackupUpdate.enabled?: boolean`.
- **init/shutdown scripts are deliberately out, and it is not the API stopping it.** `InitShutdownScriptUpdate` declares `enabled` too. An init/shutdown script is not *scheduled* — it runs at a point in the system's lifecycle, carries no cron fields and reports no `schedule` at all, which is exactly why `automated_tasks_list` is not called `scheduled_tasks_list` (`CLAUDE.md`, #97). Accepting one under a tool named `scheduled_task_set_enabled` would put that promise back one level down. **This is the one place I narrowed the ticket's conditional**, and it needs a tool whose name does not claim a schedule rather than an argument added here — proposed as a follow-up ticket on #121.

## Plan and outcome

**The plan names the read `execute` makes as well as the mutation** (#119). `execute` reads immediately before the call, because the prior state is only readable there; a plan naming only the mutation would omit a call the user is approving. The read is issued unconditionally and nothing branches on it, so `execute` stays a pure function of (args, system).

The plan names the task the way its listing tool does — description or name, path or dataset, and the schedule in the English `tasks.ts` already renders — beside the kind and the id, and fails when no task of that kind carries that id. **A cron job's `command` is not repeated there**: it is whatever the operator typed and can hold an inlined credential, and a plan is shown to a person and then recorded. `automated_tasks_list` is where it is reported.

**Where the schedule will not render in words, the plan points at the tool that reports the cron fields exactly — except for `replication`, where no tool does.** `TaskKind` carries `cronFieldsListedBy` beside `listedBy` for that reason: they are the same tool for five of the six kinds, and null for `replication`, because `replication_status` reports a task's state and its last run and carries no `schedule` at all. Listing a kind's id and reporting its schedule are two different promises, and only the first is what `listedBy` makes. The `replication` fallback says outright that no tool in the catalog reports them rather than naming one that does not.

**The outcome is read from the response, never from the request.** These methods answer with the updated task, so `resulting_enabled` comes off that response through the same guard the row was read with, and `changed` is `previously_enabled !== resulting_enabled` — two readings or null. `confirmed` is the separate fact that the response agrees with the request, and **`confirmed: false` is not a success**: the call did not reject and the task is not in the state that was asked for.

**`changed: false` is two outcomes, not one, and the description says so.** It compares the two *readings*, so it is false both where the task was already in the requested state and where the call did not apply and left it in the other one — the second being exactly the `confirmed: false` case above. `confirmed` is what tells them apart, and the description says `changed` must not be read without it.

`lookup` (`FOUND` / `NOT_FOUND` / `UNREADABLE`) has three values and `previously_enabled` has four causes for its null — the fourth being `FOUND` on a task that stated no readable `enabled`. The description says so outright rather than letting `lookup` look like it partitions the outcome.

**The id is checked on the response, not trusted to the filter.** The read passes `[['id', '=', id]]` and then finds the row by id anyway: an unrecognised query parameter is dropped rather than refused (the mechanism #115 already states for `select`), so a filter that did not apply returns the whole table and looks identical to one that matched everything — and its first row is a different task.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test` (1,167 passing), `yarn test:coverage` (99.73% statements / 99.42% branches global, `tasks.ts` 100/100) and `yarn build` all run locally and pass on the head commit. Nothing was skipped.

## Review rounds

Five local rounds ran through `local-review.py`. Rounds 1–3 ran the shared reviewer itself — the same one the required check runs — and round 3 came back clean (exit 0). Both MEDIUMs from rounds 1–2 are fixed in their own commits:

- a test that built a second fake system for its spy and passed a different context to `execute`, so it asserted about a system the call never saw and could not fail;
- the read plan step naming one positional param where `api.query(method, filters)` dispatches `[filters ?? [], options ?? {}]` — the plan showed a call one argument shorter than the one that runs.

**The required check then raised a MEDIUM the local rounds had not**, and round 4 is the answer to it: the `changed` field's description partitioned "already in that state" from "the call failed", which is precisely backwards for the case the field was widened to catch. The rewording is in the *Plan and outcome* section above. Round 4's own run of the shared reviewer raised a second MEDIUM — the `replication` cron-fields pointer — which is fixed in the same commit and described above.

**Round 5 is the weaker kind.** The shared reviewer timed out at its 420s cap without producing findings, so `local-review.py` exited 2 and the round was run by a subagent against the same brief — same rubric, same threshold, a different reader. It came back with no finding at MEDIUM or above. **Treat that as a weaker signal than rounds 1–3's exit 0**, which was the check's own reviewer.

## What I did not change, and why

Six LOWs are left for a reviewer or a later ticket. Four are carried over from round 3 and two were raised against round 4's own commit:

- **`NONE_REPORTED` duplicates `alerts.ts`'s identical `(the system reported none)` wording**, which `CLAUDE.md` names as the kind of thing belonging in `common.ts`. Real, and promoting a shared constant is a change to two families' files that this ticket did not otherwise touch — the same bar `strictTextList` was promoted at, once a third caller appeared.
- **`readParams` is used only by the plan step while each kind's `read` inlines its own filter**, so the two can drift. Binding them would mean passing a non-literal filter, which widens the client's inferred types and loses the compile-time check that a filter matches its entity (#115's inline rule). The spec asserts both shapes.
- **`rowWithId` folds a read that answered with something other than a list into the same null as a genuine miss**, so a non-list answer reports `NOT_FOUND` and the plan fails as though the task were absent. A rejected read is already separated (`UNREADABLE`); this is the narrower case of a read that completed and answered a shape the tool cannot use. Worth a third value, and worth stating in the description. The required check raised this one too, and agreed it is LOW.
- **The six reads pass no `select`**, so whole rows cross the wire — including `cloud_backup.password` and the credential records. Nothing reaches a caller: the plan names an allowlist of fields and the result reports only booleans. Adding `select` is the same bandwidth measure `tasks_recent_runs` takes, and #115 is explicit that it is not the boundary.
- **The description carries no per-system warning for `id`** of the kind `alerts_dismiss` carries for `uuid`. An integer task id collides across systems far more readily than a uuid does, and under `systems: all` that matters. The argument description does say the id is read "on the system being targeted"; a fan-out caveat as prominent as `alerts_dismiss`'s would be better. Raised by both the required check and round 4.
- **The five kinds that do have a `cronFieldsListedBy` point at it for both reasons the words can be missing** — a schedule in a shape `describeSchedule` will not render, and a row carrying no readable `schedule` at all — and in the second case the tool named will answer `schedule: null`. The conflation is deliberate and stated in `schedulePhrase`'s JSDoc: it errs toward refusing to claim the task has no schedule, which is the safe direction, and unlike the `replication` case the listing tool does still report a `schedule` key whose null its own description explains.

Two assertions in `scheduled-task-set-enabled.spec.ts` cannot fail independently of the `toEqual`/`toContain` immediately above them — `not.toContain('init_shutdown_script')` and `not.toContain('\`replication_status\` reports its cron fields')`. Both document intent and add no coverage. Left rather than removed, since the whole diff is already reviewed and each removal is a fresh unreviewed one.

## Documentation

`app/CLAUDE.md` gains a `#121` decision for what a later cycle cannot infer: that a tool named for a category may not accept a member of another one even where the API permits it, why one tool over six kinds is *not* #97's section test, that a mutating tool's outcome is read from what came back, and that a filter is bandwidth while the check on the response is the control. The #87 split trigger's bullet records that `tasks.spec.ts` crossed 1,500 lines here (1,352 + ~460) where #97's fourth tool did not, so the tests took `scheduled-task-set-enabled.spec.ts` and the four listing tools stayed put.
