### PR TITLE
feat(tools): add automated_task_set_enabled, switching an init/shutdown script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1105,6 +1105,67 @@ following the job is named in the step's *description* instead, because a step's
 `params` are the exact params a call runs with and the job id does not exist
 until the approved call has been made.
 
+### A name broader than the tool is paid for in the description and the plan (#126)
+
+`automated_task_set_enabled` switches an init/shutdown script on or off, and
+that is the ONLY thing it does — while `automated_tasks_list`, the tool it takes
+its name and its ids from, has four sections and three of them are switched by
+`scheduled_task_set_enabled` instead. The name is therefore broader than the
+tool, which is ordinarily the finding rather than the design: it is
+`storage_scrub_history` promising history the data cannot hold, moved up from a
+field to a tool name.
+
+**It was taken deliberately, and what makes it survivable is worth naming
+because a later tool will face the same choice.** #121 established that a tool
+named for a category may not accept a member of another one, which left the
+excluded kind needing a name that claims no schedule; `automated_task_set_enabled`
+is that name, and the alternative — `init_shutdown_script_set_enabled` — says
+exactly what the tool does and would need renaming the day a second
+non-scheduled kind arrives. Breadth was chosen over precision, so three things
+carry the scope the name does not:
+
+- **The description states the boundary FIRST**, before anything about the
+  outcome: which of the four sections the id comes from, and which tool takes
+  the other three.
+- **The `id` argument's own description repeats it**, because that is what a
+  caller reads when it is choosing a number.
+- **The plan is what actually stops a mis-aimed id.** Task ids are per-table
+  integers, so a cron job's id 3 is also a script's id 3, and unlike #121 there
+  is no discriminator to require — one kind means nothing to discriminate. What
+  remains is that an approver reading *"the init/shutdown script with comment
+  ..."* sees something that is not the cron job they meant. **Where a tool
+  cannot detect the wrong argument, the plan has to make it recognisable**, and
+  that is a reason for the plan to name an entity in human terms over and above
+  #121's.
+
+**Ask which way a name is wrong before accepting it.** A name promising a
+category it does not cover is recoverable this way; a name promising a
+GUARANTEE the normalization does not deliver is not, because no description
+undoes a field that reads as established.
+
+### Where a listing's own vocabulary runs out, point rather than re-gloss (#126)
+
+The plan for this tool cannot end with `describeTask`'s schedule phrase — an
+init/shutdown script carries no cron record, and rendering one would be the
+tool's own fiction about when the work happens (#97). What replaces it is the
+`when` the row actually carries, passed through as the system spelled it, plus a
+pointer at `automated_tasks_list` as the place each lifecycle point is
+described.
+
+**The three points are deliberately NOT glossed a second time here.**
+`automated_tasks_list`'s description already says what `PREINIT`, `POSTINIT` and
+`SHUTDOWN` name; a second account written into a plan is a second opinion that
+can drift from the first, which is the same argument `TRANSFER_ENDS` makes for
+restating `cloudsync_tasks_list`'s reading of `direction` rather than deriving
+its own, and the same argument `schedulePhrase` makes for pointing at the tool
+that reports the cron fields it will not put into English.
+
+**A lifecycle point that could not be read is stated, and NOT defaulted to
+startup.** An approver told nothing reads the silence as "it runs at boot" — and
+a `SHUTDOWN` script is the one where switching it off at the wrong moment costs
+most, which is `transferModeSentence`'s refusal to default to the harmless mode
+in a second family.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ confirmation UX, audit sinks) enters through injected interfaces.
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
   for good, which its description and its plan state and this field does not.
-  The last two switch a task on or off between them and neither covers the
-  other's kinds: `scheduled_task_set_enabled` takes the six that run on a
-  schedule, and `automated_task_set_enabled` the init/shutdown scripts, which
-  run at a point in the system's lifecycle instead.
+  `scheduled_task_set_enabled` and `automated_task_set_enabled` switch a task
+  on or off between them and neither covers the other's kinds: the first takes
+  the six that run on a schedule, and the second the init/shutdown scripts,
+  which run at a point in the system's lifecycle instead.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `system_health_report`, `fleet_compliance_report`, `fleet_health_rollup`.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
-  `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run` — the last of
-  these the only one that starts a background job, which it watches for a
-  bounded time and then reports on rather than waiting out. `destructiveness`
+  `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run`,
+  `automated_task_set_enabled` — `cloudsync_run` the only one that starts a
+  background job, which it watches for a bounded time and then reports on
+  rather than waiting out. `destructiveness`
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
   for good, which its description and its plan state and this field does not.
+  The last two switch a task on or off between them and neither covers the
+  other's kinds: `scheduled_task_set_enabled` takes the six that run on a
+  schedule, and `automated_task_set_enabled` the init/shutdown scripts, which
+  run at a point in the system's lifecycle instead.
 - **System registry** — 1..N named systems, each owning its own
   `@truenas/api-client` instance and credentials; `systems` selector
   (name / list / `all`, defaulting when one system is registered).

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,4 +131,5 @@ export {
   alertsRestore,
   scheduledTaskSetEnabled,
   cloudsyncRun,
+  automatedTaskSetEnabled,
 } from '@/tools/index';

--- a/src/tools/automated-task-set-enabled.spec.ts
+++ b/src/tools/automated-task-set-enabled.spec.ts
@@ -1,0 +1,439 @@
+import { describe, expect, it } from 'vitest';
+import { Role } from '@/interfaces';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { automatedTaskSetEnabled } from '@/tools/index';
+
+/**
+ * `automated_task_set_enabled`'s tests live here rather than in
+ * `tasks.spec.ts`, which is the #87 split exception and is CHECKED rather than
+ * felt: `tasks.spec.ts` is 1,352 lines and this block is several hundred more,
+ * so the merged file crosses the 1,500-line trigger. The split is by tool, as
+ * `scheduled-task-set-enabled.spec.ts` and `cloudsync-run.spec.ts` already are;
+ * the four listing tools stay where they are.
+ */
+
+/** One init/shutdown script as `initshutdownscript.query` answers with it. */
+const script = {
+  id: 3,
+  comment: 'mount the archive',
+  type: 'COMMAND',
+  when: 'POSTINIT',
+  // Both of these are in the row and neither may reach the plan: the command is
+  // whatever the operator typed, and the script path is not read.
+  command: 'mount -t nfs backup:/vault /mnt/vault -o pass=hunter2',
+  script: null,
+  enabled: true,
+  timeout: 10,
+};
+
+/** A `SHUTDOWN` script defined by a path rather than an inlined command. */
+const shutdownScript = {
+  id: 3,
+  comment: 'flush the cache',
+  type: 'SCRIPT',
+  when: 'SHUTDOWN',
+  command: null,
+  script: '/mnt/tank/scripts/flush-cache.sh',
+  enabled: true,
+  timeout: 30,
+};
+
+/**
+ * A system listing those rows and answering the update with the row as it would
+ * be after the change — which is what `initshutdownscript.update` answers with.
+ */
+const system = (rows: unknown = [script], updated?: unknown) =>
+  fakeSystem({
+    'initshutdownscript.query': rows,
+    'initshutdownscript.update': updated === undefined ? { ...script, enabled: false } : updated,
+  });
+
+/** The args for the ordinary case: switch script 3 off. */
+const off = { id: 3, enabled: false };
+
+describe('automated_task_set_enabled', () => {
+  it('is a reversible mutating tool needing the full role', () => {
+    expect(automatedTaskSetEnabled).toMatchObject({
+      name: 'automated_task_set_enabled',
+      mutating: true,
+      destructiveness: 'reversible',
+      requiredRole: Role.Full,
+    });
+  });
+
+  it('takes an id and a state, and no kind', () => {
+    const schema = automatedTaskSetEnabled.inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(['id', 'enabled']);
+    // There is exactly one kind here, so there is nothing to discriminate — and
+    // that is precisely why the description has to say which section the id
+    // comes from, tested below.
+    expect(Object.keys(schema.properties)).toEqual(['id', 'enabled']);
+  });
+
+  it('says which section its ids come from and which tool takes the other three', () => {
+    // The name is broader than the tool — `automated_tasks_list` has four
+    // sections and this acts on one — so the description is what carries the
+    // scope. A caller reading only the name would reach it with a cron job's
+    // id, and this tool cannot tell.
+    const description = automatedTaskSetEnabled.description;
+    expect(description).toContain('THIS TOOL ACTS ON INIT/SHUTDOWN SCRIPTS AND ON NOTHING ELSE');
+    expect(description).toContain('`init_shutdown_scripts` SECTION ONLY');
+    expect(description).toContain('`scheduled_task_set_enabled`');
+    expect(description).toContain('CANNOT TELL THAT IT WAS HANDED AN id FROM THE WRONG SECTION');
+    expect(description).toContain('ONLY THE `enabled` FIELD IS SENT');
+  });
+
+  it('says an init/shutdown script is not scheduled and states no schedule', () => {
+    const description = automatedTaskSetEnabled.description;
+    expect(description).toContain('an init/shutdown script IS NOT SCHEDULED');
+    expect(description).toContain('NO SCHEDULE IS STATED ANYWHERE');
+  });
+
+  it('does not let `changed: false` claim the script was already in the requested state', () => {
+    // `changed` compares the two READINGS, so false covers the unapplied call
+    // as well as the no-op — the case at "does not report success when the
+    // response disagrees with the request" below.
+    const description = automatedTaskSetEnabled.description;
+    expect(description).toContain('WHICH IS TWO OUTCOMES AND NOT ONE');
+    expect(description).toContain('the call did not apply');
+    expect(description).toContain('`changed` must not be read without it');
+  });
+
+  it('normalizes args: keeps the two and drops unknown keys', () => {
+    expect(
+      automatedTaskSetEnabled.normalizeArgs?.({
+        id: 3,
+        enabled: true,
+        kind: 'cron',
+        extra: 1,
+        systems: 'all',
+      }),
+    ).toEqual({ id: 3, enabled: true });
+  });
+
+  describe('argument validation', () => {
+    const ctx = system().ctx;
+
+    it('requires a whole-number id', async () => {
+      for (const bad of [undefined, null, '3', 3.5, Number.NaN]) {
+        expect(() => automatedTaskSetEnabled.normalizeArgs?.({ id: bad, enabled: false })).toThrow(
+          /"id" is required and must be a whole number/,
+        );
+        await expect(
+          automatedTaskSetEnabled.plan(ctx, { id: bad, enabled: false }),
+        ).rejects.toThrow(/"id" is required/);
+      }
+    });
+
+    it('requires a boolean enabled and coerces nothing into one', async () => {
+      // Coercing "false" to true would switch ON a script the caller asked to
+      // switch off.
+      for (const bad of [undefined, null, 'false', 0, 1]) {
+        expect(() => automatedTaskSetEnabled.normalizeArgs?.({ id: 3, enabled: bad })).toThrow(
+          /"enabled" is required and must be a boolean/,
+        );
+        await expect(automatedTaskSetEnabled.plan(ctx, { id: 3, enabled: bad })).rejects.toThrow(
+          /"enabled" is required/,
+        );
+      }
+    });
+
+    it('executes nothing when an argument is unreadable', async () => {
+      // The spy and the context have to come from the SAME fake system, or the
+      // assertion is about a system `execute` never saw and cannot fail.
+      const { ctx: own, query, call } = system();
+      await expect(automatedTaskSetEnabled.execute(own, { id: 3, enabled: 'yes' })).rejects.toThrow(
+        /"enabled" is required/,
+      );
+      expect(query).not.toHaveBeenCalled();
+      expect(call).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the plan it returns', () => {
+    it('plans the read it makes as well as the mutation it makes', async () => {
+      const steps = await automatedTaskSetEnabled.plan(system().ctx, off);
+      // Two steps because `execute` makes two calls. A plan naming only the
+      // mutation would not be a true account of what runs.
+      expect(steps.map((step) => step.method)).toEqual([
+        'initshutdownscript.query',
+        'initshutdownscript.update',
+      ]);
+      // Two positional params, because `api.query(method, filters)` dispatches
+      // `[filters ?? [], options ?? {}]` — the plan names the call that runs.
+      expect(steps[0]).toMatchObject({ params: [[['id', '=', 3]], {}] });
+      expect(steps[0].description).toMatch(/Changes nothing/);
+    });
+
+    it('sends only the enabled field, and sends the state that was asked for', async () => {
+      const [, mutation] = await automatedTaskSetEnabled.plan(system().ctx, off);
+      expect(mutation.params).toEqual([3, { enabled: false }]);
+      const disabled = { ...script, enabled: false };
+      const [, on] = await automatedTaskSetEnabled.plan(
+        system([disabled], { ...disabled, enabled: true }).ctx,
+        { id: 3, enabled: true },
+      );
+      expect(on.params).toEqual([3, { enabled: true }]);
+      expect(mutation.description).toContain('Only the enabled flag is sent');
+    });
+
+    it('names the script by comment, when and type', async () => {
+      const [, mutation] = await automatedTaskSetEnabled.plan(system().ctx, off);
+      expect(mutation.description).toContain('Disable the init/shutdown script');
+      expect(mutation.description).toContain('comment "mount the archive"');
+      expect(mutation.description).toContain('when "POSTINIT"');
+      expect(mutation.description).toContain('type "COMMAND"');
+      expect(mutation.description).toContain('(id 3)');
+    });
+
+    it('states the lifecycle point and that there is no schedule', async () => {
+      const [, mutation] = await automatedTaskSetEnabled.plan(system().ctx, off);
+      expect(mutation.description).toContain('It runs at POSTINIT');
+      expect(mutation.description).toContain('has no schedule at all');
+      // The three points are not glossed a second time here: the listing tool
+      // already describes them, and a second account can drift from the first.
+      expect(mutation.description).toContain(
+        '`automated_tasks_list` is where each lifecycle point is described',
+      );
+    });
+
+    it('renders no schedule phrase, however the row is shaped', async () => {
+      // `describeTask` ends every scheduled task with one; an init/shutdown
+      // script has no cron record and a phrase in its place would be fiction.
+      for (const rows of [[script], [shutdownScript], [{ ...script, when: null }]]) {
+        const [, mutation] = await automatedTaskSetEnabled.plan(system(rows).ctx, off);
+        // Neither a rendered schedule nor `schedulePhrase`'s stated-absence
+        // fallback: there is no cron record here for either to be about. No
+        // time of day appears at all, and the one mention of the word is the
+        // statement that there is no schedule.
+        expect(mutation.description).not.toMatch(/\d{1,2}:\d{2}/);
+        expect(mutation.description).not.toContain('not rendered in words here');
+        expect(mutation.description.match(/schedule/g)).toEqual(['schedule']);
+      }
+    });
+
+    it('says the lifecycle point was not read rather than assuming startup', async () => {
+      // Defaulting to a boot-time point would read as safe for a script that in
+      // fact runs on the way down, which is where switching it off at the wrong
+      // moment matters most.
+      const { ctx } = system([{ ...script, when: 7 }]);
+      const [, mutation] = await automatedTaskSetEnabled.plan(ctx, off);
+      expect(mutation.description).toContain(
+        'The system reported no lifecycle point for it this tool could read',
+      );
+      expect(mutation.description).not.toContain('It runs at');
+      expect(mutation.description).toContain('when (the system reported none)');
+    });
+
+    it('states a field the system reported none of rather than dropping it', async () => {
+      const { ctx } = system([{ ...script, comment: '', type: null }]);
+      const [, mutation] = await automatedTaskSetEnabled.plan(ctx, off);
+      expect(mutation.description).toContain('comment (the system reported none)');
+      expect(mutation.description).toContain('type (the system reported none)');
+    });
+
+    it("does not repeat the script's command, which can hold an inlined secret", async () => {
+      const [, mutation] = await automatedTaskSetEnabled.plan(system().ctx, off);
+      expect(mutation.description).not.toContain('hunter2');
+      expect(mutation.description).not.toContain('mount -t nfs');
+      expect(mutation.description).toContain(
+        "neither the script's command nor its path is repeated here",
+      );
+    });
+
+    it('does not repeat the path of a SCRIPT-type entry either', async () => {
+      const [, mutation] = await automatedTaskSetEnabled.plan(system([shutdownScript]).ctx, off);
+      expect(mutation.description).not.toContain('flush-cache.sh');
+      expect(mutation.description).toContain('type "SCRIPT"');
+      expect(mutation.description).toContain('It runs at SHUTDOWN');
+    });
+
+    it('says which way the switch will move', async () => {
+      const [, disabling] = await automatedTaskSetEnabled.plan(system().ctx, off);
+      expect(disabling.description).toContain('It is enabled, so this will disable it.');
+      const offRow = { ...script, enabled: false };
+      const [, enabling] = await automatedTaskSetEnabled.plan(
+        system([offRow], { ...offRow, enabled: true }).ctx,
+        { id: 3, enabled: true },
+      );
+      expect(enabling.description).toContain('It is disabled, so this will enable it.');
+    });
+
+    it('says so when the script is already in the requested state', async () => {
+      const already = { ...script, enabled: false };
+      const [, mutation] = await automatedTaskSetEnabled.plan(
+        system([already], already).ctx,
+        off,
+      );
+      expect(mutation.description).toContain(
+        'It is already disabled, so this changes nothing and is not an error.',
+      );
+    });
+
+    it('refuses to claim a direction when the prior state is unreadable', async () => {
+      const { ctx } = system([{ ...script, enabled: 'yes' }]);
+      const [, mutation] = await automatedTaskSetEnabled.plan(ctx, off);
+      expect(mutation.description).toContain(
+        'Whether it is enabled could not be read, so this may change nothing.',
+      );
+    });
+
+    it('fails when no init/shutdown script has that id, naming where ids come from', async () => {
+      const { ctx } = system([{ ...script, id: 4 }]);
+      await expect(automatedTaskSetEnabled.plan(ctx, off)).rejects.toThrow(
+        /No init\/shutdown script with id 3 on this system — the ids this tool takes come from the `init_shutdown_scripts` section of `automated_tasks_list`/,
+      );
+    });
+  });
+
+  describe('the id it acts on', () => {
+    it('re-checks the id on the response rather than trusting the filter', async () => {
+      // An unrecognised query parameter is dropped rather than refused, so a
+      // filter that did not apply comes back as the whole table — and its first
+      // row is a different script.
+      const whole = [{ ...script, id: 1, comment: 'first' }, { ...script, id: 2 }, script];
+      const [, mutation] = await automatedTaskSetEnabled.plan(system(whole).ctx, off);
+      expect(mutation.params).toEqual([3, { enabled: false }]);
+      expect(mutation.description).toContain('comment "mount the archive"');
+      expect(mutation.description).not.toContain('comment "first"');
+    });
+
+    it('treats an answer that is not a list as no script with that id', async () => {
+      await expect(automatedTaskSetEnabled.plan(system(7).ctx, off)).rejects.toThrow(
+        /No init\/shutdown script with id 3/,
+      );
+    });
+
+    it('skips a listed row that is not a record', async () => {
+      const { ctx } = system([null, 'a row', script]);
+      const [, mutation] = await automatedTaskSetEnabled.plan(ctx, off);
+      expect(mutation.description).toContain('comment "mount the archive"');
+    });
+
+    it('skips a listed row whose own id is not a number', async () => {
+      const { ctx } = system([{ ...script, id: '3' }]);
+      await expect(automatedTaskSetEnabled.plan(ctx, off)).rejects.toThrow(
+        /No init\/shutdown script with id 3/,
+      );
+    });
+  });
+
+  describe('the outcome it reports', () => {
+    it('executes the read and then the update the plan named', async () => {
+      const { ctx, query, call } = system();
+      await automatedTaskSetEnabled.execute(ctx, off);
+      expect(query).toHaveBeenCalledWith('initshutdownscript.query', [['id', '=', 3]]);
+      expect(call).toHaveBeenCalledWith('initshutdownscript.update', [3, { enabled: false }]);
+    });
+
+    it('reports a script it actually changed', async () => {
+      expect(await automatedTaskSetEnabled.execute(system().ctx, off)).toEqual({
+        id: 3,
+        requested_enabled: false,
+        lookup: 'FOUND',
+        lookup_error: null,
+        previously_enabled: true,
+        resulting_enabled: false,
+        changed: true,
+        confirmed: true,
+      });
+    });
+
+    it('reports a script already in the requested state as changing nothing', async () => {
+      const already = { ...script, enabled: false };
+      const result = await automatedTaskSetEnabled.execute(system([already], already).ctx, off);
+      expect(result).toMatchObject({
+        previously_enabled: false,
+        resulting_enabled: false,
+        changed: false,
+        confirmed: true,
+      });
+    });
+
+    it('reports FOUND with a null prior state when the script stated no enabled', async () => {
+      // The fourth cause of a null `previously_enabled`, which `lookup` alone
+      // does not separate from the other three.
+      const { ctx } = system([{ ...script, enabled: 'yes' }]);
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        lookup: 'FOUND',
+        previously_enabled: null,
+        resulting_enabled: false,
+        changed: null,
+      });
+    });
+
+    it('reports NOT_FOUND and still makes the update the plan named', async () => {
+      const { ctx, call } = system([]);
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        lookup: 'NOT_FOUND',
+        lookup_error: null,
+        previously_enabled: null,
+        resulting_enabled: false,
+        changed: null,
+        confirmed: true,
+      });
+      // Unconditional: skipping it would be `execute` branching on state read
+      // after the plan was approved.
+      expect(call).toHaveBeenCalledWith('initshutdownscript.update', [3, { enabled: false }]);
+    });
+
+    it('reports UNREADABLE with the reason, and still makes the update', async () => {
+      const { ctx, call } = failingSystem(
+        { 'initshutdownscript.update': { ...script, enabled: false } },
+        { 'initshutdownscript.query': new Error('websocket closed') },
+      );
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        lookup: 'UNREADABLE',
+        lookup_error: 'websocket closed',
+        previously_enabled: null,
+        changed: null,
+      });
+      expect(call).toHaveBeenCalledWith('initshutdownscript.update', [3, { enabled: false }]);
+    });
+
+    it('does not report success when the response disagrees with the request', async () => {
+      // The method answers with the updated script, so a response still
+      // reporting the old state is the system not having applied the change.
+      const { ctx } = system([script], { ...script, enabled: true });
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        requested_enabled: false,
+        previously_enabled: true,
+        resulting_enabled: true,
+        changed: false,
+        confirmed: false,
+      });
+    });
+
+    it('establishes nothing about the result when the response states no enabled', async () => {
+      const { ctx } = system([script], { ...script, enabled: 'yes' });
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        previously_enabled: true,
+        resulting_enabled: null,
+        changed: null,
+        confirmed: null,
+      });
+    });
+
+    it('establishes nothing about the result when the response is not a record', async () => {
+      const { ctx } = system([script], true);
+      expect(await automatedTaskSetEnabled.execute(ctx, off)).toMatchObject({
+        resulting_enabled: null,
+        changed: null,
+        confirmed: null,
+      });
+    });
+
+    it('fails the call when the update itself rejects', async () => {
+      const { ctx } = failingSystem(
+        { 'initshutdownscript.query': [script] },
+        { 'initshutdownscript.update': { reason: 'script is locked' } },
+      );
+      await expect(automatedTaskSetEnabled.execute(ctx, off)).rejects.toEqual({
+        reason: 'script is locked',
+      });
+    });
+  });
+});

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-four sketch tools', () => {
+  it('registers the fifty-five sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -59,6 +59,7 @@ describe('createDefaultCatalog', () => {
       'alerts_restore',
       'scheduled_task_set_enabled',
       'cloudsync_run',
+      'automated_task_set_enabled',
     ]);
   });
 
@@ -77,6 +78,12 @@ describe('createDefaultCatalog', () => {
   it('does not advertise cloudsync_run to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
       'cloudsync_run',
+    );
+  });
+
+  it('does not advertise automated_task_set_enabled to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'automated_task_set_enabled',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,7 @@ import {
   updateStatus,
 } from '@/tools/system';
 import {
+  automatedTaskSetEnabled,
   automatedTasksList,
   cloudsyncRun,
   cloudsyncTasksList,
@@ -42,7 +43,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-nine read-only tools plus five mutating tools. */
+/** The sketch's catalog: forty-nine read-only tools plus six mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -99,6 +100,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(alertsRestore);
   catalog.register(scheduledTaskSetEnabled);
   catalog.register(cloudsyncRun);
+  catalog.register(automatedTaskSetEnabled);
   return catalog;
 }
 
@@ -112,6 +114,7 @@ export {
   appsUpdateSummary,
   auditConfig,
   auditLogQuery,
+  automatedTaskSetEnabled,
   automatedTasksList,
   bootPoolStatus,
   certificatesList,

--- a/src/tools/scheduled-task-set-enabled.spec.ts
+++ b/src/tools/scheduled-task-set-enabled.spec.ts
@@ -162,6 +162,11 @@ describe('scheduled_task_set_enabled', () => {
     }
     expect(description).toContain('INIT/SHUTDOWN SCRIPTS ARE NOT COVERED');
     expect(description).toContain('ONLY THE `enabled` FIELD IS SENT');
+    // The gap this tool names has to name the tool that fills it. This
+    // description said no tool here switched one on or off, which stopped being
+    // true the moment `automated_task_set_enabled` landed — a caller routing on
+    // it would refuse a request the catalog can serve.
+    expect(description).toContain('`automated_task_set_enabled`');
   });
 
   it('does not let `changed: false` claim the task was already in the requested state', () => {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -59,6 +59,12 @@ import {
  * on: it starts one of the tasks `cloudsync_tasks_list` reports, and its plan
  * names that task in the terms that listing already uses — description, path,
  * direction, the remote end, and the credential by name and id.
+ *
+ * `automated_task_set_enabled` is the third, and it exists because the tool
+ * above it deliberately refuses a kind: an init/shutdown script is not
+ * scheduled, so `scheduled_task_set_enabled`'s name cannot carry it. The two
+ * together are what makes every `enabled` in this family's listings actionable;
+ * neither name covers what the other does, and each description says so.
  */
 
 /**
@@ -2337,6 +2343,325 @@ export const cloudsyncRun: MutatingTool = {
       // so the finish time follows it and cannot contradict it. The listings
       // keep reading the set: none of them carries an `ended` to disagree with.
       finished_at: ended ? isoOrNull(jobMillis(record?.time_finished)) : null,
+    };
+  },
+};
+
+/**
+ * `automated_task_set_enabled`: switching one init/shutdown script on or off,
+ * and the other half of {@link scheduledTaskSetEnabled}.
+ *
+ * THE NAME IS THE DECISION HERE, and it is the one thing about this tool worth
+ * arguing over. `scheduled_task_set_enabled` covers the six kinds that run on a
+ * schedule and refuses this one because its own name promises a schedule an
+ * init/shutdown script does not have (#121); the kind it refuses then needs a
+ * name that claims no schedule, and `automated_task_set_enabled` is the one
+ * that matches `automated_tasks_list`, which is the tool these ids come from.
+ *
+ * WHAT THAT NAME COSTS, STATED RATHER THAN GLOSSED. `automated_tasks_list` has
+ * FOUR sections and this tool acts on ONE of them: a cron job, an rsync task
+ * and a cloud backup task are all listed there, are all automated tasks by any
+ * ordinary reading, and are all switched by the OTHER tool. So the name is
+ * broader than the tool, which is the house's most common review finding —
+ * `storage_scrub_history` promising history the data cannot hold — pointed at a
+ * tool name instead of a field. Three things carry that weight instead of the
+ * name, and all three are load-bearing:
+ *
+ * - The description says outright, first, which of the four sections this
+ *   takes ids from and which tool takes the other three.
+ * - `id` is documented as coming from `init_shutdown_scripts` specifically.
+ *   Task ids are per-table integers, so a cron job's id 3 is also an
+ *   init/shutdown script's id 3 and this tool cannot tell that it was handed
+ *   the wrong one — there is no discriminator to require, because there is only
+ *   one kind here.
+ * - The plan therefore has to be recognisable, which is what actually stops a
+ *   mis-aimed id: an approver reading "the init/shutdown script with comment
+ *   ..." sees a thing that is not the cron job they meant, and refuses.
+ *
+ * The alternative name — `init_shutdown_script_set_enabled` — says exactly what
+ * the tool does and would need renaming the day a second non-scheduled kind
+ * arrives. The ticket chose breadth; this comment is here so the next reader
+ * knows it was a choice and what pays for it.
+ *
+ * ONLY `enabled` IS SENT, for {@link scheduledTaskSetEnabled}'s reason:
+ * `initshutdownscript.update` takes a partial `InitShutdownScriptUpdate`, so
+ * round-tripping more of the row than was asked for can revert a concurrent
+ * edit — and that type declares `command`, `script`, `when` and `timeout`,
+ * every one of which this tool has no business writing.
+ *
+ * NO SCHEDULE IS RENDERED AND NONE MAY BE INVENTED. {@link describeTask} ends
+ * every task with a schedule phrase; this one cannot, because there is no cron
+ * record to read and a phrase in its place would be this tool's own fiction
+ * about when the work happens (#97). What replaces it is the lifecycle point
+ * the script actually carries, and a pointer at the tool that says what each
+ * point means.
+ */
+
+/**
+ * How the plan states when in the system's lifecycle a script runs, or that the
+ * system reported nothing this tool could read.
+ *
+ * The three values are NOT glossed here. `automated_tasks_list`'s description
+ * already says what `PREINIT`, `POSTINIT` and `SHUTDOWN` name, and a second
+ * account of them written into a plan is a second opinion that can drift from
+ * the first — the same reason {@link TRANSFER_ENDS} restates
+ * `cloudsync_tasks_list`'s reading of `direction` rather than deriving its own.
+ * The value is passed through as the system spelled it and the approver is
+ * pointed at the tool that describes it, which is {@link schedulePhrase}'s move
+ * for a schedule it will not put into English.
+ *
+ * A `when` this tool could not read says exactly that. It is not defaulted to
+ * startup: an approver told nothing would read the silence as the script
+ * running at boot, and a script that runs on the way DOWN is the one where
+ * switching it off at the wrong moment matters most.
+ */
+function lifecycleSentence(row: Record<string, unknown>): string {
+  const when = textOrNull(row['when']);
+  const point =
+    when === null
+      ? 'The system reported no lifecycle point for it this tool could read'
+      : `It runs at ${when}`;
+  return (
+    `${point} — an init/shutdown script runs at a point in the system's ` +
+    'lifecycle rather than at a time of day, has no schedule at all, and ' +
+    '`automated_tasks_list` is where each lifecycle point is described.'
+  );
+}
+
+/**
+ * The script in the terms `automated_tasks_list` reports it, for the human
+ * approving the plan.
+ *
+ * NEITHER `command` NOR `script` IS AMONG THESE, which is #121's call for a
+ * cron job's `command` reaching both fields of the one entry that has them: a
+ * `command` is whatever an operator typed and can hold a password someone
+ * inlined, a `script` is a path this repository never reads the contents of,
+ * and a plan is shown to a person and then recorded. `comment`, `when` and
+ * `type` identify the entry without repeating either. `type` is carried because
+ * it is what says WHICH of the two is in use, which is the part of them an
+ * approver needs and the part that holds no secret.
+ *
+ * A label the system named no value for is stated as {@link NONE_REPORTED}
+ * rather than dropped, as {@link describeTask}'s are: a plan silently omitting
+ * the comment reads as a script without one, and the approver cannot tell
+ * which.
+ */
+function describeInitShutdownScript(row: Record<string, unknown>, id: number): string {
+  const labelled: [string, string | null][] = [
+    // The middleware's own name for the free-text label on these; there is no
+    // `description` on the row, exactly as `mapInitShutdownScript` records.
+    ['comment', textOrNull(row['comment'])],
+    ['when', textOrNull(row['when'])],
+    ['type', textOrNull(row['type'])],
+  ];
+  const named = labelled.map(
+    ([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`,
+  );
+  return `the init/shutdown script with ${named.join(', ')} (id ${id})`;
+}
+
+/**
+ * The caller's two arguments, or the error naming what is wrong with them.
+ *
+ * Strict on both, as {@link parseSwitch} is and word for word for the same
+ * reason: coercing `"false"` to true would switch ON a script the caller asked
+ * to switch off, which is not a narrower answer to the question asked but the
+ * opposite one. There is no `kind` to resolve — this tool has one — so what
+ * {@link parseSwitch} does in three checks this does in two.
+ */
+function parseScriptSwitch(args: Record<string, unknown>): { id: number; enabled: boolean } {
+  const id = args['id'];
+  if (typeof id !== 'number' || !Number.isInteger(id)) {
+    throw new Error('"id" is required and must be a whole number');
+  }
+  const enabled = args['enabled'];
+  if (typeof enabled !== 'boolean') {
+    throw new Error('"enabled" is required and must be a boolean');
+  }
+  return { id, enabled };
+}
+
+/** Where the ids this tool takes come from, in the one wording used throughout. */
+const SCRIPT_IDS_FROM = 'the `init_shutdown_scripts` section of `automated_tasks_list`';
+
+export const automatedTaskSetEnabled: MutatingTool = {
+  name: 'automated_task_set_enabled',
+  description:
+    'Turns one init/shutdown script on this TrueNAS system on or off, and ' +
+    'changes nothing else about it. Two-phase: called without a ' +
+    'confirmation_token it returns a plan for user approval; called with one it ' +
+    'switches the script. THIS TOOL ACTS ON INIT/SHUTDOWN SCRIPTS AND ON ' +
+    'NOTHING ELSE. `automated_tasks_list` has four sections and `id` HERE COMES ' +
+    'FROM ITS `init_shutdown_scripts` SECTION ONLY: a cron job, an rsync task ' +
+    'or a cloud backup task is switched by `scheduled_task_set_enabled`, with ' +
+    'its `kind` set to `cron`, `rsync` or `cloud_backup`, and that tool also ' +
+    'covers periodic snapshot, cloud sync and replication tasks. THIS TOOL ' +
+    'CANNOT TELL THAT IT WAS HANDED AN id FROM THE WRONG SECTION: task ids are ' +
+    'per-table integers, so id 3 exists under every kind and names a different ' +
+    'task under each, and there is no `kind` argument here because this tool ' +
+    'covers exactly one. CHECK THE PLAN NAMES THE ENTRY YOU MEANT before ' +
+    'approving it. It exists separately because an init/shutdown script IS NOT ' +
+    'SCHEDULED — it runs at a point in the system\'s lifecycle, which `when` ' +
+    'names — so a tool named for scheduled tasks cannot carry it. `enabled` is ' +
+    'the state to move the script to, true or false, and is required: there is ' +
+    'no toggle, because a toggle acts on a state read after the plan was ' +
+    'approved. ONLY THE `enabled` FIELD IS SENT. The script\'s type, its ' +
+    'command or path, its lifecycle point and its timeout are left exactly as ' +
+    'they are, and this tool cannot change them, cannot create or delete a ' +
+    'script, and cannot run one now. THE PLAN NAMES THE SCRIPT IN HUMAN TERMS ' +
+    '— its `comment`, its `when` and its `type` — beside the id, so that what ' +
+    'is approved is recognisable. NEITHER THE `command` NOR THE `script` PATH ' +
+    'IS REPEATED IN THE PLAN: a command is whatever an operator typed and can ' +
+    'contain a secret, and a script path is not read; `automated_tasks_list` is ' +
+    'where both are reported. NO SCHEDULE IS STATED ANYWHERE, because there is ' +
+    'none — `automated_tasks_list` describes what each lifecycle point means. ' +
+    'PLANNING AGAINST AN id NO INIT/SHUTDOWN SCRIPT HAS FAILS, naming the id ' +
+    'and the section its ids come from — so an approved plan is always a plan ' +
+    'about a script that existed when it was made, and a failure here is very ' +
+    'often an id belonging to one of the other three sections rather than a ' +
+    'missing script. SWITCHING A SCRIPT TO THE STATE IT IS ALREADY IN IS NOT AN ' +
+    'ERROR, and the result says which of the two happened. `requested_enabled` ' +
+    'is what was asked for. `previously_enabled` is the script\'s state as read ' +
+    'immediately before the call. `resulting_enabled` is the state read back ' +
+    'off the response the update itself answered with, which is the updated ' +
+    'script. `changed` is true where those two disagree and false where they ' +
+    'are the same, WHICH IS TWO OUTCOMES AND NOT ONE: either the script was ' +
+    'already in the requested state, or the call did not apply and left it in ' +
+    'the other one. `confirmed` is what tells those two apart, and `changed` ' +
+    'must not be read without it. ALL THREE OF `previously_enabled`, ' +
+    '`resulting_enabled` AND `changed` ARE NULL WHERE THE STATE BEHIND THEM ' +
+    'COULD NOT BE ESTABLISHED, WHICH IS NOT "NOTHING CHANGED", and `changed` is ' +
+    'null whenever either of the other two is. `confirmed` is whether ' +
+    '`resulting_enabled` is what was requested: true is the system reporting ' +
+    'back the state that was asked for, FALSE IS THE SYSTEM REPORTING THE OTHER ' +
+    'STATE AND IS NOT A SUCCESS — the call did not reject and the script is not ' +
+    'in the requested state — and null is a response that stated no `enabled` ' +
+    'this tool could read, under which nothing here establishes what the script ' +
+    'is now set to. `lookup` says what the read before the call did: `FOUND` is ' +
+    'a read that named this script, `NOT_FOUND` a read that completed and ' +
+    'listed no init/shutdown script with that id (it was deleted between the ' +
+    'plan and the confirmation), and `UNREADABLE` a read that failed, with ' +
+    '`lookup_error` naming why. IT HAS THREE VALUES AND `previously_enabled` ' +
+    'HAS FOUR CAUSES FOR ITS NULL: the two above, and ALSO `FOUND` where the ' +
+    'script stated no `enabled` this tool could read as a boolean. So `lookup` ' +
+    'alone does not tell them apart, and `FOUND` beside a null ' +
+    '`previously_enabled` is that fourth case. THE UPDATE IS ATTEMPTED IN ALL ' +
+    'THREE CASES, because what runs must be what was approved. WHAT A DISABLED ' +
+    'SCRIPT COSTS IS NOT VISIBLE UNTIL THE SYSTEM NEXT REACHES THAT POINT IN ' +
+    'ITS LIFECYCLE: a `PREINIT` or `POSTINIT` script switched off announces ' +
+    'nothing until the next boot, and a `SHUTDOWN` one not until the system is ' +
+    'going down. `automated_tasks_list` reports it as `enabled: false` and ' +
+    'nothing raises an alert. This tool is the exact inverse of itself with ' +
+    '`enabled` flipped.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer',
+        description:
+          "The init/shutdown script's `id` as the `init_shutdown_scripts` " +
+          'section of `automated_tasks_list` reports it, on the system being ' +
+          'targeted. It is unique only within that section: the same integer ' +
+          'names a different task in the other three, and this tool cannot ' +
+          'tell the difference.',
+      },
+      enabled: {
+        type: 'boolean',
+        description:
+          'The state to move the script to: true switches it on, false ' +
+          'switches it off. Required — this is not a toggle.',
+      },
+    },
+    required: ['id', 'enabled'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  // The operation is a boolean on one row and the inverse call puts it back, so
+  // this is the plain case `reversible` was written for — the distinction
+  // `Destructiveness` draws at its own declaration, between a tool that authors
+  // a destruction and one that only triggers an operator's, does not arise
+  // here. What the script itself does when it next runs is the operator's, and
+  // this tool neither reads nor changes it.
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    const { id, enabled } = parseScriptSwitch(rawArgs);
+    return { id, enabled };
+  },
+  async plan(ctx, rawArgs): Promise<PlanStep[]> {
+    const { id, enabled } = parseScriptSwitch(rawArgs);
+    const rows = await firstValueFrom(
+      ctx.system.client.api.query('initshutdownscript.query', [['id', '=', id]]),
+    );
+    const row = rowWithId(rows, id);
+    // Naming where the ids come from matters more here than it does for the
+    // six kinds: there is no `kind` to have got wrong, so a caller that reaches
+    // this failure has most likely handed over an id from one of the other
+    // three sections of the same listing.
+    if (row === null) {
+      throw new Error(
+        `No init/shutdown script with id ${id} on this system — the ids this ` +
+          `tool takes come from ${SCRIPT_IDS_FROM}`,
+      );
+    }
+    return [
+      {
+        method: 'initshutdownscript.query',
+        params: readParams(id),
+        description:
+          `Read this system's init/shutdown script with id ${id}, to report whether it was ` +
+          'already in the state this call moves it to. Changes nothing.',
+      },
+      {
+        method: 'initshutdownscript.update',
+        params: [id, { enabled }],
+        description:
+          `${enabled ? 'Enable' : 'Disable'} ${describeInitShutdownScript(row, id)}. ` +
+          `${lifecycleSentence(row)} Only the enabled flag is sent, and neither the ` +
+          "script's command nor its path is repeated here. " +
+          `${switchSentence(booleanOrNull(row['enabled']), enabled)}`,
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const { id, enabled } = parseScriptSwitch(rawArgs);
+    const api = ctx.system.client.api;
+    // Caught rather than thrown, as {@link scheduledTaskSetEnabled}'s is: this
+    // read exists to describe the outcome, and letting it fail the call would
+    // lose an approval the user has already given for a mutation that is still
+    // safe to make.
+    let row: Record<string, unknown> | null = null;
+    let lookupError: string | null = null;
+    try {
+      row = rowWithId(
+        await firstValueFrom(api.query('initshutdownscript.query', [['id', '=', id]])),
+        id,
+      );
+    } catch (reason) {
+      lookupError = errorText(reason);
+    }
+    // Unconditional, whatever the read said. Skipping the update for a script
+    // the read no longer lists would be `execute` branching on state read at
+    // execution time, which is what the confirmation token cannot bind.
+    const updated = await firstValueFrom(
+      api.call('initshutdownscript.update', [id, { enabled }]),
+    );
+    const previous = row === null ? null : booleanOrNull(row['enabled']);
+    // The method answers with the updated script, so what it says about
+    // `enabled` is the state that actually resulted — read back through the
+    // same guard rather than echoing what was asked for.
+    const resulting = booleanOrNull(recordOrNull(updated)?.['enabled']);
+    return {
+      id,
+      requested_enabled: enabled,
+      lookup: lookupError !== null ? 'UNREADABLE' : row === null ? 'NOT_FOUND' : 'FOUND',
+      lookup_error: lookupError,
+      previously_enabled: previous,
+      resulting_enabled: resulting,
+      // Both readings or nothing, for the reason its sibling gives: a `changed`
+      // derived from the request rather than from the response would report a
+      // call the system did not apply as having changed something.
+      changed: previous === null || resulting === null ? null : previous !== resulting,
+      confirmed: resulting === null ? null : resulting === enabled,
     };
   },
 };

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1359,8 +1359,11 @@ export const tasksRecentRuns: ReadOnlyTool = {
  * scheduled: it runs at a point in the system's lifecycle, carries no cron
  * fields and reports no `schedule` at all, which is why `automated_tasks_list`
  * is not called `scheduled_tasks_list`. Accepting one under a tool named
- * `scheduled_task_set_enabled` would put that promise back one level down. It
- * needs a tool whose name does not claim a schedule, which is its own ticket.
+ * `scheduled_task_set_enabled` would put that promise back one level down. The
+ * tool whose name does not claim a schedule is
+ * {@link automatedTaskSetEnabled}, below, and both descriptions name the other
+ * — a caller routing on this one alone would otherwise refuse a request the
+ * catalog can serve.
  *
  * ONLY `enabled` IS SENT. These are partial updates, so a tool that round-trips
  * more of the row than it was asked to change can silently revert a concurrent
@@ -1616,16 +1619,40 @@ interface TaskSwitch {
 }
 
 /**
- * The caller's arguments, or the error naming what is wrong with them.
+ * The two arguments every switching tool here takes, or the error naming what
+ * is wrong with them.
  *
- * Strict on all three, as `snapshots_create` is about `recursive` and for a
- * sharper version of the same reason: coercing `"false"` to true would switch
- * ON a backup task the caller asked to switch off, and a kind read loosely
- * would act on a different table's id `3`. There is nothing here a wrong
+ * Strict on both, as `snapshots_create` is about `recursive` and for a sharper
+ * version of the same reason: coercing `"false"` to true would switch ON a
+ * backup task the caller asked to switch off. There is nothing here a wrong
  * reading answers a narrower question — it answers a different one.
  *
- * `id` must be a whole number: the middleware holds these under integer
- * primary keys, and `3.5` is not one of them.
+ * `id` must be a whole number: the middleware holds these under integer primary
+ * keys, and `3.5` is not one of them.
+ *
+ * Shared by {@link parseSwitch} and {@link automatedTaskSetEnabled} rather than
+ * written twice. Two copies of a validation are two wordings of one refusal the
+ * moment either is edited, which is the drift `common.ts` was cut to stop; it
+ * is not in `common.ts` because the argument names are this family's own.
+ */
+function parseIdAndEnabled(args: Record<string, unknown>): { id: number; enabled: boolean } {
+  const id = args['id'];
+  if (typeof id !== 'number' || !Number.isInteger(id)) {
+    throw new Error('"id" is required and must be a whole number');
+  }
+  const enabled = args['enabled'];
+  if (typeof enabled !== 'boolean') {
+    throw new Error('"enabled" is required and must be a boolean');
+  }
+  return { id, enabled };
+}
+
+/**
+ * The caller's arguments, or the error naming what is wrong with them.
+ *
+ * The kind is checked first and separately, because a kind read loosely would
+ * act on a different table's id `3` — and it is checked before the other two so
+ * that the message a caller gets names the argument that is most likely wrong.
  */
 function parseSwitch(args: Record<string, unknown>): TaskSwitch {
   const kind = args['kind'];
@@ -1635,15 +1662,7 @@ function parseSwitch(args: Record<string, unknown>): TaskSwitch {
       `"kind" is required and must be one of ${TASK_KINDS.map((one) => one.kind).join(', ')}`,
     );
   }
-  const id = args['id'];
-  if (typeof id !== 'number' || !Number.isInteger(id)) {
-    throw new Error('"id" is required and must be a whole number');
-  }
-  const enabled = args['enabled'];
-  if (typeof enabled !== 'boolean') {
-    throw new Error('"enabled" is required and must be a boolean');
-  }
-  return { spec, id, enabled };
+  return { spec, ...parseIdAndEnabled(args) };
 }
 
 /**
@@ -1698,6 +1717,75 @@ function readParams(id: number): unknown {
   return [[['id', '=', id]], {}];
 }
 
+/**
+ * The plan's first step: the read `execute` makes before the mutation.
+ *
+ * One wording for both switching tools. A step that said "changes nothing" in
+ * one tool and something subtly different in the other would be two accounts of
+ * one call, and this is the sentence a person reads before approving.
+ */
+function readStep(method: string, noun: string, id: number): PlanStep {
+  return {
+    method,
+    params: readParams(id),
+    description:
+      `Read this system's ${noun} with id ${id}, to report whether it was ` +
+      'already in the state this call moves it to. Changes nothing.',
+  };
+}
+
+/**
+ * What a switching tool reports about the change it just made, given the read
+ * before the call and the response to it.
+ *
+ * Shared by both switching tools because every field is derived the same way,
+ * and derived wrongly in ways that are easy to reintroduce one copy at a time:
+ * `changed` compares the two READINGS rather than the request, `confirmed` is
+ * the separate fact that the response agrees with the request, and both are
+ * null wherever a reading behind them is. What is NOT here is anything naming
+ * the thing switched — the caller adds its own `id` and, where it has one,
+ * `kind`.
+ *
+ * The read is caught rather than thrown for {@link scheduledTaskSetEnabled}'s
+ * reason: it exists to describe the outcome, and letting it fail the call would
+ * lose an approval the user has already given for a mutation that is still safe
+ * to make. The update is then issued unconditionally, whatever the read said —
+ * skipping it for a row the read no longer lists would be `execute` branching
+ * on state read at execution time, which is what the confirmation token cannot
+ * bind.
+ */
+async function switchOutcome(
+  read: () => Promise<unknown>,
+  update: () => Promise<unknown>,
+  id: number,
+  enabled: boolean,
+): Promise<Record<string, unknown>> {
+  let row: Record<string, unknown> | null = null;
+  let lookupError: string | null = null;
+  try {
+    row = rowWithId(await read(), id);
+  } catch (reason) {
+    lookupError = errorText(reason);
+  }
+  const updated = await update();
+  const previous = row === null ? null : booleanOrNull(row['enabled']);
+  // The update methods answer with the updated entity, so what the response
+  // says about `enabled` is the state that actually resulted — read back
+  // through the same guard rather than echoing what was asked for.
+  const resulting = booleanOrNull(recordOrNull(updated)?.['enabled']);
+  return {
+    lookup: lookupError !== null ? 'UNREADABLE' : row === null ? 'NOT_FOUND' : 'FOUND',
+    lookup_error: lookupError,
+    previously_enabled: previous,
+    resulting_enabled: resulting,
+    // Both readings or nothing. A `changed` derived from the request rather
+    // than from the response would report a call the system did not apply as
+    // having changed something.
+    changed: previous === null || resulting === null ? null : previous !== resulting,
+    confirmed: resulting === null ? null : resulting === enabled,
+  };
+}
+
 export const scheduledTaskSetEnabled: MutatingTool = {
   name: 'scheduled_task_set_enabled',
   description:
@@ -1714,8 +1802,10 @@ export const scheduledTaskSetEnabled: MutatingTool = {
     '`cloud_backup`, from its `cloud_backup_tasks` section. Every one of those ' +
     'listing tools reports the `id` this tool takes, so no second lookup is ' +
     'needed. INIT/SHUTDOWN SCRIPTS ARE NOT COVERED: they are not scheduled — ' +
-    'they run at a point in the system\'s lifecycle — and no tool here ' +
-    'switches one on or off. `enabled` is the state to move the task to, true ' +
+    'they run at a point in the system\'s lifecycle — and ' +
+    '`automated_task_set_enabled` is the tool that switches one of those on or ' +
+    'off, taking its ids from the `init_shutdown_scripts` section of ' +
+    '`automated_tasks_list`. `enabled` is the state to move the task to, true ' +
     'or false, and is required: there is no toggle, because a toggle acts on a ' +
     'state read after the plan was approved. ONLY THE `enabled` FIELD IS SENT. ' +
     'The schedule, paths, retention, credentials and every other setting are ' +
@@ -1813,13 +1903,7 @@ export const scheduledTaskSetEnabled: MutatingTool = {
       );
     }
     return [
-      {
-        method: spec.readMethod,
-        params: readParams(id),
-        description:
-          `Read this system's ${spec.noun} with id ${id}, to report whether it was ` +
-          'already in the state this call moves it to. Changes nothing.',
-      },
+      readStep(spec.readMethod, spec.noun, id),
       {
         method: spec.updateMethod,
         params: [id, { enabled }],
@@ -1831,39 +1915,16 @@ export const scheduledTaskSetEnabled: MutatingTool = {
   },
   async execute(ctx, rawArgs) {
     const { spec, id, enabled } = parseSwitch(rawArgs);
-    // Caught rather than thrown: this read exists to describe the outcome, and
-    // letting it fail the call would lose an approval the user has already
-    // given for a mutation that is still safe to make. The result then says the
-    // prior state could not be established.
-    let row: Record<string, unknown> | null = null;
-    let lookupError: string | null = null;
-    try {
-      row = rowWithId(await spec.read(ctx, id), id);
-    } catch (reason) {
-      lookupError = errorText(reason);
-    }
-    // Unconditional, whatever the read said. Skipping the update for a task the
-    // read no longer lists would be `execute` branching on state read at
-    // execution time, which is what the confirmation token cannot bind.
-    const updated = await spec.update(ctx, id, enabled);
-    const previous = row === null ? null : booleanOrNull(row['enabled']);
-    // The method answers with the updated task, so what it says about `enabled`
-    // is the state that actually resulted — read back through the same guard
-    // rather than echoing what was asked for.
-    const resulting = booleanOrNull(recordOrNull(updated)?.['enabled']);
     return {
       kind: spec.kind,
       id,
       requested_enabled: enabled,
-      lookup: lookupError !== null ? 'UNREADABLE' : row === null ? 'NOT_FOUND' : 'FOUND',
-      lookup_error: lookupError,
-      previously_enabled: previous,
-      resulting_enabled: resulting,
-      // Both readings or nothing. A `changed` derived from the request rather
-      // than from the response would report a call the system did not apply as
-      // having changed something.
-      changed: previous === null || resulting === null ? null : previous !== resulting,
-      confirmed: resulting === null ? null : resulting === enabled,
+      ...(await switchOutcome(
+        () => spec.read(ctx, id),
+        () => spec.update(ctx, id, enabled),
+        id,
+        enabled,
+      )),
     };
   },
 };
@@ -2460,29 +2521,23 @@ function describeInitShutdownScript(row: Record<string, unknown>, id: number): s
   return `the init/shutdown script with ${named.join(', ')} (id ${id})`;
 }
 
-/**
- * The caller's two arguments, or the error naming what is wrong with them.
- *
- * Strict on both, as {@link parseSwitch} is and word for word for the same
- * reason: coercing `"false"` to true would switch ON a script the caller asked
- * to switch off, which is not a narrower answer to the question asked but the
- * opposite one. There is no `kind` to resolve — this tool has one — so what
- * {@link parseSwitch} does in three checks this does in two.
- */
-function parseScriptSwitch(args: Record<string, unknown>): { id: number; enabled: boolean } {
-  const id = args['id'];
-  if (typeof id !== 'number' || !Number.isInteger(id)) {
-    throw new Error('"id" is required and must be a whole number');
-  }
-  const enabled = args['enabled'];
-  if (typeof enabled !== 'boolean') {
-    throw new Error('"enabled" is required and must be a boolean');
-  }
-  return { id, enabled };
-}
-
 /** Where the ids this tool takes come from, in the one wording used throughout. */
 const SCRIPT_IDS_FROM = 'the `init_shutdown_scripts` section of `automated_tasks_list`';
+
+/**
+ * Whatever `initshutdownscript.query` answered with for this id, unread.
+ *
+ * The filter is written here once and the call is the same in `plan` and in
+ * `execute`, which is what {@link TaskKind.read} does for the six kinds. It is
+ * bandwidth and not the control: {@link rowWithId} checks the id on the
+ * response, because an unrecognised query parameter is dropped rather than
+ * refused and a filter that did not apply comes back as the whole table.
+ */
+function readScript(ctx: ToolContext, id: number): Promise<unknown> {
+  return firstValueFrom(
+    ctx.system.client.api.query('initshutdownscript.query', [['id', '=', id]]),
+  );
+}
 
 export const automatedTaskSetEnabled: MutatingTool = {
   name: 'automated_task_set_enabled',
@@ -2584,15 +2639,12 @@ export const automatedTaskSetEnabled: MutatingTool = {
   // this tool neither reads nor changes it.
   destructiveness: 'reversible',
   normalizeArgs(rawArgs) {
-    const { id, enabled } = parseScriptSwitch(rawArgs);
+    const { id, enabled } = parseIdAndEnabled(rawArgs);
     return { id, enabled };
   },
   async plan(ctx, rawArgs): Promise<PlanStep[]> {
-    const { id, enabled } = parseScriptSwitch(rawArgs);
-    const rows = await firstValueFrom(
-      ctx.system.client.api.query('initshutdownscript.query', [['id', '=', id]]),
-    );
-    const row = rowWithId(rows, id);
+    const { id, enabled } = parseIdAndEnabled(rawArgs);
+    const row = rowWithId(await readScript(ctx, id), id);
     // Naming where the ids come from matters more here than it does for the
     // six kinds: there is no `kind` to have got wrong, so a caller that reaches
     // this failure has most likely handed over an id from one of the other
@@ -2604,13 +2656,7 @@ export const automatedTaskSetEnabled: MutatingTool = {
       );
     }
     return [
-      {
-        method: 'initshutdownscript.query',
-        params: readParams(id),
-        description:
-          `Read this system's init/shutdown script with id ${id}, to report whether it was ` +
-          'already in the state this call moves it to. Changes nothing.',
-      },
+      readStep('initshutdownscript.query', 'init/shutdown script', id),
       {
         method: 'initshutdownscript.update',
         params: [id, { enabled }],
@@ -2623,45 +2669,19 @@ export const automatedTaskSetEnabled: MutatingTool = {
     ];
   },
   async execute(ctx, rawArgs) {
-    const { id, enabled } = parseScriptSwitch(rawArgs);
-    const api = ctx.system.client.api;
-    // Caught rather than thrown, as {@link scheduledTaskSetEnabled}'s is: this
-    // read exists to describe the outcome, and letting it fail the call would
-    // lose an approval the user has already given for a mutation that is still
-    // safe to make.
-    let row: Record<string, unknown> | null = null;
-    let lookupError: string | null = null;
-    try {
-      row = rowWithId(
-        await firstValueFrom(api.query('initshutdownscript.query', [['id', '=', id]])),
-        id,
-      );
-    } catch (reason) {
-      lookupError = errorText(reason);
-    }
-    // Unconditional, whatever the read said. Skipping the update for a script
-    // the read no longer lists would be `execute` branching on state read at
-    // execution time, which is what the confirmation token cannot bind.
-    const updated = await firstValueFrom(
-      api.call('initshutdownscript.update', [id, { enabled }]),
-    );
-    const previous = row === null ? null : booleanOrNull(row['enabled']);
-    // The method answers with the updated script, so what it says about
-    // `enabled` is the state that actually resulted — read back through the
-    // same guard rather than echoing what was asked for.
-    const resulting = booleanOrNull(recordOrNull(updated)?.['enabled']);
+    const { id, enabled } = parseIdAndEnabled(rawArgs);
     return {
       id,
       requested_enabled: enabled,
-      lookup: lookupError !== null ? 'UNREADABLE' : row === null ? 'NOT_FOUND' : 'FOUND',
-      lookup_error: lookupError,
-      previously_enabled: previous,
-      resulting_enabled: resulting,
-      // Both readings or nothing, for the reason its sibling gives: a `changed`
-      // derived from the request rather than from the response would report a
-      // call the system did not apply as having changed something.
-      changed: previous === null || resulting === null ? null : previous !== resulting,
-      confirmed: resulting === null ? null : resulting === enabled,
+      ...(await switchOutcome(
+        () => readScript(ctx, id),
+        () =>
+          firstValueFrom(
+            ctx.system.client.api.call('initshutdownscript.update', [id, { enabled }]),
+          ),
+        id,
+        enabled,
+      )),
     };
   },
 };


### PR DESCRIPTION
Fixes #126.

`scheduled_task_set_enabled` (#121) covers the six kinds that genuinely run on a
schedule and deliberately refuses init/shutdown scripts, because its own name
promises a schedule they do not have. That left the one entry in
`automated_tasks_list` carrying an `enabled` that nothing in the catalog could
act on. This adds the tool that acts on it.

## What it does

`automated_task_set_enabled` takes a script's `id` and the state to move it to,
calls `initshutdownscript.update` with **only** the `enabled` field, and reports
the outcome read back off the response. `InitShutdownScriptUpdate` declares
`enabled?: boolean` on `DefaultApiDirectory` — confirmed in the pinned client's
`dist/index.d.ts` rather than assumed, as the ticket said.

The plan returns **two** steps, the read and the mutation, because `execute`
makes both calls (#119). The read is caught rather than thrown, the update is
issued unconditionally whatever the read said, and the result carries the same
account its sibling gives: `previously_enabled`, `resulting_enabled`, `changed`
(the two readings compared, never the request), `confirmed` (the separate fact
that the response agrees with what was asked), and a three-valued `lookup` whose
`FOUND` beside a null `previously_enabled` is the fourth cause the tool's
description names.

## The two things that are its own rather than copied

**No schedule is rendered and none is invented.** `describeTask` ends every
scheduled task with a schedule phrase; there is no cron record here, so a phrase
in its place would be the tool's own fiction about when the work happens (#97).
The plan states the lifecycle point the row carries, passed through as the system
spelled it, and points at `automated_tasks_list` for what each point means —
rather than glossing `PREINIT`/`POSTINIT`/`SHUTDOWN` a second time, which is a
second opinion that can drift from the first. A `when` that could not be read
says exactly that and is **not** defaulted to startup: an approver told nothing
reads the silence as "it runs at boot", and a `SHUTDOWN` script is the one where
switching it off at the wrong moment costs most.

**The name is broader than the tool, and that is a decision rather than an
oversight.** `automated_tasks_list` has four sections and this acts on one; the
other three are `scheduled_task_set_enabled`'s. So the name promises a category
it does not cover — ordinarily the finding rather than the design. It was taken
because #121 left the excluded kind needing a name that claims no schedule, and
the precise alternative (`init_shutdown_script_set_enabled`) would need renaming
the day a second non-scheduled kind arrives. Three things carry the scope
instead, and all three are load-bearing:

- the description states the boundary **first**, before anything about the
  outcome — which section the id comes from, and which tool takes the other
  three;
- the `id` argument's own description repeats it, because that is what a caller
  reads when it is choosing a number;
- the plan is what actually stops a mis-aimed id. Task ids are per-table
  integers, so a cron job's id 3 is also a script's id 3, and unlike #121 there
  is no discriminator to require — one kind means nothing to discriminate. What
  remains is that an approver reading *"the init/shutdown script with comment
  ..."* sees something that is not the cron job they meant.

Both of these are written up in `CLAUDE.md`, since neither is inferable from the
code and the second is a choice a later tool will face again.

## Credentials

Neither `command` nor `script` reaches the plan. A command is whatever an
operator typed and can hold a password someone inlined; a script is a path whose
contents this repository never reads; a plan is shown to a person and then
recorded. `comment`, `when` and `type` identify the entry without either, and
`type` is carried because it is the part of them an approver needs and the part
that holds no secret. This is #121's call for a cron job's `command`, reaching
both fields of the one entry that has them. Two tests hold it.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run
locally and pass — the same four the CI workflow gates on, on this machine
rather than on the matrix. Coverage: `tasks.ts` at 100% branches and statements,
global 99.44/99.74 against floors of 96/97. 1,252 tests, 0 failures.

The local review ran the project's own reviewer in a separate process, three
rounds, and the third returned nothing at MEDIUM or above.

## What earlier rounds found, and what changed

- **MEDIUM, round 1** — `scheduled_task_set_enabled`'s description still said
  that no tool here switches an init/shutdown script on or off. That stopped
  being true in the commit that made it worth saying, and a caller routing on it
  would have refused a request the catalog can serve. Both descriptions now name
  the other, and a test holds it there; nothing had been asserting it, which is
  why it went stale unnoticed. The docblock calling that tool "its own ticket"
  went with it.
- **HIGH, round 2** — `src/index.ts`, the public barrel, re-exports every one of
  the other fifty-four tools by name and did not re-export this one, so a
  consumer importing it from the package would not compile. Registering a tool
  means `src/tools/index.ts`, the module's spec, **and** the barrel.
- **Duplication, round 1 (LOW, fixed anyway)** — `parseIdAndEnabled`, `readStep`
  and `switchOutcome` are now written once and used by both switching tools.
  Each is somewhere a fix to one copy would silently not have reached the other,
  which is `common.ts`'s argument inside one family; the helpers stay in
  `tasks.ts`, where the vocabulary is.

## What I did not change, and why

The clean round returned five LOWs. None blocks, and each is recorded here
rather than fixed, because every fix is a new diff and a new diff is another
round:

1. **`normalizeArgs` silently drops a `kind` argument**, which is the one
   wrong-section signal this tool could detect — a caller copying
   `scheduled_task_set_enabled`'s shape would switch a script instead of the
   cron job it named. The sharpest of the five and the one I would take first.
   It is a real narrowing of the name problem above and not merely style;
   rejecting an unexpected `kind` would, however, be this tool's schema refusing
   an argument it does not declare, which no other tool here does, so it is a
   convention decision rather than a local fix.
2. **`NOT_FOUND`'s gloss** — "it was deleted between the plan and the
   confirmation" — names one of three ways `rowWithId` answers null; a non-list
   response and unreadable rows land there too. The wording is
   `scheduled_task_set_enabled`'s verbatim, so narrowing it here alone would
   make the two descriptions disagree about one shared reading.
3. **`switchOutcome` takes `id` and `enabled` beside its read/update thunks**,
   which already close over both, and nothing enforces that the pair agrees. Two
   callers today and both pass what they closed over; a third could not.
4. **`SCRIPT_IDS_FROM` is documented as "the one wording used throughout" and is
   referenced once** — the tool and schema descriptions spell the phrase out
   independently, because they are string literals a constant cannot reach
   without breaking the description's own concatenation. The doc comment
   overstates what the constant achieves.
5. **`automated_tasks_list` points at neither switching tool**, despite being
   the id source for both and sharing a name prefix with the one that covers a
   quarter of it. That matches the family's existing convention —
   `cloudsync_tasks_list` does not point at `cloudsync_run` either — so changing
   it is a change to a read-only tool's contract and to that convention, which
   is a ticket rather than a line.

Separately, the round-2 review noted the plan's label-rendering map is now
written three times in `tasks.ts` (`describeTask`, `describeCloudSyncTask` and
`describeInitShutdownScript`). A shared helper beside `NONE_REPORTED` would
carry all three; two of them belong to tools this ticket did not touch.
