### PR TITLE
feat(tools): add cloudsync_run, the catalog's first job-backed mutation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -990,12 +990,25 @@ failed sync as a success. A terminal state this catalog does not recognise is
 **not** read as a success, which is `tasks_recent_runs`'s direction: a run that
 cannot be shown to have worked has not been shown to have worked.
 
-**Three answers, not two, and the description says which is which.** `ended`
-false is a sync still going and says nothing about whether it will work;
-`succeeded` null is that case or an unreadable state, and is neither a failure
-nor a success. The tool reports no progress percentage and no live status, and
-names `tasks_recent_runs` — whose `id` is this tool's `job_id` — as where a
-still-running sync is followed up.
+**`ended: false` is "not established", and the description must not enumerate
+it as a partition.** It covers a sync still going, a watch cut short by an
+error, a state the client does not treat as terminal, an unreadable state, and
+no job seen at all — and `state` and `job_id` narrow that without separating the
+first three. Two review rounds were spent here on one sentence promising three
+answers over four causes and then telling a caller which was which. **A
+not-established field is not a status enum**; say what it rules out and name
+what cannot be told apart. `succeeded` null is every one of those cases, and is
+neither a failure nor a success. The tool reports no progress percentage and no
+live status, and names `tasks_recent_runs` — whose `id` is this tool's `job_id`
+— as where a still-running sync is followed up.
+
+**A state that looks like a success does not make one, and that is the same
+rule.** `succeeded` is null beside a `state` of `SUCCESS` where the run was not
+established to be over, because the outcome is read off `ended` and a job can
+move out of a state this tool merely saw. **Do not describe an unrecognised
+terminal state as reporting `succeeded: false`** — the honest claim is the
+weaker one this tool actually makes, that no state the catalog does not know is
+ever read as a success, whichever way the watch ended.
 
 **A plan names what the operation does to the data, not what the tool's name
 suggests it does.** `cloudsync_run` starts a task whose own `transfer_mode` — a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1051,6 +1051,19 @@ happened here twice. **Where a field's declared meaning and a tool's use of it
 come apart, fix the declaration** — the local comment then says which case the
 tool is, not what the field means.
 
+**The declaration was not the only place saying the old thing, and a rule is
+only fixed where every statement of it is.** `ToolCatalog.register`'s rejection
+message said the policy keeps irreversibly destructive *operations* out of the
+catalog, and `README.md` said it again in the same words — a guarantee broader
+than the check, which rejects a tool that COMPOSES such an operation and says
+nothing about one that triggers an operation an operator authored. Both now say
+the narrower true thing, and `AdvertisedTool.destructiveness` — the field an
+adapter actually reads, which had no doc comment at all — carries the pointer to
+`Destructiveness` and the warning not to read it alone. **When a redefinition
+lands, grep for the sentence it replaces**: the enforcement point, the advertised
+shape and the user-facing description each state a field's meaning
+independently, and a reader reaches whichever one is nearest.
+
 **The plan names one call, which is #119's distinction rather than a lapse.**
 `scheduled_task_set_enabled` names its read as a step because `execute` makes
 it; this tool reads only at plan time — to name the task, and to fail on an id

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1022,6 +1022,18 @@ catalog cannot read says so rather than defaulting to the harmless one — an
 approver told nothing about deletion reads the silence as "nothing is deleted",
 which is the one reading that costs data.
 
+**A plan identifies an entity every way the listing it borrows its terms from
+does.** A cloud sync task's `credentials` is declared a whole record and the
+middleware also sends the id-only form, which is why `credentialId` exists and
+why `cloudsync_tasks_list` reports `credential_id` beside `credential_name`. A
+plan reading only the name renders "credential (the system reported none)" for
+a task that named its credential perfectly well — **a reduced identification is
+not a shorter answer but a STATED ABSENCE**, and it is stated in the one text a
+person reads before approving. Both labels are carried, under the listing's own
+field names so the two accounts cannot be read as two facts. This is #93's
+direction rule reaching a plan: a field dropping towards a claim has to be
+refused, and "no credential" is a claim.
+
 **`destructiveness` is about the operation, not about the bytes, and it cannot
 say both.** A cloud sync run can be stopped; what it has already written or
 deleted is gone. The field is `reversible` because `irreversible` exists only so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -982,11 +982,21 @@ which is the one reading that costs data.
 **`destructiveness` is about the operation, not about the bytes, and it cannot
 say both.** A cloud sync run can be stopped; what it has already written or
 deleted is gone. The field is `reversible` because `irreversible` exists only so
-the catalog can REJECT a tool (`catalog/tool.ts`), so the other value would
-remove the tool rather than describe it more honestly. **Where those two come
-apart, the field records the operation and the description carries the account of
-the data** — and the description then may not claim reversibility on the field's
-behalf.
+the catalog can REJECT a tool — `catalog/catalog.ts` throws on registration — so
+the other value would delete this tool rather than describe it more honestly.
+**Where those two come apart, the field records the operation and the
+description carries the account of the data**, and the description then may not
+claim reversibility on the field's behalf.
+
+What decides which value a triggering tool takes is **whether it authors the
+destruction or only its timing.** Everything a cloud sync run deletes was
+decided by whoever configured the task, and the system does the same thing
+unattended at the next scheduled window; this tool moves the moment, not the
+effect. A tool that composed a deletion of its own — chose the paths, or the
+mode — would be the case the destructive-action policy is actually about, and
+would not belong in the catalog at all. **Ask which of those two a new mutating
+tool is before reaching for either value**, and say the answer where the tool
+declares it rather than leaving the field to carry an argument on its own.
 
 **The plan names one call, which is #119's distinction rather than a lapse.**
 `scheduled_task_set_enabled` names its read as a step because `execute` makes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -967,6 +967,27 @@ nor a success. The tool reports no progress percentage and no live status, and
 names `tasks_recent_runs` — whose `id` is this tool's `job_id` — as where a
 still-running sync is followed up.
 
+**A plan names what the operation does to the data, not what the tool's name
+suggests it does.** `cloudsync_run` starts a task whose own `transfer_mode` — a
+required field on the pinned entity — decides whether the run DELETES anything:
+`COPY` deletes nothing, `SYNC` removes whatever at the destination is not at the
+source, and `MOVE` removes the source once the copy lands. A plan step reading
+"this copies data" would have been true for one of the three and would have
+hidden a deletion behind the word the tool is named for. The mode is named in
+the plan, its effect is spelled out in the mode's own terms, and a mode this
+catalog cannot read says so rather than defaulting to the harmless one — an
+approver told nothing about deletion reads the silence as "nothing is deleted",
+which is the one reading that costs data.
+
+**`destructiveness` is about the operation, not about the bytes, and it cannot
+say both.** A cloud sync run can be stopped; what it has already written or
+deleted is gone. The field is `reversible` because `irreversible` exists only so
+the catalog can REJECT a tool (`catalog/tool.ts`), so the other value would
+remove the tool rather than describe it more honestly. **Where those two come
+apart, the field records the operation and the description carries the account of
+the data** — and the description then may not claim reversibility on the field's
+behalf.
+
 **The plan names one call, which is #119's distinction rather than a lapse.**
 `scheduled_task_set_enabled` names its read as a step because `execute` makes
 it; this tool reads only at plan time — to name the task, and to fail on an id

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -943,6 +943,18 @@ route was taken.** `api.job` is `callAndGetJobId` piped into `trackJob`, and
 silently aborted a half-finished upload would be the worst defect such a tool
 could have, so this is checked against the client rather than assumed of it.
 
+**An error raised while FOLLOWING the job is not the call failing, and must not
+be reported as one.** `trackJob` reads `core.get_jobs` and listens on a socket
+that can drop, so the stream can error long after the mutation landed. Letting
+that reject the handler tells the caller the sync failed when it is running, and
+throws away the job id in the same act — the unnameable-run failure the bound
+exists to prevent, reached from the other side. So an error after the client has
+reported on the job ends the watch and the result says what was established,
+which is `ended: false`. An error BEFORE the first emission still fails: there
+is no id to keep, nothing to report, and the likeliest cause is the call being
+rejected. **A mutating tool that follows its own effect has two failure eras,
+and only the first of them is the call's.**
+
 **Whether the job ended is read from the tracking COMPLETING, not from a state
 list.** The client completes the stream on its own `isJobFinished`, so
 completion moves with the middleware's terminal set instead of with a set
@@ -952,13 +964,21 @@ anything is called ended.
 
 **Every other field that means "the run is over" is then read off THAT, not off
 a second list.** `finished_at` gates on `ended` rather than through
-`jobFinishedAt`, whose `ENDED_JOB_STATES` is a set written down in this
-repository: a terminal state a later TrueNAS release adds completes the client's
-stream and is absent from that set, so the two disagree exactly on the case this
-tool is careful about, and the result would call a run over and refuse to say
-when it ended. The listings keep reading the set because none of them carries an
-`ended` for it to contradict. **A tool with two derivations of one fact has to
-make one of them subordinate**, and the subordinate one is the local list.
+`jobFinishedAt`, whose `ENDED_JOB_STATES` is this repository's own set. The two
+are **equal on the pinned client** — its `terminalStates`, which is what
+`isJobFinished` tests and so what completes the tracking, holds exactly those
+five states, read out of `dist/index.js` rather than assumed — so this is not a
+bug being fixed. It is two independently maintained lists that happen to agree,
+and a client release widening its own would have this result call a run ended
+and refuse to say when it ended. **A tool with two derivations of one fact makes
+one of them subordinate**, and the subordinate one is the local list. The
+listings keep reading the set: none of them carries an `ended` to disagree with.
+
+The trap that costs a round here is stating the divergence as something a later
+**TrueNAS** release does. It is not: the terminal set is the CLIENT's, so only a
+client bump moves it, and nothing a middleware adds reaches it on its own. A
+job in a state neither list names does not complete the tracking at all — it
+runs until the bound expires and reports `ended: false`.
 
 **Terminal does not mean succeeded, and on this method there is nothing else to
 read.** `cloudsync.sync` declares `response: null`, so the job's `result` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -950,6 +950,16 @@ written down here. A completion carrying no emission is the client having found
 no such job, which establishes nothing — so both halves are required before
 anything is called ended.
 
+**Every other field that means "the run is over" is then read off THAT, not off
+a second list.** `finished_at` gates on `ended` rather than through
+`jobFinishedAt`, whose `ENDED_JOB_STATES` is a set written down in this
+repository: a terminal state a later TrueNAS release adds completes the client's
+stream and is absent from that set, so the two disagree exactly on the case this
+tool is careful about, and the result would call a run over and refuse to say
+when it ended. The listings keep reading the set because none of them carries an
+`ended` for it to contradict. **A tool with two derivations of one fact has to
+make one of them subordinate**, and the subordinate one is the local list.
+
 **Terminal does not mean succeeded, and on this method there is nothing else to
 read.** `cloudsync.sync` declares `response: null`, so the job's `result` is
 null on success and on failure alike; the client says as much itself. The
@@ -995,8 +1005,18 @@ unattended at the next scheduled window; this tool moves the moment, not the
 effect. A tool that composed a deletion of its own — chose the paths, or the
 mode — would be the case the destructive-action policy is actually about, and
 would not belong in the catalog at all. **Ask which of those two a new mutating
-tool is before reaching for either value**, and say the answer where the tool
-declares it rather than leaving the field to carry an argument on its own.
+tool is before reaching for either value.**
+
+**That rule is written at `Destructiveness`'s own declaration, and that is where
+it had to go.** `ToolCatalog.list()` puts `destructiveness` into every
+`AdvertisedTool`, so an adapter deciding how loudly to warn reads the field's
+doc comment — which said only "how hard a mutating tool is to undo" while a
+tool three fields away said `NOTHING HERE UNDOES ANY OF THAT`. A redefinition
+that lives in one tool's comment and in this file is not one the next tool over
+the seam inherits; a reviewer re-derives it per tool instead, which is what
+happened here twice. **Where a field's declared meaning and a tool's use of it
+come apart, fix the declaration** — the local comment then says which case the
+tool is, not what the field means.
 
 **The plan names one call, which is #119's distinction rather than a lapse.**
 `scheduled_task_set_enabled` names its read as a step because `execute` makes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -898,6 +898,84 @@ without it, and a plan is shown to a person and then recorded. Passing a field
 through in a listing whose description warns about it is not the same act as
 putting it in a mutating tool's approval text.
 
+### A job-backed tool watches for a bounded time and reports what it has (#122)
+
+`cloudsync_run` is the catalog's first tool that starts a job, and the shape it
+takes is the one later job-backed tools should copy.
+
+**The core needed nothing.** `ApiSurface` is `DefaultApiDirectory`, whose shape
+is `{ call, job, event }`, so `system.client.api.job(method, params)` was
+already available to every handler and already typed off the *job* directory —
+a key space disjoint from the call directory, so a job method is unreachable
+through `api.call` and vice versa. The client sends the request, correlates the
+job id off the job events, tracks the job and completes the observable at a
+terminal state. Earlier discussion here treated job support as a core
+prerequisite; it was not.
+
+**The duration decision is the one a job-backed tool actually has to make, and
+awaiting completion is the wrong default.** A cloud sync is unbounded — minutes
+for a delta, hours for a first upload — and awaiting it holds the MCP tool call
+open for the whole thing. The host times out, and the call it times out on is
+the only one that ever knew the job id, so the run continues with nothing able
+to name it afterwards. So: **watch for a bounded time, then report either how
+the job ended or that it is still going, with the job id either way.**
+
+Starting the job and returning the id immediately is what that degrades to when
+the bound passes, which makes it the floor rather than a third option — and it
+is not the wait-free route it looks like, because the id itself arrives from the
+first job event carrying the request's id and so waits on the network too. A
+bound is owed either way; this spends it on an answer that is sometimes
+complete.
+
+**The bound is a ceiling on the tool's patience, not an estimate of the job.**
+It has to sit comfortably inside the MCP host's own timeout, since a bound that
+outlives the host's never gets to report anything at all — and the host's is not
+readable from here, because `src/interfaces.ts` is the whole environment
+boundary and carries no deadline. Thirty seconds is chosen to be shorter than
+the shortest in ordinary use rather than tuned to any one of them, and it is
+returned as `watched_seconds` so a caller never infers which bound applied, the
+same way `snapshots_list` returns the `limit` it used.
+
+**Ending the watch must not end the job, and that was established before the
+route was taken.** `api.job` is `callAndGetJobId` piped into `trackJob`, and
+`trackJob` only observes — it filters the job event stream and reads
+`core.get_jobs`. Unsubscribing sends nothing to the middleware. A bound that
+silently aborted a half-finished upload would be the worst defect such a tool
+could have, so this is checked against the client rather than assumed of it.
+
+**Whether the job ended is read from the tracking COMPLETING, not from a state
+list.** The client completes the stream on its own `isJobFinished`, so
+completion moves with the middleware's terminal set instead of with a set
+written down here. A completion carrying no emission is the client having found
+no such job, which establishes nothing — so both halves are required before
+anything is called ended.
+
+**Terminal does not mean succeeded, and on this method there is nothing else to
+read.** `cloudsync.sync` declares `response: null`, so the job's `result` is
+null on success and on failure alike; the client says as much itself. The
+outcome is read from `state` against the same success vocabulary the tasks
+family already reads a run's state against, and `result` is not read at all — a
+tool that awaited completion and reported success would have reported every
+failed sync as a success. A terminal state this catalog does not recognise is
+**not** read as a success, which is `tasks_recent_runs`'s direction: a run that
+cannot be shown to have worked has not been shown to have worked.
+
+**Three answers, not two, and the description says which is which.** `ended`
+false is a sync still going and says nothing about whether it will work;
+`succeeded` null is that case or an unreadable state, and is neither a failure
+nor a success. The tool reports no progress percentage and no live status, and
+names `tasks_recent_runs` — whose `id` is this tool's `job_id` — as where a
+still-running sync is followed up.
+
+**The plan names one call, which is #119's distinction rather than a lapse.**
+`scheduled_task_set_enabled` names its read as a step because `execute` makes
+it; this tool reads only at plan time — to name the task, and to fail on an id
+no task has — and `execute` re-reads nothing, exactly as `snapshots_create` does
+not re-check its dataset. The `core.get_jobs` the client's tracking issues while
+following the job is named in the step's *description* instead, because a step's
+`params` are the exact params a call runs with and the job id does not exist
+until the approved call has been made.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -950,10 +950,30 @@ that reject the handler tells the caller the sync failed when it is running, and
 throws away the job id in the same act — the unnameable-run failure the bound
 exists to prevent, reached from the other side. So an error after the client has
 reported on the job ends the watch and the result says what was established,
-which is `ended: false`. An error BEFORE the first emission still fails: there
-is no id to keep, nothing to report, and the likeliest cause is the call being
-rejected. **A mutating tool that follows its own effect has two failure eras,
-and only the first of them is the call's.**
+which is `ended: false`. An error BEFORE the client has named the job still
+fails: there is no id to keep and nothing to report. **A mutating tool that
+follows its own effect has two failure eras, and only the first of them is the
+call's.**
+
+**Which is why this tool calls `callAndGetJobId` and `trackJob` apart rather
+than `api.job`, which is those two piped together.** The two eras are divided by
+the moment the client correlates the job id off the job event, and `api.job`
+consumes that id inside its own `switchMap` — nothing of the job reaches the
+caller's pipe until `trackJob` emits. But `trackJob` opens by dispatching
+`core.get_jobs`, which can fail on its own, and by then the sync is running and
+the client has its id. Through `api.job` that failure arrives as a rejection
+carrying nothing: the caller is told the mutation failed, and the only number
+that could still name the run is gone. **Where a client method pipes two stages
+together and the seam between them is where a tool's own guard lives, call the
+stages.** What that costs is the client's stated reason to prefer `api.job` — a
+job typed `result: unknown` — and it costs nothing here, because `cloudsync.sync`
+declares `response: null` and this tool never reads `result`.
+
+`job_id` then comes from that correlation and NOT from the `id` on whatever the
+tracking last reported. They are the same number, since the tracking filters on
+it — and only the first survives a watch that established nothing else, which is
+exactly when a caller most needs something to name the run with. **One fact, one
+derivation**, the same rule `finished_at` follows above.
 
 **Whether the job ended is read from the tracking COMPLETING, not from a state
 list.** The client completes the stream on its own `isJobFinished`, so

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ confirmation UX, audit sinks) enters through injected interfaces.
 
 ## What the sketch implements
 
-- **Tool catalog** — curated tools with role metadata; irreversibly destructive
-  operations are rejected at registration by policy. Read-only family:
+- **Tool catalog** — curated tools with role metadata; a tool that composes an
+  irreversibly destructive operation is rejected at registration by policy.
+  Read-only family:
   `system_info`, `system_update_status`, `system_reboot_info`,
   `audit_log_query`, `audit_config`, `security_config`, `system_general_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
@@ -36,7 +37,10 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
   `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run` — the last of
   these the only one that starts a background job, which it watches for a
-  bounded time and then reports on rather than waiting out.
+  bounded time and then reports on rather than waiting out. `destructiveness`
+  is about a tool's own operation and not about the data that operation acts
+  on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
+  for good, which its description and its plan state and this field does not.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_health_report`, `fleet_compliance_report`, `fleet_health_rollup`.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
-  `alerts_restore`, `scheduled_task_set_enabled`.
+  `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run` — the last of
+  these the only one that starts a background job, which it watches for a
+  bounded time and then reports on rather than waiting out.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/catalog/catalog.ts
+++ b/src/catalog/catalog.ts
@@ -11,6 +11,14 @@ export interface AdvertisedTool {
   description: string;
   inputSchema: Record<string, unknown>;
   mutating: boolean;
+  /**
+   * Present on a mutating tool, and — since the catalog rejects the other value
+   * — always `reversible`. {@link Destructiveness} states what that does and
+   * does not record: it is about the tool's OWN operation, never about the data
+   * that operation acts on. **An adapter deciding how loudly to warn must not
+   * read this field alone**; what an operation does to the data is in
+   * `description`, which is where a tool triggering one is required to state it.
+   */
   destructiveness?: Destructiveness;
 }
 
@@ -45,10 +53,18 @@ export class ToolCatalog {
     if (this.tools.has(tool.name)) {
       throw new Error(`Tool "${tool.name}" is already registered`);
     }
+    // What this rejects is a tool that COMPOSES an irreversibly destructive
+    // operation — one that chooses what is destroyed. It is not the wider
+    // promise that nothing in the catalog can trigger such an operation someone
+    // else authored: `cloudsync_run` registers as `reversible` and starts a task
+    // whose own `transfer_mode` may delete data for good. {@link Destructiveness}
+    // is where that distinction is stated; this check enforces one side of it,
+    // and the message says which so a reader does not take it for both.
     if (tool.mutating && tool.destructiveness === 'irreversible') {
       throw new Error(
-        `Tool "${tool.name}" is irreversibly destructive; the destructive-action ` +
-          'policy keeps such operations out of the catalog — direct users to the web UI',
+        `Tool "${tool.name}" composes an irreversibly destructive operation; the ` +
+          'destructive-action policy keeps such a tool out of the catalog — direct ' +
+          'users to the web UI',
       );
     }
     const properties = tool.inputSchema['properties'];

--- a/src/catalog/tool.ts
+++ b/src/catalog/tool.ts
@@ -52,10 +52,11 @@ export interface PlanStep {
  * question as what that operation does to the data it acts on.
  *
  * `irreversible` exists only so the catalog can reject it: per the
- * destructive-action policy, irreversibly destructive operations are absent
- * from the catalog by construction. So the two values are not a scale with a
- * safe end and a dangerous one; the second is a rejection, and every tool that
- * registers carries the first.
+ * destructive-action policy, a tool that COMPOSES an irreversibly destructive
+ * operation is absent from the catalog by construction. That is narrower than
+ * "nothing here can destroy data", and the difference is the paragraph below.
+ * So the two values are not a scale with a safe end and a dangerous one; the
+ * second is a rejection, and every tool that registers carries the first.
  *
  * What that leaves for a tool that TRIGGERS an operation someone else authored
  * is `reversible`, and the reason is the distinction above rather than a

--- a/src/catalog/tool.ts
+++ b/src/catalog/tool.ts
@@ -48,9 +48,30 @@ export interface PlanStep {
 }
 
 /**
- * How hard a mutating tool is to undo. `irreversible` exists only so the
- * catalog can reject it: per the destructive-action policy, irreversibly
- * destructive operations are absent from the catalog by construction.
+ * How hard a mutating tool's OWN operation is to undo — which is not the same
+ * question as what that operation does to the data it acts on.
+ *
+ * `irreversible` exists only so the catalog can reject it: per the
+ * destructive-action policy, irreversibly destructive operations are absent
+ * from the catalog by construction. So the two values are not a scale with a
+ * safe end and a dangerous one; the second is a rejection, and every tool that
+ * registers carries the first.
+ *
+ * What that leaves for a tool that TRIGGERS an operation someone else authored
+ * is `reversible`, and the reason is the distinction above rather than a
+ * loophole. `cloudsync_run` starts a cloud sync task whose own `transfer_mode`
+ * may delete data for good; the mode, the paths and the direction were all
+ * decided by whoever configured the task, and the system does the same thing
+ * unattended at the next scheduled window. Such a tool moves the moment, not
+ * the effect, and the operation it does author — the run — can be stopped. A
+ * tool that composed a destruction of its own, choosing the paths or the mode,
+ * is the case the policy is actually about and does not belong in the catalog
+ * at all. **Ask which of those two a new mutating tool is** before reading this
+ * field as a claim about the data.
+ *
+ * So an adapter deciding how loudly to warn cannot read this field alone: what
+ * an operation does to the data is in the tool's `description`, which is where
+ * such a tool is required to state it.
  */
 export type Destructiveness = 'reversible' | 'irreversible';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,4 +130,5 @@ export {
   alertsDismiss,
   alertsRestore,
   scheduledTaskSetEnabled,
+  cloudsyncRun,
 } from '@/tools/index';

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi } from 'vitest';
+import { concat, EMPTY, NEVER, Observable, of, throwError } from 'rxjs';
+import { Role } from '@/interfaces';
+import { PlanStep, SystemHandle, ToolContext } from '@/catalog/tool';
+import { cloudsyncRun } from '@/tools/index';
+
+/**
+ * `cloudsync_run`'s tests live here rather than in `tasks.spec.ts` under the
+ * #87 split trigger, checked rather than felt: `tasks.spec.ts` is 1,352 lines
+ * and this block is several hundred more, so the merged file would cross 1,500
+ * exactly as it did at #121. The four listing tools stay where they are.
+ *
+ * The fake system is local to this file rather than added to
+ * `src/testing/fake-systems.ts`. That fixture stubs `call` and `query` from one
+ * method→response map, and a job is not one response: it is a stream, and half
+ * of what is tested here is what happens when that stream does NOT complete.
+ * One caller is not enough to know what shape a shared job fixture should have
+ * — the second job-backed tool is when to promote it, the way `strictTextList`
+ * was promoted at #102 after two copies existed.
+ */
+
+/** A cloud sync task row as `cloudsync.query` answers with one. */
+const task = {
+  id: 4,
+  description: 'Nightly Backblaze',
+  path: '/mnt/tank/media',
+  direction: 'PUSH',
+  enabled: true,
+  attributes: { bucket: 'nas-offsite', folder: '/media' },
+  // The provider is where the access key lives, and nothing may reach a plan
+  // from inside it — asserted below rather than assumed.
+  credentials: { id: 2, name: 'Backblaze B2', provider: { pass: 'hunter2' } },
+};
+
+/** A second task, to catch a filter that did not apply coming back as the table. */
+const otherTask = { ...task, id: 9, description: 'Weekly S3', path: '/mnt/tank/docs' };
+
+/** A job as the client's tracking emits one. */
+const jobAt = (state: string, extra: Record<string, unknown> = {}) => ({
+  id: 77,
+  method: 'cloudsync.sync',
+  state,
+  // Null on this method whether the run worked or failed — which is the whole
+  // reason the outcome is read from `state`.
+  result: null,
+  error: null,
+  time_finished: { $date: 1_756_000_000_000 },
+  ...extra,
+});
+
+/**
+ * A system listing `rows` for `cloudsync.query` and following a started job
+ * through `job`.
+ */
+function jobSystem(
+  options: {
+    rows?: unknown;
+    job?: Observable<unknown>;
+    queryFails?: unknown;
+  } = {},
+): { ctx: ToolContext; query: ReturnType<typeof vi.fn>; job: ReturnType<typeof vi.fn> } {
+  const query = vi.fn(() =>
+    'queryFails' in options ? throwError(() => options.queryFails) : of(options.rows ?? [task]),
+  );
+  const job = vi.fn(() => options.job ?? of(jobAt('SUCCESS')));
+  const system = { name: 'nas', client: { api: { query, job } } } as unknown as SystemHandle;
+  return { ctx: { system }, query, job };
+}
+
+/** The one step the plan returns, typed. */
+const planStep = async (ctx: ToolContext, args: Record<string, unknown>): Promise<PlanStep> => {
+  const steps = await cloudsyncRun.plan(ctx, args);
+  expect(steps).toHaveLength(1);
+  return steps[0];
+};
+
+describe('cloudsync_run', () => {
+  it('is a reversible mutating tool needing the full role', () => {
+    expect(cloudsyncRun).toMatchObject({
+      name: 'cloudsync_run',
+      mutating: true,
+      destructiveness: 'reversible',
+      requiredRole: Role.Full,
+    });
+  });
+
+  it('takes the task id and nothing but an optional dry run', () => {
+    const schema = cloudsyncRun.inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(schema.properties)).toEqual(['id', 'dry_run']);
+    expect(schema.required).toEqual(['id']);
+  });
+
+  describe('normalizeArgs', () => {
+    it('defaults dry_run to false and drops anything else', () => {
+      expect(cloudsyncRun.normalizeArgs?.({ id: 4, systems: 'all' })).toEqual({
+        id: 4,
+        dry_run: false,
+      });
+    });
+
+    it('keeps an explicit dry run, so the token binds the two calls apart', () => {
+      expect(cloudsyncRun.normalizeArgs?.({ id: 4, dry_run: true })).toEqual({
+        id: 4,
+        dry_run: true,
+      });
+    });
+
+    it.each([
+      ['a missing id', {}],
+      ['an id that is not a number', { id: '4' }],
+      ['an id that is not whole', { id: 4.5 }],
+    ])('rejects %s', (_name, args) => {
+      expect(() => cloudsyncRun.normalizeArgs?.(args)).toThrow('"id" is required');
+    });
+
+    it('rejects a dry_run that is not a boolean rather than coercing it', () => {
+      // "false" is truthy, so a coercing read would move real data under an
+      // approval given for a dry run.
+      expect(() => cloudsyncRun.normalizeArgs?.({ id: 4, dry_run: 'false' })).toThrow(
+        '"dry_run" must be a boolean',
+      );
+    });
+  });
+
+  describe('plan', () => {
+    it('names one call: the job, with the params it will run with', async () => {
+      const { ctx } = jobSystem();
+      const step = await planStep(ctx, { id: 4 });
+      expect(step.method).toBe('cloudsync.sync');
+      expect(step.params).toEqual([4, { dry_run: false }]);
+    });
+
+    it('sends the options object on an ordinary run too, so the shape is one shape', async () => {
+      const { ctx } = jobSystem();
+      expect((await planStep(ctx, { id: 4, dry_run: true })).params).toEqual([
+        4,
+        { dry_run: true },
+      ]);
+    });
+
+    it('names the task the way cloudsync_tasks_list does, remote end included', async () => {
+      const { ctx } = jobSystem();
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain('description "Nightly Backblaze"');
+      expect(description).toContain('path "/mnt/tank/media"');
+      expect(description).toContain('direction "PUSH"');
+      expect(description).toContain('remote bucket "nas-offsite"');
+      expect(description).toContain('remote folder "/media"');
+      expect(description).toContain('credential "Backblaze B2"');
+      expect(description).toContain('(id 4)');
+    });
+
+    it('names the credential and never what is inside it', async () => {
+      const { ctx } = jobSystem();
+      expect((await planStep(ctx, { id: 4 })).description).not.toContain('hunter2');
+    });
+
+    it('states that a field the system reported nothing for is exactly that', async () => {
+      const { ctx } = jobSystem({ rows: [{ id: 4 }] });
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain('description (the system reported none)');
+      expect(description).toContain('remote bucket (the system reported none)');
+      expect(description).toContain('credential (the system reported none)');
+    });
+
+    it('says the sync copies data, and says a dry run does not', async () => {
+      const { ctx } = jobSystem();
+      expect((await planStep(ctx, { id: 4 })).description).toContain(
+        'This copies data between this system and the remote.',
+      );
+      const dry = await planStep(ctx, { id: 4, dry_run: true });
+      expect(dry.description).toContain('A dry run moves no data, and still contacts the remote.');
+      expect(dry.description).toContain('Dry-run the cloud sync task');
+    });
+
+    it('says the job is followed for a bounded time and then left running', async () => {
+      const { ctx } = jobSystem();
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain('for at most 30 seconds');
+      expect(description).toContain('The sync continues after that whether or not it has finished');
+      // The client's tracking read is named in the step rather than being a
+      // step of its own: its params are not knowable until the job exists.
+      expect(description).toContain('core.get_jobs');
+    });
+
+    it('filters the read by id', async () => {
+      const { ctx, query } = jobSystem();
+      await planStep(ctx, { id: 4 });
+      expect(query).toHaveBeenCalledWith('cloudsync.query', [['id', '=', 4]]);
+    });
+
+    it('finds the task by id in the response, never by taking the first row', async () => {
+      // What a filter that was dropped rather than refused comes back as.
+      const { ctx } = jobSystem({ rows: [otherTask, task] });
+      expect((await planStep(ctx, { id: 4 })).description).toContain('Nightly Backblaze');
+    });
+
+    it('fails when the read lists no task with that id, naming the listing tool', async () => {
+      const { ctx } = jobSystem({ rows: [otherTask] });
+      await expect(cloudsyncRun.plan(ctx, { id: 4 })).rejects.toThrow(
+        'No cloud sync task with id 4 on this system — the ids this tool takes come from ' +
+          '`cloudsync_tasks_list`',
+      );
+    });
+
+    it('fails when the read answers with something that is not a list', async () => {
+      const { ctx } = jobSystem({ rows: { id: 4 } });
+      await expect(cloudsyncRun.plan(ctx, { id: 4 })).rejects.toThrow('No cloud sync task with id');
+    });
+
+    it('starts nothing', async () => {
+      const { ctx, job } = jobSystem();
+      await planStep(ctx, { id: 4 });
+      expect(job).not.toHaveBeenCalled();
+    });
+
+    it('lets a failed read fail the plan, since nothing has been approved yet', async () => {
+      const { ctx } = jobSystem({ queryFails: new Error('middleware is down') });
+      await expect(cloudsyncRun.plan(ctx, { id: 4 })).rejects.toThrow('middleware is down');
+    });
+  });
+
+  describe('execute', () => {
+    it('starts the job through the job surface, with the params the plan named', async () => {
+      const { ctx, job } = jobSystem();
+      await cloudsyncRun.execute(ctx, { id: 4 });
+      expect(job).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: false }]);
+    });
+
+    it('passes a dry run through as asked, and reports what was sent', async () => {
+      const { ctx, job } = jobSystem();
+      const result = await cloudsyncRun.execute(ctx, { id: 4, dry_run: true });
+      expect(job).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: true }]);
+      expect(result).toMatchObject({ task_id: 4, dry_run: true });
+    });
+
+    it('re-reads nothing: the plan-time read is not repeated', async () => {
+      const { ctx, query } = jobSystem();
+      await cloudsyncRun.execute(ctx, { id: 4 });
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('reports a job that succeeded, with its id and the bound that applied', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('RUNNING'), jobAt('SUCCESS')) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toEqual({
+        task_id: 4,
+        dry_run: false,
+        job_id: 77,
+        watched_seconds: 30,
+        ended: true,
+        succeeded: true,
+        state: 'SUCCESS',
+        error: null,
+        finished_at: '2025-08-24T01:46:40.000Z',
+      });
+    });
+
+    it('counts FINISHED as success, as the rest of this family does', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('FINISHED')) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({ succeeded: true });
+    });
+
+    it('reports a failed job as a failure from its state, never from a null result', async () => {
+      const { ctx } = jobSystem({
+        job: of(jobAt('FAILED', { error: 'remote refused the credential' })),
+      });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: false,
+        state: 'FAILED',
+        error: 'remote refused the credential',
+      });
+    });
+
+    it('does not read an unfamiliar terminal state as a success', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUPERSEDED')) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: false,
+        state: 'SUPERSEDED',
+      });
+    });
+
+    it('reports no error text where the job recorded none, and none for an empty string', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('FAILED', { error: '' })) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({ error: null });
+    });
+
+    it('reports a sync still running when the watch runs out, and leaves it running', async () => {
+      vi.useFakeTimers();
+      try {
+        const { ctx } = jobSystem({ job: concat(of(jobAt('RUNNING')), NEVER) });
+        const pending = cloudsyncRun.execute(ctx, { id: 4 });
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(await pending).toMatchObject({
+          job_id: 77,
+          ended: false,
+          // Still running is neither a success nor a failure.
+          succeeded: null,
+          state: 'RUNNING',
+          // Only a state that describes an ended run makes the recorded time a
+          // finish time, and RUNNING is not one — the row carries one anyway.
+          finished_at: null,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('establishes nothing from a job it never saw, and does not call that a failure', async () => {
+      const { ctx } = jobSystem({ job: EMPTY });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: null,
+        ended: false,
+        succeeded: null,
+        state: null,
+        error: null,
+        finished_at: null,
+      });
+    });
+
+    it('establishes nothing from an emission carrying no readable state', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { state: 42 })) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
+      });
+    });
+
+    it('reports no job id where the emission carries none this tool can read', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { id: 'seventy-seven' })) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: null,
+        succeeded: true,
+      });
+    });
+
+    it('lets a rejected call fail, since there is then no run to report on', async () => {
+      const { ctx } = jobSystem({ job: throwError(() => new Error('not authorised')) });
+      await expect(cloudsyncRun.execute(ctx, { id: 4 })).rejects.toThrow('not authorised');
+    });
+
+    it('rejects arguments it cannot read before making any call', async () => {
+      const { ctx, job } = jobSystem();
+      await expect(cloudsyncRun.execute(ctx, { id: 'four' })).rejects.toThrow('"id" is required');
+      expect(job).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -25,6 +25,7 @@ const task = {
   description: 'Nightly Backblaze',
   path: '/mnt/tank/media',
   direction: 'PUSH',
+  transfer_mode: 'COPY',
   enabled: true,
   attributes: { bucket: 'nas-offsite', folder: '/media' },
   // The provider is where the access key lives, and nothing may reach a plan
@@ -147,6 +148,7 @@ describe('cloudsync_run', () => {
       expect(description).toContain('description "Nightly Backblaze"');
       expect(description).toContain('path "/mnt/tank/media"');
       expect(description).toContain('direction "PUSH"');
+      expect(description).toContain('transfer mode "COPY"');
       expect(description).toContain('remote bucket "nas-offsite"');
       expect(description).toContain('remote folder "/media"');
       expect(description).toContain('credential "Backblaze B2"');
@@ -162,18 +164,70 @@ describe('cloudsync_run', () => {
       const { ctx } = jobSystem({ rows: [{ id: 4 }] });
       const { description } = await planStep(ctx, { id: 4 });
       expect(description).toContain('description (the system reported none)');
+      expect(description).toContain('transfer mode (the system reported none)');
       expect(description).toContain('remote bucket (the system reported none)');
       expect(description).toContain('credential (the system reported none)');
     });
 
-    it('says the sync copies data, and says a dry run does not', async () => {
+    it('says a COPY deletes nothing, and which end is which', async () => {
       const { ctx } = jobSystem();
-      expect((await planStep(ctx, { id: 4 })).description).toContain(
-        'This copies data between this system and the remote.',
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain(
+        'Transfer mode COPY: new and changed files are copied to the destination, and nothing ' +
+          'is deleted at either end.',
       );
+      expect(description).toContain(
+        'On a PUSH this system is the source and the remote the destination',
+      );
+      expect(description).toContain('This run does all of that for real.');
+    });
+
+    it('says outright that a SYNC deletes at the destination', async () => {
+      const { ctx } = jobSystem({ rows: [{ ...task, transfer_mode: 'SYNC' }] });
+      expect((await planStep(ctx, { id: 4 })).description).toContain(
+        'Transfer mode SYNC: the destination is made to match the source, so anything at the ' +
+          'destination that is not at the source IS DELETED.',
+      );
+    });
+
+    it('says outright that a MOVE deletes the source', async () => {
+      const { ctx } = jobSystem({ rows: [{ ...task, transfer_mode: 'MOVE' }] });
+      expect((await planStep(ctx, { id: 4 })).description).toContain(
+        'Transfer mode MOVE: files are copied to the destination and are then DELETED FROM THE ' +
+          'SOURCE.',
+      );
+    });
+
+    it.each([
+      ['a mode this tool does not know', 'REPLICATE', '"REPLICATE"'],
+      // `in` walks the prototype and would have found a function here.
+      ['a mode named after a prototype member', 'constructor', '"constructor"'],
+    ])('refuses to guess the effect of %s', async (_name, mode, quoted) => {
+      const { ctx } = jobSystem({ rows: [{ ...task, transfer_mode: mode }] });
+      expect((await planStep(ctx, { id: 4 })).description).toContain(
+        `Transfer mode ${quoted}: whether this run DELETES anything, at either end, is not ` +
+          'established here',
+      );
+    });
+
+    it('does not read an unreadable transfer mode as the harmless one', async () => {
+      const { ctx } = jobSystem({ rows: [{ ...task, transfer_mode: 7 }] });
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain(
+        'Transfer mode (the system reported none): whether this run DELETES anything',
+      );
+      expect(description).not.toContain('nothing is deleted at either end');
+    });
+
+    it('says a dry run transfers and deletes nothing', async () => {
+      const { ctx } = jobSystem({ rows: [{ ...task, transfer_mode: 'MOVE' }] });
       const dry = await planStep(ctx, { id: 4, dry_run: true });
-      expect(dry.description).toContain('A dry run moves no data, and still contacts the remote.');
       expect(dry.description).toContain('Dry-run the cloud sync task');
+      expect(dry.description).toContain(
+        'This is a dry run: it transfers and deletes nothing, and still contacts the remote.',
+      );
+      // The mode is still stated: what a dry run is a dry run OF is the point.
+      expect(dry.description).toContain('DELETED FROM THE SOURCE');
     });
 
     it('says the job is followed for a bounded time and then left running', async () => {

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -151,7 +151,8 @@ describe('cloudsync_run', () => {
       expect(description).toContain('transfer mode "COPY"');
       expect(description).toContain('remote bucket "nas-offsite"');
       expect(description).toContain('remote folder "/media"');
-      expect(description).toContain('credential "Backblaze B2"');
+      expect(description).toContain('credential name "Backblaze B2"');
+      expect(description).toContain('credential id "2"');
       expect(description).toContain('(id 4)');
     });
 
@@ -160,13 +161,25 @@ describe('cloudsync_run', () => {
       expect((await planStep(ctx, { id: 4 })).description).not.toContain('hunter2');
     });
 
+    it('identifies a credential sent in the id-only form the middleware also has', async () => {
+      // `credentials` is declared a whole record and also arrives as a bare id,
+      // which is why `credentialId` reads both. A plan reading only the name
+      // would say the system reported no credential for a task that reported
+      // one — a stated absence, in the text a person approves.
+      const { ctx } = jobSystem({ rows: [{ ...task, credentials: 2 }] });
+      const { description } = await planStep(ctx, { id: 4 });
+      expect(description).toContain('credential id "2"');
+      expect(description).toContain('credential name (the system reported none)');
+    });
+
     it('states that a field the system reported nothing for is exactly that', async () => {
       const { ctx } = jobSystem({ rows: [{ id: 4 }] });
       const { description } = await planStep(ctx, { id: 4 });
       expect(description).toContain('description (the system reported none)');
       expect(description).toContain('transfer mode (the system reported none)');
       expect(description).toContain('remote bucket (the system reported none)');
-      expect(description).toContain('credential (the system reported none)');
+      expect(description).toContain('credential name (the system reported none)');
+      expect(description).toContain('credential id (the system reported none)');
     });
 
     it('says a COPY deletes nothing, and which end is which', async () => {

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -375,8 +375,9 @@ describe('cloudsync_run', () => {
           // Still running is neither a success nor a failure.
           succeeded: null,
           state: 'RUNNING',
-          // Nothing is a finish time until the run has ended, and this one has
-          // not — the row carries a time anyway, which is the earlier run's.
+          // The record carries a time and it is still not a finish time: a run
+          // that was not established to be over was not established to have
+          // ended then.
           finished_at: null,
         });
       } finally {

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -329,16 +329,22 @@ describe('cloudsync_run', () => {
       });
     });
 
-    it('does not read an unfamiliar terminal state as a success', async () => {
+    // The tracking completing on a state neither this file nor the pinned
+    // client calls terminal is a stream that client CANNOT currently produce:
+    // its `terminalStates` holds the same five as `ENDED_JOB_STATES`, so a
+    // SUPERSEDED job runs on until the bound expires. What this fixture models
+    // is a client release that widens that set — the one case where the two
+    // lists come apart — and it is written as a test because both fields have
+    // to stay honest when it happens, not because the state is reachable today.
+    it('reads a terminal state neither list names as ended and not as a success', async () => {
       const { ctx } = jobSystem({ job: of(jobAt('SUPERSEDED')) });
       expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
         ended: true,
         succeeded: false,
         state: 'SUPERSEDED',
-        // And still reports the finish time: a state the client completed on is
-        // an ended run whether or not this family's own terminal list names it,
-        // so `finished_at` follows `ended` rather than that list. Reporting null
-        // here would have this result call the run over and refuse to say when.
+        // And the finish time follows `ended`. Reading `ENDED_JOB_STATES` here
+        // instead would have one result call the run over and refuse to say
+        // when it ended.
         finished_at: '2025-08-24T01:46:40.000Z',
       });
     });
@@ -411,6 +417,38 @@ describe('cloudsync_run', () => {
     it('lets a rejected call fail, since there is then no run to report on', async () => {
       const { ctx } = jobSystem({ job: throwError(() => new Error('not authorised')) });
       await expect(cloudsyncRun.execute(ctx, { id: 4 })).rejects.toThrow('not authorised');
+    });
+
+    it('keeps the job id when following the job fails after it has been seen', async () => {
+      const { ctx } = jobSystem({
+        job: concat(of(jobAt('RUNNING')), throwError(() => new Error('connection dropped'))),
+      });
+      // The sync is running and this is the only call that ever knew its id, so
+      // rejecting here would tell the caller the mutation failed and lose the
+      // one thing that could still name the run.
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: 'RUNNING',
+        finished_at: null,
+      });
+    });
+
+    it('does not report a job as ended because following it stopped', async () => {
+      const { ctx } = jobSystem({
+        job: concat(of(jobAt('SUCCESS')), throwError(() => new Error('connection dropped'))),
+      });
+      // The state read is SUCCESS and the stream did not complete, so nothing
+      // established that the run is over — `ended` is what says so and it is
+      // false, which is what keeps `succeeded` from being read off a state the
+      // job may still move out of.
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        state: 'SUCCESS',
+        ended: false,
+        succeeded: null,
+        finished_at: null,
+      });
     });
 
     it('rejects arguments it cannot read before making any call', async () => {

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -50,22 +50,37 @@ const jobAt = (state: string, extra: Record<string, unknown> = {}) => ({
 });
 
 /**
- * A system listing `rows` for `cloudsync.query` and following a started job
- * through `job`.
+ * A system listing `rows` for `cloudsync.query`, correlating a started job's id
+ * through `callAndGetJobId` and following it through `trackJob`.
+ *
+ * Those are the two halves `api.job` pipes together, and the tool uses them
+ * apart so that the id is in hand before anything is read about the job — so
+ * the fake has to be able to move them independently. `started` is the id
+ * stream and `job` the tracking that follows it.
  */
 function jobSystem(
   options: {
     rows?: unknown;
+    started?: Observable<number>;
     job?: Observable<unknown>;
     queryFails?: unknown;
   } = {},
-): { ctx: ToolContext; query: ReturnType<typeof vi.fn>; job: ReturnType<typeof vi.fn> } {
+): {
+  ctx: ToolContext;
+  query: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+} {
   const query = vi.fn(() =>
     'queryFails' in options ? throwError(() => options.queryFails) : of(options.rows ?? [task]),
   );
-  const job = vi.fn(() => options.job ?? of(jobAt('SUCCESS')));
-  const system = { name: 'nas', client: { api: { query, job } } } as unknown as SystemHandle;
-  return { ctx: { system }, query, job };
+  const start = vi.fn(() => options.started ?? of(77));
+  const track = vi.fn(() => options.job ?? of(jobAt('SUCCESS')));
+  const system = {
+    name: 'nas',
+    client: { api: { query, callAndGetJobId: start, trackJob: track } },
+  } as unknown as SystemHandle;
+  return { ctx: { system }, query, start, track };
 }
 
 /** The one step the plan returns, typed. */
@@ -279,9 +294,9 @@ describe('cloudsync_run', () => {
     });
 
     it('starts nothing', async () => {
-      const { ctx, job } = jobSystem();
+      const { ctx, start } = jobSystem();
       await planStep(ctx, { id: 4 });
-      expect(job).not.toHaveBeenCalled();
+      expect(start).not.toHaveBeenCalled();
     });
 
     it('lets a failed read fail the plan, since nothing has been approved yet', async () => {
@@ -292,15 +307,17 @@ describe('cloudsync_run', () => {
 
   describe('execute', () => {
     it('starts the job through the job surface, with the params the plan named', async () => {
-      const { ctx, job } = jobSystem();
+      const { ctx, start, track } = jobSystem();
       await cloudsyncRun.execute(ctx, { id: 4 });
-      expect(job).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: false }]);
+      expect(start).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: false }]);
+      // And follows the job the client correlated, rather than one it named.
+      expect(track).toHaveBeenCalledWith(77);
     });
 
     it('passes a dry run through as asked, and reports what was sent', async () => {
-      const { ctx, job } = jobSystem();
+      const { ctx, start } = jobSystem();
       const result = await cloudsyncRun.execute(ctx, { id: 4, dry_run: true });
-      expect(job).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: true }]);
+      expect(start).toHaveBeenCalledWith('cloudsync.sync', [4, { dry_run: true }]);
       expect(result).toMatchObject({ task_id: 4, dry_run: true });
     });
 
@@ -399,7 +416,8 @@ describe('cloudsync_run', () => {
     });
 
     it('establishes nothing from a job it never saw, and does not call that a failure', async () => {
-      const { ctx } = jobSystem({ job: EMPTY });
+      // No job event named the request, so there is no id and nothing to track.
+      const { ctx, track } = jobSystem({ started: EMPTY });
       expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
         job_id: null,
         ended: false,
@@ -407,6 +425,20 @@ describe('cloudsync_run', () => {
         state: null,
         error: null,
         finished_at: null,
+      });
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('keeps the id of a job the client named and then reported nothing about', async () => {
+      // The event correlated the id — the sync IS running — and the tracking
+      // said nothing readable. `ended` is false and the caller still gets the
+      // one thing that can name the run.
+      const { ctx } = jobSystem({ job: EMPTY });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
       });
     });
 
@@ -420,8 +452,10 @@ describe('cloudsync_run', () => {
       });
     });
 
-    it('reports no job id where the emission carries none this tool can read', async () => {
-      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { id: 'seventy-seven' })) });
+    it('reports no job id where the event carried none this tool can read', async () => {
+      // The client declares the id a number; a declared type is a claim about
+      // what is sent rather than about the value received.
+      const { ctx } = jobSystem({ started: of('seventy-seven' as unknown as number) });
       expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
         job_id: null,
         succeeded: true,
@@ -429,8 +463,22 @@ describe('cloudsync_run', () => {
     });
 
     it('lets a rejected call fail, since there is then no run to report on', async () => {
-      const { ctx } = jobSystem({ job: throwError(() => new Error('not authorised')) });
+      const { ctx } = jobSystem({ started: throwError(() => new Error('not authorised')) });
       await expect(cloudsyncRun.execute(ctx, { id: 4 })).rejects.toThrow('not authorised');
+    });
+
+    it('does not fail the call when the FOLLOW-UP READ fails before it reports anything', async () => {
+      // `trackJob` starts by dispatching `core.get_jobs`, which can fail on its
+      // own — after the event correlated the id, so the sync is running. Through
+      // `api.job` this would reject with nothing: the id is consumed inside that
+      // method's `switchMap` and never reaches the tool.
+      const { ctx } = jobSystem({ job: throwError(() => new Error('core.get_jobs failed')) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
+      });
     });
 
     it('keeps the job id when following the job fails after it has been seen', async () => {
@@ -466,9 +514,9 @@ describe('cloudsync_run', () => {
     });
 
     it('rejects arguments it cannot read before making any call', async () => {
-      const { ctx, job } = jobSystem();
+      const { ctx, start } = jobSystem();
       await expect(cloudsyncRun.execute(ctx, { id: 'four' })).rejects.toThrow('"id" is required');
-      expect(job).not.toHaveBeenCalled();
+      expect(start).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tools/cloudsync-run.spec.ts
+++ b/src/tools/cloudsync-run.spec.ts
@@ -335,6 +335,20 @@ describe('cloudsync_run', () => {
         ended: true,
         succeeded: false,
         state: 'SUPERSEDED',
+        // And still reports the finish time: a state the client completed on is
+        // an ended run whether or not this family's own terminal list names it,
+        // so `finished_at` follows `ended` rather than that list. Reporting null
+        // here would have this result call the run over and refuse to say when.
+        finished_at: '2025-08-24T01:46:40.000Z',
+      });
+    });
+
+    it('reports no finish time for an ended job that recorded none it can read', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { time_finished: 'yesterday' })) });
+      expect(await cloudsyncRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: true,
+        finished_at: null,
       });
     });
 
@@ -355,8 +369,8 @@ describe('cloudsync_run', () => {
           // Still running is neither a success nor a failure.
           succeeded: null,
           state: 'RUNNING',
-          // Only a state that describes an ended run makes the recorded time a
-          // finish time, and RUNNING is not one — the row carries one anyway.
+          // Nothing is a finish time until the run has ended, and this one has
+          // not — the row carries a time anyway, which is the earlier run's.
           finished_at: null,
         });
       } finally {

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-three sketch tools', () => {
+  it('registers the fifty-four sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -58,6 +58,7 @@ describe('createDefaultCatalog', () => {
       'alerts_dismiss',
       'alerts_restore',
       'scheduled_task_set_enabled',
+      'cloudsync_run',
     ]);
   });
 
@@ -70,6 +71,12 @@ describe('createDefaultCatalog', () => {
   it('does not advertise scheduled_task_set_enabled to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
       'scheduled_task_set_enabled',
+    );
+  });
+
+  it('does not advertise cloudsync_run to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'cloudsync_run',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -34,6 +34,7 @@ import {
 } from '@/tools/system';
 import {
   automatedTasksList,
+  cloudsyncRun,
   cloudsyncTasksList,
   scheduledTaskSetEnabled,
   snapshotTasksList,
@@ -41,7 +42,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-nine read-only tools plus four mutating tools. */
+/** The sketch's catalog: forty-nine read-only tools plus five mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -97,6 +98,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(alertsDismiss);
   catalog.register(alertsRestore);
   catalog.register(scheduledTaskSetEnabled);
+  catalog.register(cloudsyncRun);
   return catalog;
 }
 
@@ -114,6 +116,7 @@ export {
   bootPoolStatus,
   certificatesList,
   cloudCredentialsList,
+  cloudsyncRun,
   cloudsyncTasksList,
   createSnapshot,
   directoryServicesStatus,

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -4,6 +4,7 @@ import {
   EMPTY,
   firstValueFrom,
   lastValueFrom,
+  switchMap,
   takeUntil,
   tap,
   throwError,
@@ -57,7 +58,7 @@ import {
  * `cloudsync_run` is the second, and it is here for the same reason one step
  * on: it starts one of the tasks `cloudsync_tasks_list` reports, and its plan
  * names that task in the terms that listing already uses — description, path,
- * direction, the remote end and the credential by name.
+ * direction, the remote end, and the credential by name and id.
  */
 
 /**
@@ -2107,9 +2108,12 @@ export const cloudsyncRun: MutatingTool = {
     'or the job reported a state this tool could not read, or no job was seen ' +
     'at all. `state` and `job_id` narrow that and DO NOT PARTITION IT: a ' +
     'non-null `state` beside `ended: false` is any of the first three and this ' +
-    'tool cannot say which, a null `state` beside a `job_id` is a job whose ' +
-    'state was unreadable, and both null is a job this tool never saw OR one ' +
-    'whose state and id were both unreadable. IN NONE OF THEM HAS ANYTHING ' +
+    'tool cannot say which, a null `state` beside a `job_id` is a job the ' +
+    'system NAMED and then said nothing readable about — following it failed, ' +
+    'or the watch ran out before anything came back, or the state it reported ' +
+    'could not be read, and this tool cannot say which of those either — and ' +
+    'both null is a job no event named within the watch OR one whose id was ' +
+    'unreadable and whose state was too. IN NONE OF THEM HAS ANYTHING ' +
     'FAILED. `succeeded` is the answer to "did it work": true where the run ' +
     'ENDED in a state this catalog reads as success, false where it ENDED in ' +
     'any other state, and NULL WHERE NOTHING ESTABLISHED IT — which is every ' +
@@ -2134,13 +2138,15 @@ export const cloudsyncRun: MutatingTool = {
     'JOB RECORD CARRIES A TIME, since a run that was not established to be ' +
     'over has not been established to have ended then. It is also null where ' +
     'the job ended and recorded no time this tool could read. `job_id` is the ' +
-    'job\'s numeric identity and ' +
+    'job\'s numeric identity, TAKEN FROM THE JOB EVENT THAT NAMED THIS ' +
+    'REQUEST rather than from anything read about the job afterwards — so it ' +
+    'is reported even where the watch established nothing else at all — and it ' +
     'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A SYNC THAT WAS STILL ' +
     'RUNNING IS FOLLOWED UP — this tool reports no progress percentage and no ' +
     'live status, and that tool reports both. `job_id` is null where no job ' +
-    'event named the job within the watch, and ALSO where a job event was seen ' +
-    'and the id it carried was not a number this tool could read — so a null ' +
-    '`job_id` beside a non-null `state` is the second of those. NEITHER MEANS ' +
+    'event named the job within the watch, and ALSO where such an event was ' +
+    'seen and the id it carried was not a number this tool could read — so a ' +
+    'null `job_id` beside a non-null `state` is the second of those. NEITHER MEANS ' +
     'THE SYNC DID ' +
     'NOT START: the call was made, and `cloudsync_tasks_list` will report the ' +
     'run against the task. `task_id` is the `id` that was asked for and ' +
@@ -2230,6 +2236,7 @@ export const cloudsyncRun: MutatingTool = {
   },
   async execute(ctx, rawArgs) {
     const run = parseRun(rawArgs);
+    const api = ctx.system.client.api;
     // Set from the tracking observable COMPLETING rather than from comparing
     // the state against a list, because completion is the client's own
     // `isJobFinished` and so moves with the middleware's terminal set rather
@@ -2238,38 +2245,56 @@ export const cloudsyncRun: MutatingTool = {
     // watch ends leaves this false.
     let completed = false;
     // Whether the client ever reported on the job. Once it has, the job exists
-    // and its id is in hand, which is what the guard below turns on.
+    // and the run is under way, which is what the guard below turns on.
     let sawJob = false;
+    // The job's id, held from the moment the client correlates it.
+    let jobId: number | null = null;
     const watched = await lastValueFrom(
-      ctx.system.client.api
-        .job('cloudsync.sync', syncParams(run))
-        .pipe(
-          tap({
-            next: () => {
-              sawJob = true;
-            },
-            complete: () => {
-              completed = true;
-            },
-          }),
-          // An error raised while FOLLOWING a job the client has already
-          // reported on is not the call failing. `trackJob` reads
-          // `core.get_jobs` and listens on a socket that can drop; the sync is
-          // running whatever either of those does. Rejecting here would tell the
-          // caller the mutation failed AND take the job id with it, leaving a
-          // running sync that nothing can name — which is the failure the bound
-          // above exists to prevent, reached from the other side. So the watch
-          // ends and the result reports what was established, `ended` false.
-          //
-          // Before the first emission there is no id to keep and nothing to
-          // report, and the likeliest cause is the call itself being rejected —
-          // so that still fails, as it must.
-          catchError((error: unknown) => (sawJob ? EMPTY : throwError(() => error))),
-          takeUntil(timer(SYNC_WATCH_MS)),
-        ),
+      // Started and then followed in two steps rather than through `api.job`,
+      // which is exactly these two steps piped together. What the split buys is
+      // WHEN the id becomes readable here: `api.job` consumes it inside its own
+      // `switchMap`, so nothing of the job reaches this pipe until `trackJob`
+      // emits — and `trackJob` starts by dispatching `core.get_jobs`, which can
+      // fail on its own. The job is already running by then and the client
+      // already has its id, so absorbing that failure and reporting the id is
+      // the whole point of the guard below; through `api.job` it would instead
+      // reject with nothing, which is the unnameable run this tool is built to
+      // avoid. The client's own reason to prefer `api.job` is the result type,
+      // and `cloudsync.sync` declares `response: null` — there is no result to
+      // lose.
+      api.callAndGetJobId('cloudsync.sync', syncParams(run)).pipe(
+        tap((id) => {
+          // A job event has named this request, so the run is under way. The id
+          // is read through the same guard every other middleware number goes
+          // through: the client declares it a number, and a declared type is a
+          // claim about what is sent rather than about the value received.
+          sawJob = true;
+          jobId = numberOrNull(id);
+        }),
+        switchMap((id) => api.trackJob(id)),
+        tap({
+          complete: () => {
+            completed = true;
+          },
+        }),
+        // An error raised once a job event has named this request is not the
+        // call failing. The follow-up read and the event stream both go over a
+        // socket that can drop; the sync is running whatever either of those
+        // does. Rejecting here would tell the caller the mutation failed AND
+        // take the job id with it, leaving a running sync that nothing can name
+        // — which is the failure the bound above exists to prevent, reached
+        // from the other side. So the watch ends and the result reports what
+        // was established, `ended` false, with the id.
+        //
+        // Before that event there is nothing of the job to report and no id to
+        // keep, so an error there still fails, as it must.
+        catchError((error: unknown) => (sawJob ? EMPTY : throwError(() => error))),
+        takeUntil(timer(SYNC_WATCH_MS)),
+      ),
       // No emission at all: the request went out and nothing this tool can see
-      // came back about a job, which is reported rather than thrown — the sync
-      // may well be running.
+      // came back about the job, which is reported rather than thrown — the
+      // sync may well be running, and where an event named it `jobId` says so
+      // even though this is null.
       { defaultValue: null },
     );
     const record = lastRunOf(watched);
@@ -2284,7 +2309,13 @@ export const cloudsyncRun: MutatingTool = {
     return {
       task_id: run.id,
       dry_run: run.dryRun,
-      job_id: numberOrNull(recordOrNull(watched)?.['id']),
+      // The id the client correlated off the job event, NOT the `id` on
+      // whatever the tracking last reported. They are the same number — the
+      // tracking filters on it — and only the first survives a watch that ends
+      // with nothing having been read about the job, which is exactly when a
+      // caller most needs something to name the run with. One fact, one
+      // derivation.
+      job_id: jobId,
       watched_seconds: SYNC_WATCH_SECONDS,
       ended,
       // The state and nothing else. `result` is null on this method whatever

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1981,10 +1981,21 @@ function syncParams(run: SyncRun): JobParams<ApiSurface, 'cloudsync.sync'> {
  *
  * The remote end is named because that is what makes the approval meaningful —
  * "run cloud sync task 4" says nothing about where the data is about to go. The
- * credential is named and nothing more: its `provider` holds the access key,
- * token or password, exactly as in the listing this borrows its terms from.
+ * credential is identified and nothing more: its `provider` holds the access
+ * key, token or password, exactly as in the listing this borrows its terms
+ * from.
+ *
+ * That listing identifies it TWO ways — `credential_name` and `credential_id` —
+ * and so does this, under those names, because {@link credentialId} exists for
+ * a reason this plan is subject to as well: the middleware also sends the
+ * id-only form, where there is no `name` to read. One label would then render
+ * as {@link NONE_REPORTED} for a task that named its credential perfectly well,
+ * which is a stated absence in the text a person approves rather than a field
+ * left out.
  */
 function describeCloudSyncTask(task: Record<string, unknown>, id: number): string {
+  const credentials = task['credentials'];
+  const credential = credentialId(credentials);
   const labelled: [string, string | null][] = [
     ['description', stringField(task, 'description')],
     ['path', stringField(task, 'path')],
@@ -1992,7 +2003,8 @@ function describeCloudSyncTask(task: Record<string, unknown>, id: number): strin
     ['transfer mode', stringField(task, 'transfer_mode')],
     ['remote bucket', stringField(task['attributes'], 'bucket')],
     ['remote folder', stringField(task['attributes'], 'folder')],
-    ['credential', stringField(task['credentials'], 'name')],
+    ['credential name', stringField(credentials, 'name')],
+    ['credential id', credential === null ? null : String(credential)],
   ];
   const named = labelled.map(
     ([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`,
@@ -2069,7 +2081,9 @@ export const cloudsyncRun: MutatingTool = {
     'CLOUD SYNC TASK HAS FAILS naming that id — so an approved plan is always ' +
     'about a task that existed when it was made. The plan names the task the ' +
     'way that listing does: its description, its local path, its direction, the ' +
-    'remote bucket and folder, and the stored credential by name. No key, ' +
+    'remote bucket and folder, and the stored credential by name and id — both, ' +
+    'as that listing reports them, since a task can name its credential by ' +
+    'either. No key, ' +
     'token or password appears in the plan or in the result. `dry_run` reports ' +
     'what the sync would do without moving any data, and DEFAULTS TO FALSE, so ' +
     'an omitted `dry_run` copies for real. A DRY RUN STILL STARTS A JOB AND ' +

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2137,10 +2137,18 @@ export const cloudsyncRun: MutatingTool = {
   // `reversible` is a claim about the OPERATION — the run can be stopped — and
   // not about the bytes, which a `SYNC` or a `MOVE` deletes for good. The two
   // are not the same and this field cannot say both: `irreversible` exists only
-  // so the catalog can REJECT it (`catalog/tool.ts`), so marking it that way
-  // would remove the tool rather than describe it more honestly. The honest
-  // account of what the run does to the data is in the description above and in
-  // the plan, which is where a person reads it.
+  // so the catalog can REJECT a tool (`catalog/catalog.ts` throws on it), so
+  // the other value would delete this tool rather than describe it more
+  // honestly.
+  //
+  // What settles which of the two it is: THIS TOOL TRIGGERS AN OPERATION IT
+  // DOES NOT AUTHOR. Everything a run deletes was decided by whoever configured
+  // the task — the mode, the paths, the direction — and the system does the
+  // same thing on its own at the next scheduled window. What this changes is
+  // WHEN, not WHAT, which is not the case the destructive-action policy is
+  // about: a tool that composed its own deletion would be. The account of what
+  // the run does to the data is in the description above and named in the plan,
+  // which is where the person approving it reads it.
   destructiveness: 'reversible',
   normalizeArgs(rawArgs) {
     const run = parseRun(rawArgs);

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2076,7 +2076,8 @@ export const cloudsyncRun: MutatingTool = {
     'could not read, or no job was seen at all — and `state` and `job_id` are ' +
     'what tell those apart: a state beside `ended: false` is a sync still ' +
     'under way, a null `state` beside a `job_id` is a job whose state was ' +
-    'unreadable, and both null is a job this tool never saw. IN NONE OF THE ' +
+    'unreadable, and both null is a job this tool never saw OR one whose state ' +
+    'and id were both unreadable. IN NONE OF THE ' +
     'THREE HAS ANYTHING FAILED. `succeeded` is the answer to "did it work": ' +
     'true where the job ended in a state this catalog reads as success, false ' +
     'where it ended in any other state — including one added by a later ' +
@@ -2092,15 +2093,24 @@ export const cloudsyncRun: MutatingTool = {
     'null where it recorded none, so a job that ended without succeeding and ' +
     'with a null `error` failed for a reason the system did not record — it ' +
     'has not succeeded. `finished_at` is when the job ended, as an ISO 8601 ' +
-    'UTC timestamp, reported only under a state that describes an ended run ' +
-    'and null under every other. `job_id` is the job\'s numeric identity and ' +
+    'UTC timestamp, REPORTED ONLY WHERE `ended` IS TRUE — so it moves with ' +
+    '`ended` and never contradicts it — and null everywhere else, INCLUDING A ' +
+    'JOB STILL RUNNING, whose record can already carry the finish time of an ' +
+    'earlier run. It is also null where the job ended and recorded no time ' +
+    'this tool could read. `job_id` is the job\'s numeric identity and ' +
     'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A SYNC THAT WAS STILL ' +
     'RUNNING IS FOLLOWED UP — this tool reports no progress percentage and no ' +
     'live status, and that tool reports both. `job_id` is null where no job ' +
-    'event named the job within the watch, which does NOT mean the sync did ' +
-    'not start: the call was made, and `cloudsync_tasks_list` will report the ' +
+    'event named the job within the watch, and ALSO where a job event was seen ' +
+    'and the id it carried was not a number this tool could read — so a null ' +
+    '`job_id` beside a non-null `state` is the second of those. NEITHER MEANS ' +
+    'THE SYNC DID ' +
+    'NOT START: the call was made, and `cloudsync_tasks_list` will report the ' +
     'run against the task. `task_id` is the `id` that was asked for and ' +
-    '`dry_run` what was actually sent. THIS TOOL CANNOT STOP A RUNNING SYNC, ' +
+    '`dry_run` what was actually sent. `watched_seconds` is the CEILING that ' +
+    'applied to the watch and not how long it actually lasted — a job that ' +
+    'ended in two seconds still reports the full bound. THIS TOOL CANNOT STOP ' +
+    'A RUNNING SYNC, ' +
     'cannot change, create or delete a task, and cannot sync anything that is ' +
     'not already a task on the system. WHAT THE RUN DOES TO THE DATA IS THE ' +
     "TASK'S OWN `transfer_mode`, WHICH THE PLAN NAMES AND THIS TOOL DOES NOT " +
@@ -2134,21 +2144,14 @@ export const cloudsyncRun: MutatingTool = {
   },
   requiredRole: Role.Full,
   mutating: true,
-  // `reversible` is a claim about the OPERATION — the run can be stopped — and
-  // not about the bytes, which a `SYNC` or a `MOVE` deletes for good. The two
-  // are not the same and this field cannot say both: `irreversible` exists only
-  // so the catalog can REJECT a tool (`catalog/catalog.ts` throws on it), so
-  // the other value would delete this tool rather than describe it more
-  // honestly.
-  //
-  // What settles which of the two it is: THIS TOOL TRIGGERS AN OPERATION IT
-  // DOES NOT AUTHOR. Everything a run deletes was decided by whoever configured
-  // the task — the mode, the paths, the direction — and the system does the
-  // same thing on its own at the next scheduled window. What this changes is
-  // WHEN, not WHAT, which is not the case the destructive-action policy is
-  // about: a tool that composed its own deletion would be. The account of what
-  // the run does to the data is in the description above and named in the plan,
-  // which is where the person approving it reads it.
+  // THIS TOOL TRIGGERS AN OPERATION IT DOES NOT AUTHOR, which is the case
+  // `Destructiveness` names at its own declaration in `catalog/tool.ts`:
+  // everything a run deletes was decided by
+  // whoever configured the task — the mode, the paths, the direction — and the
+  // system does the same thing on its own at the next scheduled window. What
+  // this changes is WHEN, not WHAT. The account of what the run does to the
+  // data is in the description above and named in the plan, which is where the
+  // person approving it reads it, and where that declaration says it belongs.
   destructiveness: 'reversible',
   normalizeArgs(rawArgs) {
     const run = parseRun(rawArgs);
@@ -2235,7 +2238,15 @@ export const cloudsyncRun: MutatingTool = {
       succeeded: ended ? SUCCEEDED_JOB_STATES.has(state) : null,
       state,
       error: jobError(record),
-      finished_at: jobFinishedAt(record, state),
+      // Gated on `ended` and NOT through {@link jobFinishedAt}, which reads
+      // {@link ENDED_JOB_STATES} — a list written down here. The two readings
+      // of "the run is over" disagree exactly where this tool is most careful:
+      // `ended` comes from the client's own completion, so a terminal state a
+      // later TrueNAS release adds is ended here and absent from that list, and
+      // this field would then report null for a run the same result has just
+      // called over. The listings keep the list because none of them carries an
+      // `ended` for it to contradict.
+      finished_at: ended ? isoOrNull(jobMillis(record?.time_finished)) : null,
     };
   },
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2085,22 +2085,28 @@ export const cloudsyncRun: MutatingTool = {
     'already under way. A failure BEFORE anything was seen of the job fails ' +
     'this call instead, and even then MAY STILL HAVE STARTED THE SYNC: check ' +
     '`cloudsync_tasks_list` rather than assuming nothing ran. ' +
-    '`ended` is whether the job was established to have reached a state it will ' +
-    'not move out of. TRUE MEANS THE RUN IS OVER; FALSE IS THREE ANSWERS AND ' +
-    'NOT ONE — the sync is still going (which includes a watch cut short by ' +
-    'either of those), or the job reported a state this tool ' +
-    'could not read, or no job was seen at all — and `state` and `job_id` are ' +
-    'what tell those apart: a state beside `ended: false` is a sync still ' +
-    'under way, a null `state` beside a `job_id` is a job whose state was ' +
-    'unreadable, and both null is a job this tool never saw OR one whose state ' +
-    'and id were both unreadable. IN NONE OF THE ' +
-    'THREE HAS ANYTHING FAILED. `succeeded` is the answer to "did it work": ' +
-    'true where the job ended in a state this catalog reads as success, false ' +
-    'where it ended in any other state — including one added by a later ' +
-    'TrueNAS release, so an unfamiliar terminal state is never read as a ' +
-    'success — and NULL WHERE NOTHING ESTABLISHED IT, which is the job still ' +
-    'running or a state this tool could not read. A null `succeeded` IS NOT A ' +
-    'FAILURE AND IS NOT A SUCCESS. `state` is the state the system last ' +
+    '`ended` is whether the job was ESTABLISHED to have reached a state it ' +
+    'will not move out of. TRUE MEANS THE RUN IS OVER. FALSE MEANS NOTHING WAS ' +
+    'ESTABLISHED AND IS NOT ONE ANSWER — the sync is still going, or the watch ' +
+    'was cut short by either of the failures above, or the job reached a state ' +
+    'the system does not treat as ending a run and so may or may not be over, ' +
+    'or the job reported a state this tool could not read, or no job was seen ' +
+    'at all. `state` and `job_id` narrow that and DO NOT PARTITION IT: a ' +
+    'non-null `state` beside `ended: false` is any of the first three and this ' +
+    'tool cannot say which, a null `state` beside a `job_id` is a job whose ' +
+    'state was unreadable, and both null is a job this tool never saw OR one ' +
+    'whose state and id were both unreadable. IN NONE OF THEM HAS ANYTHING ' +
+    'FAILED. `succeeded` is the answer to "did it work": true where the run ' +
+    'ENDED in a state this catalog reads as success, false where it ENDED in ' +
+    'any other state, and NULL WHERE NOTHING ESTABLISHED IT — which is every ' +
+    'case above where `ended` is false. A null `succeeded` IS NOT A FAILURE ' +
+    'AND IS NOT A SUCCESS, and A STATE THAT LOOKS LIKE A SUCCESS DOES NOT MAKE ' +
+    'ONE: `succeeded` is null beside a `state` of `SUCCESS` where the run was ' +
+    'not established to be over, since a job can still move out of a state ' +
+    'this tool merely saw. NO STATE THIS CATALOG DOES NOT KNOW IS EVER READ AS ' +
+    'A SUCCESS, whether the run ended in it or the watch ended without the run ' +
+    'ending — so a state a later TrueNAS release adds reports as itself and ' +
+    'never as a success. `state` is the state the system last ' +
     'reported, passed through as the system spelled it and null where none was ' +
     'read; `SUCCESS` and `FINISHED` are the two this tool counts as success. ' +
     'The job\'s `result` is NOT read and could not settle any of this: ' +
@@ -2110,10 +2116,11 @@ export const cloudsyncRun: MutatingTool = {
     'with a null `error` failed for a reason the system did not record — it ' +
     'has not succeeded. `finished_at` is when the job ended, as an ISO 8601 ' +
     'UTC timestamp, REPORTED ONLY WHERE `ended` IS TRUE — so it moves with ' +
-    '`ended` and never contradicts it — and null everywhere else, INCLUDING A ' +
-    'JOB STILL RUNNING, whose record can already carry the finish time of an ' +
-    'earlier run. It is also null where the job ended and recorded no time ' +
-    'this tool could read. `job_id` is the job\'s numeric identity and ' +
+    '`ended` and never contradicts it — and NULL EVERYWHERE ELSE EVEN IF THE ' +
+    'JOB RECORD CARRIES A TIME, since a run that was not established to be ' +
+    'over has not been established to have ended then. It is also null where ' +
+    'the job ended and recorded no time this tool could read. `job_id` is the ' +
+    'job\'s numeric identity and ' +
     'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A SYNC THAT WAS STILL ' +
     'RUNNING IS FOLLOWED UP — this tool reports no progress percentage and no ' +
     'live status, and that tool reports both. `job_id` is null where no job ' +

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,7 @@
-import { firstValueFrom } from 'rxjs';
+import type { JobParams } from '@truenas/api-client';
+import { firstValueFrom, lastValueFrom, takeUntil, tap, timer } from 'rxjs';
 import { Role } from '@/interfaces';
-import { MutatingTool, PlanStep, ReadOnlyTool, ToolContext } from '@/catalog/tool';
+import { ApiSurface, MutatingTool, PlanStep, ReadOnlyTool, ToolContext } from '@/catalog/tool';
 import {
   booleanOrNull,
   errorText,
@@ -38,11 +39,16 @@ import {
  * long-running operation on TrueNAS is a job and they all land in the same
  * place.
  *
- * `scheduled_task_set_enabled` is the one tool here that changes anything, and
+ * `scheduled_task_set_enabled` is the first tool here that changes anything, and
  * it is the only one that acts on a kind another family lists: reading a task
  * and then switching it off is one question, and which file the listing lives
  * in is not part of it. It is written beside the schedule rendering above
  * because a plan naming a task has to name it the way its listing tool does.
+ *
+ * `cloudsync_run` is the second, and it is here for the same reason one step
+ * on: it starts one of the tasks `cloudsync_tasks_list` reports, and its plan
+ * names that task in the terms that listing already uses — description, path,
+ * direction, the remote end and the credential by name.
  */
 
 /**
@@ -1842,6 +1848,309 @@ export const scheduledTaskSetEnabled: MutatingTool = {
       // having changed something.
       changed: previous === null || resulting === null ? null : previous !== resulting,
       confirmed: resulting === null ? null : resulting === enabled,
+    };
+  },
+};
+
+/**
+ * `cloudsync_run`: starting one cloud sync task now, and the catalog's first
+ * job-backed tool.
+ *
+ * THE JOB SEAM NEEDED NOTHING NEW IN THIS REPOSITORY. `ApiSurface` is
+ * `DefaultApiDirectory`, whose shape is `{ call, job, event }`, so
+ * `system.client.api.job(...)` was already available to every handler and typed
+ * off the job directory — the client sends the request, correlates the job id
+ * off the job events, tracks the job and completes the observable at a terminal
+ * state. Earlier discussion here treated job support as a core prerequisite;
+ * it is not, and that framing was wrong.
+ *
+ * TERMINAL DOES NOT MEAN SUCCEEDED, and on this method there is nothing else to
+ * read. `cloudsync.sync` declares `response: null`, so the job's `result` is
+ * null on success and on failure alike and cannot tell them apart — the client
+ * says so itself, that "reaching a terminal state is not on its own enough to
+ * assume a result". The outcome is read from `state`, against the same
+ * {@link SUCCEEDED_JOB_STATES} the rest of this family reads a run's state
+ * against, and `result` is not read at all. A tool that awaited completion and
+ * reported success would have reported every failed sync as a success.
+ *
+ * THE DURATION DECISION IS ROUTE 3 OF THE THREE THE TICKET NAMED: watch the job
+ * for a bounded time, then report either how it ended or that it is still
+ * going — with the job id either way. Why not the other two:
+ *
+ * - AWAITING COMPLETION holds the tool call open for as long as the copy takes,
+ *   which is minutes for a delta and hours for a first upload. The host times
+ *   out, and the call it times out on is the only one that ever knew the job
+ *   id, so the sync runs on with nothing able to name it afterwards.
+ * - STARTING AND RETURNING THE ID is what this degrades to when the bound
+ *   passes, so it is the floor rather than an alternative — and it is not the
+ *   bound-free route it looks like: the id itself arrives from the first job
+ *   event carrying this request's id, so that route waits on the network too
+ *   and needs a bound of its own, spent before any outcome could be known.
+ *   Route 3 spends the same wait on an answer that is sometimes complete.
+ *
+ * THE BOUND IS THE ONE NUMBER THIS TOOL HAS TO DEFEND. It must sit comfortably
+ * inside the MCP host's own timeout, because a bound that outlives the host's
+ * never gets to report anything at all; the host's is not readable from here —
+ * `src/interfaces.ts` is the whole environment boundary and carries no deadline
+ * — so {@link SYNC_WATCH_MS} is chosen to be shorter than the shortest in
+ * ordinary use rather than tuned to any one of them. It is returned as
+ * `watched_seconds`, so a caller never has to infer which bound applied, the
+ * same way `snapshots_list` returns the `limit` it actually used.
+ *
+ * ENDING THE WATCH DOES NOT END THE SYNC, and that is read off the client
+ * rather than assumed: `api.job` is `callAndGetJobId` piped into `trackJob`,
+ * and `trackJob` only observes — it filters the job event stream and reads
+ * `core.get_jobs`. Unsubscribing from it sends nothing to the middleware. A
+ * bound that silently aborted a half-finished upload would be the worst defect
+ * this tool could have, so it is the one property here established before the
+ * route was taken rather than after.
+ *
+ * THE PLAN NAMES ONE CALL, WHICH IS #119'S DISTINCTION RATHER THAN A LAPSE.
+ * `scheduled_task_set_enabled` names its read as a step because `execute` makes
+ * that read; this tool reads only at plan time — to name the task, and to fail
+ * on an id no task has — and `execute` re-reads nothing, exactly as
+ * `snapshots_create` does not re-check its dataset. The `core.get_jobs` the
+ * client's own tracking issues while following the job is named in the step's
+ * description instead of as a step, because a step's `params` are the exact
+ * params a call runs with and the job id does not exist until the approved call
+ * has been made.
+ */
+
+/**
+ * How long {@link cloudsyncRun} watches the job it started before reporting
+ * what it has and returning. Thirty seconds; see the note above for why the
+ * number is a ceiling on this tool's own patience rather than an estimate of
+ * how long a sync takes.
+ */
+const SYNC_WATCH_MS = 30_000;
+
+/** Seconds, for the result, so the bound is reported in the unit it is stated in. */
+const SYNC_WATCH_SECONDS = SYNC_WATCH_MS / 1000;
+
+/** The two arguments this tool takes, with `dry_run` already defaulted. */
+interface SyncRun {
+  id: number;
+  dryRun: boolean;
+}
+
+/**
+ * The caller's arguments, or the error naming what is wrong with them.
+ *
+ * Strict on both, as {@link parseSwitch} is and for the same reason: coercing
+ * `"false"` to true would move real data to a remote under an approval given
+ * for a dry run, which is not a narrower answer to the question asked but a
+ * different one. `id` must be a whole number, since the middleware holds these
+ * tasks under integer primary keys.
+ */
+function parseRun(args: Record<string, unknown>): SyncRun {
+  const id = args['id'];
+  if (typeof id !== 'number' || !Number.isInteger(id)) {
+    throw new Error('"id" is required and must be a whole number');
+  }
+  const dryRun = args['dry_run'];
+  if (dryRun != null && typeof dryRun !== 'boolean') {
+    throw new Error('"dry_run" must be a boolean');
+  }
+  return { id, dryRun: dryRun === true };
+}
+
+/**
+ * The params the job is started with, typed off the job directory — a disjoint
+ * key space from the call directory, so `CallParams` cannot name them.
+ *
+ * The options object is always sent rather than omitted when `dry_run` is
+ * false: the plan shows the params, and a plan whose second argument appears
+ * only on a dry run would be showing two different call shapes for one tool.
+ */
+function syncParams(run: SyncRun): JobParams<ApiSurface, 'cloudsync.sync'> {
+  return [run.id, { dry_run: run.dryRun }];
+}
+
+/**
+ * The task in the terms `cloudsync_tasks_list` reports it, for the human
+ * approving the plan.
+ *
+ * The remote end is named because that is what makes the approval meaningful —
+ * "run cloud sync task 4" says nothing about where the data is about to go. The
+ * credential is named and nothing more: its `provider` holds the access key,
+ * token or password, exactly as in the listing this borrows its terms from.
+ */
+function describeCloudSyncTask(task: Record<string, unknown>, id: number): string {
+  const labelled: [string, string | null][] = [
+    ['description', stringField(task, 'description')],
+    ['path', stringField(task, 'path')],
+    ['direction', stringField(task, 'direction')],
+    ['remote bucket', stringField(task['attributes'], 'bucket')],
+    ['remote folder', stringField(task['attributes'], 'folder')],
+    ['credential', stringField(task['credentials'], 'name')],
+  ];
+  const named = labelled.map(
+    ([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`,
+  );
+  return `the cloud sync task with ${named.join(', ')} (id ${id})`;
+}
+
+export const cloudsyncRun: MutatingTool = {
+  name: 'cloudsync_run',
+  description:
+    'Starts one cloud sync task on this TrueNAS system now, without waiting ' +
+    'for its schedule, and reports how far it got. Two-phase: called without a ' +
+    'confirmation_token it returns a plan for user approval; called with one it ' +
+    'starts the sync. `id` is the task\'s `id` as `cloudsync_tasks_list` ' +
+    'reports it, on the system being targeted, and PLANNING AGAINST AN id NO ' +
+    'CLOUD SYNC TASK HAS FAILS naming that id — so an approved plan is always ' +
+    'about a task that existed when it was made. The plan names the task the ' +
+    'way that listing does: its description, its local path, its direction, the ' +
+    'remote bucket and folder, and the stored credential by name. No key, ' +
+    'token or password appears in the plan or in the result. `dry_run` reports ' +
+    'what the sync would do without moving any data, and DEFAULTS TO FALSE, so ' +
+    'an omitted `dry_run` copies for real. A DRY RUN STILL STARTS A JOB AND ' +
+    'STILL CONTACTS THE REMOTE — it is not a local simulation, and it costs ' +
+    'whatever listing the remote costs. THE RESULT IS ABOUT THE JOB THIS CALL ' +
+    'STARTED, AND "STARTED" IS NOT "SUCCEEDED". A cloud sync is unbounded — ' +
+    'minutes for a small delta, hours for a first upload — so this tool ' +
+    'WATCHES THE JOB FOR AT MOST `watched_seconds` AND THEN RETURNS WHATEVER ' +
+    'IT HAS, leaving the sync running. It never waits for the copy to finish. ' +
+    '`ended` is whether the job reached a state it will not move out of within ' +
+    'that time; `ended: false` IS A SYNC THAT IS STILL GOING and says nothing ' +
+    'about whether it will work. `succeeded` is the answer to "did it work": ' +
+    'true where the job ended in a state this catalog reads as success, false ' +
+    'where it ended in any other state — including one added by a later ' +
+    'TrueNAS release, so an unfamiliar terminal state is never read as a ' +
+    'success — and NULL WHERE NOTHING ESTABLISHED IT, which is the job still ' +
+    'running or a state this tool could not read. A null `succeeded` IS NOT A ' +
+    'FAILURE AND IS NOT A SUCCESS. `state` is the state the system last ' +
+    'reported, passed through as the system spelled it and null where none was ' +
+    'read; `SUCCESS` and `FINISHED` are the two this tool counts as success. ' +
+    'The job\'s `result` is NOT read and could not settle any of this: ' +
+    '`cloudsync.sync` returns nothing, so a finished job carries a null result ' +
+    'whether it worked or failed. `error` is the text the job recorded and is ' +
+    'null where it recorded none, so a job that ended without succeeding and ' +
+    'with a null `error` failed for a reason the system did not record — it ' +
+    'has not succeeded. `finished_at` is when the job ended, as an ISO 8601 ' +
+    'UTC timestamp, reported only under a state that describes an ended run ' +
+    'and null under every other. `job_id` is the job\'s numeric identity and ' +
+    'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A SYNC THAT WAS STILL ' +
+    'RUNNING IS FOLLOWED UP — this tool reports no progress percentage and no ' +
+    'live status, and that tool reports both. `job_id` is null where no job ' +
+    'event named the job within the watch, which does NOT mean the sync did ' +
+    'not start: the call was made, and `cloudsync_tasks_list` will report the ' +
+    'run against the task. `task_id` is the `id` that was asked for and ' +
+    '`dry_run` what was actually sent. THIS TOOL CANNOT STOP A RUNNING SYNC, ' +
+    'cannot change, create or delete a task, and cannot sync anything that is ' +
+    'not already a task on the system. Starting a sync is reversible in that ' +
+    'the run can be aborted from the TrueNAS UI, but THE DATA MOVEMENT ITSELF ' +
+    'IS NOT UNDONE by this or by anything here: a `PUSH` overwrites at the ' +
+    'remote and a `PULL` overwrites locally, according to the task\'s own ' +
+    'configuration, which this tool does not report and does not change.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer',
+        description:
+          "The cloud sync task's `id` as `cloudsync_tasks_list` reports it, on " +
+          'the system being targeted.',
+      },
+      dry_run: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Report what the sync would do without moving data. Default false, ' +
+          'which copies for real. A dry run still starts a job and still ' +
+          'contacts the remote.',
+      },
+    },
+    required: ['id'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    const run = parseRun(rawArgs);
+    return { id: run.id, dry_run: run.dryRun };
+  },
+  async plan(ctx, rawArgs): Promise<PlanStep[]> {
+    const run = parseRun(rawArgs);
+    // The id is checked on the response and not only asked for in the filter,
+    // for the reason {@link rowWithId} gives: a filter that did not apply comes
+    // back as the whole table, and the first row of that is a different task.
+    const rows = await firstValueFrom(
+      ctx.system.client.api.query('cloudsync.query', [['id', '=', run.id]]),
+    );
+    const task = rowWithId(rows, run.id);
+    if (task === null) {
+      throw new Error(
+        `No cloud sync task with id ${run.id} on this system — the ids this ` +
+          'tool takes come from `cloudsync_tasks_list`',
+      );
+    }
+    return [
+      {
+        method: 'cloudsync.sync',
+        params: syncParams(run),
+        description:
+          `${run.dryRun ? 'Dry-run' : 'Run'} ${describeCloudSyncTask(task, run.id)} now. ` +
+          `${
+            run.dryRun
+              ? 'A dry run moves no data, and still contacts the remote.'
+              : 'This copies data between this system and the remote.'
+          } ` +
+          'This starts a background job; the job is then followed through the ' +
+          "client's own tracking, which reads `core.get_jobs` and changes " +
+          `nothing, for at most ${SYNC_WATCH_SECONDS} seconds. The sync ` +
+          'continues after that whether or not it has finished.',
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const run = parseRun(rawArgs);
+    // Set from the tracking observable COMPLETING rather than from comparing
+    // the state against a list, because completion is the client's own
+    // `isJobFinished` and so moves with the middleware's terminal set rather
+    // than with a set written down here. The bound below cuts the stream by
+    // unsubscribing, which is not a completion, so a job still running when the
+    // watch ends leaves this false.
+    let completed = false;
+    const watched = await lastValueFrom(
+      ctx.system.client.api
+        .job('cloudsync.sync', syncParams(run))
+        .pipe(
+          tap({
+            complete: () => {
+              completed = true;
+            },
+          }),
+          takeUntil(timer(SYNC_WATCH_MS)),
+        ),
+      // No emission at all: the request went out and nothing this tool can see
+      // came back about a job, which is reported rather than thrown — the sync
+      // may well be running.
+      { defaultValue: null },
+    );
+    const record = lastRunOf(watched);
+    // Read through the same guards the listings read a job record with, and
+    // deliberately NOT through `lastRunState`, whose null case means "the task
+    // has never run" — an answer about a task, where this is an answer about
+    // one job that has just been started.
+    const state = stringField(watched, 'state');
+    // A completion with no emission is the client having found no such job,
+    // which establishes nothing about the run; both halves are required.
+    const ended = completed && state !== null;
+    return {
+      task_id: run.id,
+      dry_run: run.dryRun,
+      job_id: numberOrNull(recordOrNull(watched)?.['id']),
+      watched_seconds: SYNC_WATCH_SECONDS,
+      ended,
+      // The state and nothing else. `result` is null on this method whatever
+      // happened, so reading it could only ever have produced a wrong answer.
+      // The direction is `notSucceeded`'s: a terminal state this catalog does
+      // not recognise is not read as a success.
+      succeeded: ended ? SUCCEEDED_JOB_STATES.has(state) : null,
+      state,
+      error: jobError(record),
+      finished_at: jobFinishedAt(record, state),
     };
   },
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1980,6 +1980,7 @@ function describeCloudSyncTask(task: Record<string, unknown>, id: number): strin
     ['description', stringField(task, 'description')],
     ['path', stringField(task, 'path')],
     ['direction', stringField(task, 'direction')],
+    ['transfer mode', stringField(task, 'transfer_mode')],
     ['remote bucket', stringField(task['attributes'], 'bucket')],
     ['remote folder', stringField(task['attributes'], 'folder')],
     ['credential', stringField(task['credentials'], 'name')],
@@ -1988,6 +1989,64 @@ function describeCloudSyncTask(task: Record<string, unknown>, id: number): strin
     ([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`,
   );
   return `the cloud sync task with ${named.join(', ')} (id ${id})`;
+}
+
+/**
+ * What each transfer mode does to the data, in the plan's own words.
+ *
+ * `transfer_mode` is declared REQUIRED on the pinned cloud sync entity and it
+ * decides whether the run deletes anything: `COPY` deletes nothing, `SYNC`
+ * makes the destination match the source and so removes whatever is not at the
+ * source, and `MOVE` removes the source once the copy has landed. A plan that
+ * said "this copies data" for all three would hide a deletion behind the word
+ * the tool's name uses — a plan is what a person approves, so that is the same
+ * defect as a description promising more than the normalization delivers,
+ * pointed the other way.
+ */
+const TRANSFER_MODE_EFFECT: Record<string, string> = {
+  COPY: 'new and changed files are copied to the destination, and nothing is deleted at either end.',
+  SYNC:
+    'the destination is made to match the source, so anything at the destination that is ' +
+    'not at the source IS DELETED.',
+  MOVE: 'files are copied to the destination and are then DELETED FROM THE SOURCE.',
+};
+
+/**
+ * Which end is which, since every sentence above is written in terms of source
+ * and destination.
+ *
+ * This is `cloudsync_tasks_list`'s own reading of `direction`, restated rather
+ * than re-derived — that tool's description already says `path` is the local
+ * end, the source on a `PUSH` and the destination on a `PULL`.
+ */
+const TRANSFER_ENDS =
+  'On a PUSH this system is the source and the remote the destination; on a PULL it is the ' +
+  'other way round.';
+
+/**
+ * The effect sentence for this task's mode, or the statement that the effect
+ * was not established.
+ *
+ * A mode this tool cannot read is said to be exactly that, and NOT defaulted to
+ * the harmless one: an approver told nothing about deletion would read the
+ * absence as "nothing is deleted", which is the one reading that costs data.
+ *
+ * `Object.hasOwn` rather than `in`, which walks the prototype — `'constructor'`
+ * is `in` every object literal and would come back as a function where a
+ * sentence is expected (#101).
+ */
+function transferModeSentence(task: Record<string, unknown>): string {
+  const mode = stringField(task, 'transfer_mode');
+  const effect =
+    mode !== null && Object.hasOwn(TRANSFER_MODE_EFFECT, mode)
+      ? TRANSFER_MODE_EFFECT[mode]
+      : undefined;
+  if (effect !== undefined) return `Transfer mode ${mode}: ${effect} ${TRANSFER_ENDS}`;
+  return (
+    `Transfer mode ${mode === null ? NONE_REPORTED : `"${mode}"`}: whether this run DELETES ` +
+    'anything, at either end, is not established here — read the task\'s transfer mode before ' +
+    'approving.'
+  );
 }
 
 export const cloudsyncRun: MutatingTool = {
@@ -2011,9 +2070,14 @@ export const cloudsyncRun: MutatingTool = {
     'minutes for a small delta, hours for a first upload — so this tool ' +
     'WATCHES THE JOB FOR AT MOST `watched_seconds` AND THEN RETURNS WHATEVER ' +
     'IT HAS, leaving the sync running. It never waits for the copy to finish. ' +
-    '`ended` is whether the job reached a state it will not move out of within ' +
-    'that time; `ended: false` IS A SYNC THAT IS STILL GOING and says nothing ' +
-    'about whether it will work. `succeeded` is the answer to "did it work": ' +
+    '`ended` is whether the job was established to have reached a state it will ' +
+    'not move out of. TRUE MEANS THE RUN IS OVER; FALSE IS THREE ANSWERS AND ' +
+    'NOT ONE — the sync is still going, or the job reported a state this tool ' +
+    'could not read, or no job was seen at all — and `state` and `job_id` are ' +
+    'what tell those apart: a state beside `ended: false` is a sync still ' +
+    'under way, a null `state` beside a `job_id` is a job whose state was ' +
+    'unreadable, and both null is a job this tool never saw. IN NONE OF THE ' +
+    'THREE HAS ANYTHING FAILED. `succeeded` is the answer to "did it work": ' +
     'true where the job ended in a state this catalog reads as success, false ' +
     'where it ended in any other state — including one added by a later ' +
     'TrueNAS release, so an unfamiliar terminal state is never read as a ' +
@@ -2038,11 +2102,16 @@ export const cloudsyncRun: MutatingTool = {
     'run against the task. `task_id` is the `id` that was asked for and ' +
     '`dry_run` what was actually sent. THIS TOOL CANNOT STOP A RUNNING SYNC, ' +
     'cannot change, create or delete a task, and cannot sync anything that is ' +
-    'not already a task on the system. Starting a sync is reversible in that ' +
-    'the run can be aborted from the TrueNAS UI, but THE DATA MOVEMENT ITSELF ' +
-    'IS NOT UNDONE by this or by anything here: a `PUSH` overwrites at the ' +
-    'remote and a `PULL` overwrites locally, according to the task\'s own ' +
-    'configuration, which this tool does not report and does not change.',
+    'not already a task on the system. WHAT THE RUN DOES TO THE DATA IS THE ' +
+    "TASK'S OWN `transfer_mode`, WHICH THE PLAN NAMES AND THIS TOOL DOES NOT " +
+    'CHANGE: `COPY` deletes nothing, `SYNC` makes the destination match the ' +
+    'source and so DELETES whatever at the destination is not at the source, ' +
+    'and `MOVE` DELETES THE SOURCE once the copy lands — with `direction` ' +
+    'saying which end is which, this system being the source on a `PUSH` and ' +
+    'the destination on a `PULL`. NOTHING HERE UNDOES ANY OF THAT. The run ' +
+    'itself can be stopped from the TrueNAS UI, which is all this tool\'s ' +
+    "`destructiveness` records; the bytes it has already written or deleted " +
+    'stay written or deleted.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -2065,6 +2134,13 @@ export const cloudsyncRun: MutatingTool = {
   },
   requiredRole: Role.Full,
   mutating: true,
+  // `reversible` is a claim about the OPERATION — the run can be stopped — and
+  // not about the bytes, which a `SYNC` or a `MOVE` deletes for good. The two
+  // are not the same and this field cannot say both: `irreversible` exists only
+  // so the catalog can REJECT it (`catalog/tool.ts`), so marking it that way
+  // would remove the tool rather than describe it more honestly. The honest
+  // account of what the run does to the data is in the description above and in
+  // the plan, which is where a person reads it.
   destructiveness: 'reversible',
   normalizeArgs(rawArgs) {
     const run = parseRun(rawArgs);
@@ -2091,10 +2167,11 @@ export const cloudsyncRun: MutatingTool = {
         params: syncParams(run),
         description:
           `${run.dryRun ? 'Dry-run' : 'Run'} ${describeCloudSyncTask(task, run.id)} now. ` +
+          `${transferModeSentence(task)} ` +
           `${
             run.dryRun
-              ? 'A dry run moves no data, and still contacts the remote.'
-              : 'This copies data between this system and the remote.'
+              ? 'This is a dry run: it transfers and deletes nothing, and still contacts the remote.'
+              : 'This run does all of that for real.'
           } ` +
           'This starts a background job; the job is then followed through the ' +
           "client's own tracking, which reads `core.get_jobs` and changes " +

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,5 +1,14 @@
 import type { JobParams } from '@truenas/api-client';
-import { firstValueFrom, lastValueFrom, takeUntil, tap, timer } from 'rxjs';
+import {
+  catchError,
+  EMPTY,
+  firstValueFrom,
+  lastValueFrom,
+  takeUntil,
+  tap,
+  throwError,
+  timer,
+} from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, MutatingTool, PlanStep, ReadOnlyTool, ToolContext } from '@/catalog/tool';
 import {
@@ -2070,9 +2079,16 @@ export const cloudsyncRun: MutatingTool = {
     'minutes for a small delta, hours for a first upload — so this tool ' +
     'WATCHES THE JOB FOR AT MOST `watched_seconds` AND THEN RETURNS WHATEVER ' +
     'IT HAS, leaving the sync running. It never waits for the copy to finish. ' +
+    'THE WATCH ALSO ENDS IF FOLLOWING THE JOB FAILS — a dropped connection, a ' +
+    'failed read of the job list — and that is reported as what was ' +
+    'established rather than as the sync having failed, since the run was ' +
+    'already under way. A failure BEFORE anything was seen of the job fails ' +
+    'this call instead, and even then MAY STILL HAVE STARTED THE SYNC: check ' +
+    '`cloudsync_tasks_list` rather than assuming nothing ran. ' +
     '`ended` is whether the job was established to have reached a state it will ' +
     'not move out of. TRUE MEANS THE RUN IS OVER; FALSE IS THREE ANSWERS AND ' +
-    'NOT ONE — the sync is still going, or the job reported a state this tool ' +
+    'NOT ONE — the sync is still going (which includes a watch cut short by ' +
+    'either of those), or the job reported a state this tool ' +
     'could not read, or no job was seen at all — and `state` and `job_id` are ' +
     'what tell those apart: a state beside `ended: false` is a sync still ' +
     'under way, a null `state` beside a `job_id` is a job whose state was ' +
@@ -2200,15 +2216,34 @@ export const cloudsyncRun: MutatingTool = {
     // unsubscribing, which is not a completion, so a job still running when the
     // watch ends leaves this false.
     let completed = false;
+    // Whether the client ever reported on the job. Once it has, the job exists
+    // and its id is in hand, which is what the guard below turns on.
+    let sawJob = false;
     const watched = await lastValueFrom(
       ctx.system.client.api
         .job('cloudsync.sync', syncParams(run))
         .pipe(
           tap({
+            next: () => {
+              sawJob = true;
+            },
             complete: () => {
               completed = true;
             },
           }),
+          // An error raised while FOLLOWING a job the client has already
+          // reported on is not the call failing. `trackJob` reads
+          // `core.get_jobs` and listens on a socket that can drop; the sync is
+          // running whatever either of those does. Rejecting here would tell the
+          // caller the mutation failed AND take the job id with it, leaving a
+          // running sync that nothing can name — which is the failure the bound
+          // above exists to prevent, reached from the other side. So the watch
+          // ends and the result reports what was established, `ended` false.
+          //
+          // Before the first emission there is no id to keep and nothing to
+          // report, and the likeliest cause is the call itself being rejected —
+          // so that still fails, as it must.
+          catchError((error: unknown) => (sawJob ? EMPTY : throwError(() => error))),
           takeUntil(timer(SYNC_WATCH_MS)),
         ),
       // No emission at all: the request went out and nothing this tool can see
@@ -2239,13 +2274,16 @@ export const cloudsyncRun: MutatingTool = {
       state,
       error: jobError(record),
       // Gated on `ended` and NOT through {@link jobFinishedAt}, which reads
-      // {@link ENDED_JOB_STATES} — a list written down here. The two readings
-      // of "the run is over" disagree exactly where this tool is most careful:
-      // `ended` comes from the client's own completion, so a terminal state a
-      // later TrueNAS release adds is ended here and absent from that list, and
-      // this field would then report null for a run the same result has just
-      // called over. The listings keep the list because none of them carries an
-      // `ended` for it to contradict.
+      // {@link ENDED_JOB_STATES}. The two agree on the PINNED client and are
+      // not the same reading: the client's `terminalStates` — what
+      // `isJobFinished` tests, and so what completes the tracking — holds
+      // exactly these five, checked in its `dist/index.js` rather than assumed,
+      // while the set here is this repository's own. Two independently
+      // maintained lists that happen to be equal today, and a client release
+      // that widens its own would leave this result calling a run ended and
+      // refusing to say when. `ended` is the claim this tool has already made,
+      // so the finish time follows it and cannot contradict it. The listings
+      // keep reading the set: none of them carries an `ended` to disagree with.
       finished_at: ended ? isoOrNull(jobMillis(record?.time_finished)) : null,
     };
   },


### PR DESCRIPTION
Adds `cloudsync_run`, the catalog's fifth mutating tool and its first job-backed one. Fixes #122.

## What it does

Starts `cloudsync.sync` for one existing cloud sync task and reports how far the job got. `dry_run` is supported and defaults to false; the description says a dry run still starts a job and still contacts the remote.

## The job seam needed nothing new

`ApiSurface` is `DefaultApiDirectory`, whose shape is `{ call, job, event }`, so the job seam — `api.job`, and the `callAndGetJobId`/`trackJob` pair it is made of, which is what `execute` ended up calling — was already available to every handler and already typed off the *job* directory — a key space disjoint from the call directory. The ticket's claim here was correct, and it is checked rather than taken: `cloudsync.sync` is in `ApiJobDirectoryBase`, with `params: [id: number, cloud_sync_sync_options?: CloudSyncSyncOptions]` and `response: null`.

## The duration decision: route 3, with a 30-second bound

Watch the job for a bounded time, then report either how it ended or that it is still going — with the job id either way.

- **Awaiting completion** holds the tool call open for a copy that runs for minutes or hours. The host times out, and the call it times out on is the only one that ever knew the job id, so the sync continues with nothing able to name it.
- **Starting and returning the id** is what this degrades to when the bound passes, which makes it the floor rather than an alternative. It is also not the wait-free route it looks like: the id arrives from the first job event carrying this request's id, so it waits on the network too and needs a bound of its own — one spent before any outcome could be known.

The bound is a ceiling on the tool's patience, not an estimate of the job. It has to sit inside the MCP host's own timeout, which is not readable here (`src/interfaces.ts` is the whole environment boundary and carries no deadline), so 30 seconds is chosen to be shorter than the shortest in ordinary use. It is returned as `watched_seconds`, the way `snapshots_list` returns the `limit` it applied, and the description says outright that it is the ceiling rather than how long the watch actually lasted.

**Ending the watch does not end the sync, and that was established before the route was taken.** `api.job` is `callAndGetJobId` piped into `trackJob`, and `trackJob` only observes — it filters the job event stream and reads `core.get_jobs`. Unsubscribing sends nothing to the middleware.

**Nor does failing to follow it.** `trackJob` reads `core.get_jobs` over a socket that can drop, so the stream can error long after the mutation landed. That used to reject `execute`, which told the caller the sync had failed while it was running and threw away the job id in the same act — the unnameable-run failure the bound exists to prevent, reached from the other side. An error raised once the client has named the job now ends the watch and reports what was established, `ended: false`, **with the job id**. An error *before* the job event names it still fails: there is nothing of the job to report and no id to keep.

## `execute` calls `callAndGetJobId` and `trackJob` apart, not `api.job`

`api.job` is exactly those two piped together — and it consumes the correlated job id inside its own `switchMap`, so nothing of the job reaches the caller's pipe until `trackJob` emits. `trackJob` opens by dispatching `core.get_jobs`, which can fail on its own, and by then the job event has correlated the id and **the sync is running**. Through `api.job` that failure arrived as a rejection carrying nothing: the guard above could not see the job yet, so it rethrew, and the caller was told the mutation failed while the one number that could still name the run went with it. That is the exact failure this tool is built to avoid, reached through the one path its own guard could not see. Round 8 found it.

So the two stages are called apart, `sawJob` and `job_id` are set from the correlation, and a follow-up read that fails before reporting anything ends the watch and still answers with the id. What the split costs is the client's own stated reason to prefer `api.job` — a job typed `result: unknown` — and it costs nothing here: `cloudsync.sync` declares `response: null` and this tool never reads `result`.

`job_id` comes from that correlation and no longer reads `id` off the last tracked record. They are the same number, since the tracking filters on it, and only the correlated one survives a watch that established nothing else — which is exactly when a caller most needs something to name the run with. One fact, one derivation, the same rule `finished_at` follows above. Two readings move with it and are corrected in the description: a `job_id` beside a null `state` is now also "a job the system named and then said nothing readable about", and `job_id: null` now means no job event named the request at all, or the id it carried was unreadable.

## Terminal is not succeeded

`cloudsync.sync` declares `response: null`, so the job's `result` is null on success and on failure alike. It is **not read at all**. `succeeded` comes off `state`, against the same `SUCCESS`/`FINISHED` vocabulary the rest of the tasks family already reads a run's state against.

Whether the job ended is read from the tracking observable **completing** — the client's own `isJobFinished` — rather than from a state list written down in this repository. That set is `terminalStates` in `@truenas/api-client`, read out of its `dist/index.js` rather than assumed: it holds exactly the five states `ENDED_JOB_STATES` holds. So the two agree today, and **only a client bump can move the client's, not a TrueNAS release** — a job in a state neither list names does not complete the tracking at all, and runs until the bound expires.

Two things follow, and both cost a review round to state correctly:

- **`finished_at` gates on `ended`, not on `ENDED_JOB_STATES`.** Not a live defect — the sets are equal — but they are independently maintained, and one result must not be able to call a run over and refuse to say when it ended.
- **`ended: false` is "nothing was established", not a three-way status.** It covers a sync still going, a watch cut short by one of the failures above, a job in a state the system does not treat as ending a run, an unreadable state, and no job seen at all. `state` and `job_id` narrow that and do not partition it: the first three present identically and the description says so. Nothing in any of them is a failure. `succeeded` is null throughout — including beside a `state` of `SUCCESS` that the watch never saw the job settle into.

## The plan

One step, `cloudsync.sync`, with the exact params `execute` runs. This tool reads only at plan time — to name the task and to fail on an id no task has — and `execute` re-reads nothing, which is #119's distinction rather than a lapse (`scheduled_task_set_enabled` names its read as a step because *its* execute makes that read). The `core.get_jobs` the client's tracking issues while following the job is named in the step's description instead of as a step, because a step's `params` are exact and the job id does not exist until the approved call has been made.

The plan names the task the way `cloudsync_tasks_list` does — description, path, direction, transfer mode, remote bucket and folder, and the credential **by name and id, under that listing's own field names**; its `provider` holds the access key and is never read. Both labels, because `credentials` is declared a whole record and the middleware also sends the id-only form, which is why `credentialId` exists in this file. Reading only the name rendered `credential (the system reported none)` for a task that identified its credential perfectly well — a stated absence, in the text a person approves. Round 8's MEDIUM. The read filters on the id and then finds the row by id anyway, per #121: a filter that was dropped rather than refused comes back as the whole table, and the first row of that is a different task.

## `destructiveness`: the value is unchanged, and every statement of what it means now agrees

Raised as MEDIUM in **three** rounds, and the third of them is why this section reads differently from how rounds 3 and 6 left it.

`cloudsync_run` is `reversible` and that has not moved. What moved is the prose, in three places, none of which changes a value, a type or a line of behaviour:

- **`Destructiveness`'s own declaration** (`src/catalog/tool.ts`) said only "how hard a mutating tool is to undo", while this tool sat three fields from a description reading `NOTHING HERE UNDOES ANY OF THAT`. `ToolCatalog.list()` puts the field into every `AdvertisedTool`, so an adapter deciding how loudly to warn reads that doc — and the redefinition making `reversible` true lived only in a comment beside one tool and in `CLAUDE.md`. The declaration now says what the field records: **the tool's own operation, not what the operation does to the data**, and that a tool triggering an operation someone else authored is `reversible` on that reading.
- **`ToolCatalog.register`'s rejection message and `README.md`** both still stated the older, wider guarantee — that the destructive-action policy keeps irreversibly destructive *operations* out of the catalog. The check is narrower than that: it rejects a tool that **composes** such an operation, and says nothing about one that triggers an operation an operator already authored. Both now state the narrower claim, which is the one that is true. `catalog.spec.ts` asserts on `destructive-action policy`, a substring the reworded message keeps, so the rejection path is still covered.
- **`AdvertisedTool.destructiveness`** — the field `list()` actually hands an adapter — carried no doc comment at all, so a redefinition three files away did not reach the reader most likely to act on it. It now points at `Destructiveness` and says outright that the field must not be read alone.

The rule itself: everything a cloud sync run deletes was decided by whoever configured the task, and the system does the same thing unattended at the next scheduled window — this tool moves the moment, not the effect. A tool that composed a deletion of its own is the case the destructive-action policy is about and does not belong in the catalog at all, which is what `irreversible` enforces (`catalog/catalog.ts` throws on registration).

**Everything above is additive or corrected JSDoc, prose and one error string. No value and no type changed.** Whether a third value is warranted is #128's, filed off this PR's proposal, and every option in it is still open.

The general lesson is in `CLAUDE.md`: **when a redefinition lands, grep for the sentence it replaces.** The enforcement point, the advertised shape and the user-facing README each stated the field's meaning independently, and fixing only the declaration left two of them contradicting it.

## Review rounds

- **Round 2 (one HIGH, two MEDIUM).** The HIGH: the plan said "This copies data between this system and the remote" for every task, and `transfer_mode` — declared required on the pinned entity — decides otherwise. `SYNC` makes the destination match the source and so deletes whatever at the destination is not at the source; `MOVE` deletes the source once the copy lands. One sentence hid a deletion behind the word the tool is named for, in the text a person approves. The mode is now named in the plan, its effect spelled out in its own terms, and a mode this tool cannot read says so rather than defaulting to the harmless one. Also a MEDIUM on `ended: false` being described as "still going" alone.
- **Round 3 (two MEDIUM, three LOW).** `finished_at` contradicting `ended`; the `Destructiveness` declaration. Both fixed above.
- **Round 4 (one HIGH, one MEDIUM).** The stream-error-loses-the-job-id HIGH, fixed above. The MEDIUM caught the round-3 rationale being *backwards* — it claimed a later TrueNAS release could complete the tracking on a state absent from `ENDED_JOB_STATES`, and the terminal set is the client's. Corrected in the code comment, in `CLAUDE.md` and in the spec that models it.
- **Round 5 (one MEDIUM, one LOW).** The description still promised `succeeded: false` for an unfamiliar terminal state, which the same correction rules out, and still enumerated `ended: false` as three answers over five causes. Both fixed.
- **Round 6 (one MEDIUM, three LOW).** This section previously called round 6 clean, which was wrong and is corrected here: the shared reviewer raised `destructiveness` a third time, on the ground that `catalog.ts`'s own rejection message still stated a guarantee the field no longer carries. That is the finding fixed in the section above. The three LOWs are listed below.
- **Round 7: clean.** No findings at MEDIUM or above; one LOW, listed below.
- **Round 8 (one MEDIUM, one LOW).** The required check, not a local round: the plan read `credentials.name` alone and so reported "the system reported none" for a credential sent in the id-only form. Fixed above.
- **Round 9 (one HIGH, three LOW).** The HIGH is the `api.job` seam in its own section above — the guard meant to absorb a follow-the-job failure could not see the job during the window where `trackJob`'s own `core.get_jobs` dispatch fails, so that failure rejected the call and discarded the id of a running sync. Fixed by calling the two client stages apart. Two of the LOWs were fixed with it because the same commits made them: the tasks-family header still said the plan named the credential by name, and the description's account of a null `state` beside a `job_id` no longer covered every way that pair is reached.
- **Round 10: clean.** No findings at MEDIUM or above; five LOW, four of them already on this list and the fifth added below.

Rounds 4, 5, 7, 9 and 10 ran a subagent against the same rubric because the shared reviewer timed out at 420s; rounds 2, 3 and 6 are the shared reviewer itself and round 8 is the required check on this PR. **A clean subagent round is weaker evidence than a clean shared-reviewer round** — same rubric and same threshold, different reader — and round 10, the round this push is made on, is one of the weaker ones. Round 9's HIGH is worth reading as evidence in both directions: a subagent round found what six rounds before it had not.

## What I did not change, and why

**From round 10 (one new LOW):**

- **The credential id is stringified into the plan's shared quoting, so it reads `credential id "2"`** where `cloudsync_tasks_list` reports the number `2`. Real, and the fix is a second rendering path for numeric labels in a helper this ticket did not otherwise touch — the same shape as the `renderLabelled` LOW below, which it would share. Nothing is misread: the id is exact and the label says what it is.

**From round 7 (one LOW):**

- **`.claude/review-prompt.md` still tells the CI reviewer that "irreversibly destructive operations must stay out of the catalog"** — the same sentence this PR narrowed in `catalog.ts`, `README.md` and on the `Destructiveness` declaration, and by the "grep for the sentence it replaces" rule above it is a fourth statement of it. It is left alone deliberately: editing the file that instructs the reviewer *of this pull request*, to remove the premise of a finding that reviewer raised, is not a change this ticket should make unilaterally. It belongs to #128, which owns the `destructiveness` question, and is noted here so it is not lost.

**Three LOWs from round 6:**

- **`watched_seconds` reports the 30-second ceiling rather than the elapsed watch time**, and the name reads as elapsed. The description says outright that it is the ceiling and that a job ending in two seconds still reports the full bound — the same shape as `snapshots_list` returning the `limit` it applied.
- **The caught follow-the-job error is not surfaced as a field**, so a dropped socket two seconds in is indistinguishable from a watch that ran its full bound. Real, and a `watch_error` is the right shape; it is a new result field on a tool whose result contract this round was otherwise only correcting prose on. The description already refuses to claim the two apart.
- **The duplicated "label, or `NONE_REPORTED`" rendering** shared by `describeTask` and `describeCloudSyncTask`. The field *lists* rightly differ; only the rendering repeats. A `renderLabelled` helper is the right shape and is a refactor of a function this ticket did not otherwise touch.

**From earlier rounds:**

- **The description says "the call was made" for a null `job_id` and `state`, and a watch that expires while `connection.send` is still awaiting the socket never wrote the request.** True, and the sentence's purpose is to stop a caller concluding that nothing ran — which is the direction that costs data. Narrowing it would need the tool to distinguish "sent" from "queued", which `api.job` does not expose.
- **`execute` narrows one emission through `lastRunOf` and `stringField` in adjacent lines.** Each guard answers a different question and none is hot; collapsing them is a readability change to code the reviewer read correctly. (The third narrowing this bullet used to name, `recordOrNull` for the job id, is gone: `job_id` comes from the correlation now.)
- **`SYNC_WATCH_MS` is a module constant with no adapter override, though only the adapter knows the MCP host timeout it must sit inside.** Real, and it is a change to `src/interfaces.ts` — the environment boundary — rather than to this tool. Worth its own ticket if a host is ever found whose timeout is under thirty seconds.
- **The transfer-mode account is read at plan time and is not bound by the confirmation token**, so a task edited to `MOVE` between plan and confirm would delete data the plan did not warn about. This is the same property `snapshots_create` has by design: the token binds tool + args + systems, and an `execute` that re-read and branched on state read after approval is exactly what the "pure function of (args, system)" contract forbids. Narrowing it would need a change to the confirmation model, not to this tool.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (1,215 passing) and `yarn test:coverage` all run locally and pass; `tasks.ts` is at 100% statements and branches, and the global figures (99.73 / 99.44) are above the floors in `vitest.config.ts`, which are unchanged. `yarn build` runs clean.

The spec's fake system moved with round 9's change: it stubs `callAndGetJobId` and `trackJob` rather than `api.job`, so the two stages can be moved independently — which is what lets the new case be tested at all. A follow-up read that fails before reporting anything, a job the client named and then said nothing about, and an id the event carried in a form this tool cannot read are each their own test.

Tests take their own spec, `src/tools/cloudsync-run.spec.ts`, under the #87 split trigger checked rather than felt: `tasks.spec.ts` is 1,352 lines and this block is several hundred more, so the merged file would cross 1,500 exactly as it did at #121. The job fake is local to that spec rather than added to `src/testing/fake-systems.ts` — a job is a stream rather than a response, and half of what is tested here is what happens when that stream does *not* complete; one caller is not enough to know the shape a shared fixture should take.

One spec is worth naming because it asserts something the pinned client cannot currently produce: a job completing on `SUPERSEDED`. It models a **client** release widening its own terminal set — the one case where the two lists come apart — and it is commented as that rather than as a stream that arrives today.
