### PR TITLE
refactor(catalog): keep Destructiveness at two values, and pin the narrow claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1166,6 +1166,53 @@ a `SHUTDOWN` script is the one where switching it off at the wrong moment costs
 most, which is `transferModeSentence`'s refusal to default to the harmless mode
 in a second family.
 
+### Two values, because the data effect is not a property of the tool (#128)
+
+`Destructiveness` stays `'reversible' | 'irreversible'`. #122 settled why
+`cloudsync_run` takes the first — the field records the operation, the
+description carries the account of the data, and the test for a triggering tool
+is whether it authors the destruction or only its timing. What this ticket asked
+was the next question: whether the TYPE should grow to say it, either as a third
+value that registers like `reversible` and advertises differently, or as a
+separate field for what the operation does to the data. Neither, and the reason
+is one #122 never had to reach for.
+
+**The data effect is not a property of the tool. It is a property of the entity
+the caller names at call time.** `cloudsync_run`'s effect is the named task's own
+`transfer_mode`, read at plan time: `COPY` deletes nothing, `SYNC` and `MOVE`
+delete for good, and the same tool is all three across three ids. A value or a
+field fixed at the tool's declaration has only two ways to be written and both
+are wrong — worst case for every call, which tells an approver "may delete"
+about a `COPY` task and teaches it to discount the warning, or a reading of
+state a declaration cannot see. **The plan and the description are the only two
+places a per-call fact can be stated**, and they already state it.
+
+The kinds coming next sharpen that rather than strain it. `cronjob.run` executes
+an arbitrary operator-written command, and the strongest true thing a static
+field could say about one is "whatever the operator wrote" — which is prose, and
+belongs where prose goes.
+
+**A third value is also dearer than it looks, because exactly one value is
+load-bearing.** `irreversible` is the only one that changes what
+`ToolCatalog.register` does, so a `'triggers'` that registers like `reversible`
+adds a case to a public-barrel type on which every consumer's switch gains a
+branch the check ignores. Worse, it lands on `AdvertisedTool.destructiveness`,
+whose doc comment exists to say the field must not be read alone — and a value
+named for the case is an invitation to read it alone. **Do not widen a field to
+carry a fact that is only true per call.**
+
+So what this ticket changed is the tests, and the tests are the part that was
+actually missing. `catalog.spec.ts` now covers the registration outcome for BOTH
+values: `irreversible` rejected, asserted on the narrow wording — that the tool
+*composes* such an operation — and `reversible` registering, retrievable and
+advertised carrying the value. The narrowing #122 made to that rejection
+message, to `README.md` and to the field's own declaration had **nothing
+asserting it**, so a later edit restoring the broad promise (that the policy
+keeps irreversibly destructive operations out of the catalog, which is a
+guarantee this check cannot make) would have passed every test. **A redefinition
+that lives only in prose is one edit away from being undone** — where the rule
+is enforced by a message rather than by a type, pin the message.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/src/catalog/catalog.spec.ts
+++ b/src/catalog/catalog.spec.ts
@@ -32,11 +32,32 @@ describe('ToolCatalog', () => {
     expect(() => catalog.register(readOnly('a_b'))).toThrow(/already registered/);
   });
 
-  it('rejects irreversibly destructive tools by policy', () => {
+  it('rejects irreversibly destructive tools by policy, on the narrow claim', () => {
     const catalog = new ToolCatalog();
-    expect(() =>
-      catalog.register(mutating('storage_delete_pool', { destructiveness: 'irreversible' })),
-    ).toThrow(/destructive-action policy/);
+    const register = () =>
+      catalog.register(mutating('storage_delete_pool', { destructiveness: 'irreversible' }));
+    expect(register).toThrow(/destructive-action policy/);
+    // The message says COMPOSES on purpose (#122): the check rejects a tool that
+    // chooses what is destroyed, and says nothing about one that triggers an
+    // operation an operator authored. Nothing was asserting that wording, so a
+    // message widened back to "keeps such operations out of the catalog" — a
+    // guarantee this check cannot make — would have passed.
+    expect(register).toThrow(/composes an irreversibly destructive operation/);
+  });
+
+  it('registers the reversible value, and advertises it', () => {
+    // The other half of the registration outcome, and the value every tool in
+    // the catalog carries — including one that only TRIGGERS an operation
+    // configured elsewhere, which is `cloudsync_run` and is the case #128
+    // decided not to give a value of its own. What such a run does to the data
+    // is in the tool's description and its plan, never in this field.
+    const catalog = new ToolCatalog();
+    const tool = mutating('cloudsync_run', { destructiveness: 'reversible' });
+    catalog.register(tool);
+    expect(catalog.get('cloudsync_run')).toBe(tool);
+    expect(catalog.list(Role.Full)).toEqual([
+      expect.objectContaining({ name: 'cloudsync_run', destructiveness: 'reversible' }),
+    ]);
   });
 
   it('rejects tools declaring reserved executor arguments', () => {


### PR DESCRIPTION
Closes #128

The ticket asked for one of three shapes and the reason for it. This takes the
third — the two values are correct, and the rule is written down as the answer
rather than re-derived per tool — and adds the argument that decides it, which
#122 never had to reach for.

## The decision

**The data effect is not a property of the tool. It is a property of the entity
the caller names at call time.** `cloudsync_run`'s effect is the named task's own
`transfer_mode`, read at plan time: `COPY` deletes nothing, `SYNC` and `MOVE`
delete for good, and the same tool is all three across three ids. So a value or a
field fixed at the tool's declaration has only two ways to be written and both
are wrong — worst case for every call, which tells an approver "may delete" about
a `COPY` task and teaches it to discount the warning, or a reading of state a
declaration cannot see. The plan and the description are the only two places a
per-call fact can be stated, and they already state it.

That answers both of the ticket's other shapes at once, since a third enum value
and a separate data-effect field are the same static claim wearing two hats. The
kinds coming next sharpen it: `cronjob.run` executes an arbitrary
operator-written command, and the strongest true thing a static field could say
about one is "whatever the operator wrote", which is prose.

A third value is also dearer than it looks, because exactly one value is
load-bearing. `irreversible` is the only one that changes what
`ToolCatalog.register` does, so a `'triggers'` that registers like `reversible`
adds a case to a public-barrel type on which every consumer's switch gains a
branch the check ignores — and it lands on `AdvertisedTool.destructiveness`,
whose doc comment exists to say the field must not be read alone. A value named
for the case is an invitation to read it alone.

## What actually changed, and why it is the tests

#122 narrowed three separate statements of this rule — `ToolCatalog.register`'s
rejection message, `README.md`, and `Destructiveness`'s own declaration — from
"the policy keeps irreversibly destructive **operations** out of the catalog",
which is a guarantee this check cannot make, to the narrow claim that it rejects
a tool that **composes** one. **Nothing was asserting that wording.** A later
edit restoring the broad promise would have passed every test, and the rule would
have gone back to being wrong in the one place a reader reaches first.

`catalog.spec.ts` now covers the registration outcome for both values:

- `irreversible` is rejected **and** the message is asserted to say *composes an
  irreversibly destructive operation*, pinning the narrowing rather than only the
  policy phrase.
- `reversible` registers, is retrievable through `get`, and is advertised
  carrying the value — a registration outcome in its own right rather than
  incidental to the role-filter and advertised-shape tests, which is what the
  ticket's third criterion asks for.

`app/CLAUDE.md` gets one `## Decisions` entry recording the choice among the
three shapes and the per-call argument above. It deliberately does **not**
restate #122's substance — that entry stays authoritative on what the field
records and on the authors-vs-times-the-destruction test, and a fourth statement
of the same rule is the drift this file warns about.

## What I did not change, and why

- **No type change**, so the last two acceptance criteria are met by checking
  rather than editing. `src/index.ts` exports `Destructiveness` unchanged;
  `README.md` already carries #122's narrowed wording at both places it states
  this (the policy line and the `destructiveness`-is-about-the-operation
  paragraph). Grepped every mention of "destructive" across `src/` and
  `README.md` — all statements agree.
- **`cloudsync_run` is untouched**, in behaviour and in the value it carries. The
  chosen shape says it should carry `reversible` with the account of the data in
  its description and plan, which is what it already does.
- **No comment added to `snapshots_create`, `scheduled_task_set_enabled` or
  `automated_task_set_enabled`**, where `destructiveness: 'reversible'` sits
  bare. #122's rule is that a local comment says which case the tool is; all
  three compose their own reversible change rather than triggering an
  operator-authored one, so there is no case to disambiguate and a comment would
  be noise. Only `cloudsync_run` and `alerts_dismiss` carry one, and both are
  tools where the reading is not obvious.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run
locally and pass — the same four the CI workflow gates on, on this machine rather
than on the matrix. 1,253 tests, 0 failures; global coverage 99.74 statements /
99.44 branches against floors of 97/96, and `src/catalog/catalog.ts` at
96.77/95.00 against its per-file floor of 96/95.

The local review ran the project's own reviewer in a separate process — the same
rubric, threshold and parser as the required check — and the first round returned
nothing at all, at any severity. That is the clean round, so the work stopped
there.
