### PR TITLE
feat(catalog): deliver interpretation guidance with the result, not the catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1246,16 +1246,26 @@ tenth of the raw number. But caching discounts input tokens; it does not remove
 them from the window. The constraint is the window, so the cost argument is the
 weaker half of this and must not be the one a change here is justified by.
 
-`ToolBase.resultGuidance` is where the interpretation half now lives: delivered
-with the result, once per tool per session, and never advertised.
+`ToolBase.resultGuidance` is where the interpretation half is delivered: with
+the result, once per tool per session, and never advertised.
+
+**What ships first is a COPY, and the distinction matters for a reader of this
+file.** `description` is byte-identical to what it was, still carries every word
+of the guidance, and is therefore still advertised — one hoisted `const` is
+referenced by both fields, so there is exactly one copy of the prose in the
+source and no reflow can drift them apart. `tools/list` does not shrink until
+the FOLLOW-UP stops appending that const to `description`, which lands only once
+an adapter renders `guidance`. The ordering is not discipline: while nothing
+renders the new field, removing the text from the old one would delete the
+caveats rather than move them.
 
 **The line is drawn by WHEN the text becomes actionable, not by length.**
 Interpretation guidance cannot be acted on at selection time — a caller cannot
 use "null means not read" before it holds a null. So this is not a summary of
 the description with the detail cut; it is the half that was addressed to the
-wrong moment, moved to the moment it can be used. That is also why it reads
-better there: the null/empty/unreadable conventions this repository is most
-careful about now arrive attached to the nulls they are about.
+wrong moment. Once an adapter renders it, the null/empty/unreadable conventions
+this repository is most careful about arrive attached to the nulls they are
+about, which is the gain the split is for.
 
 **What stays in `description` is anything that bears on whether to call the tool
 at all**, and getting this wrong is the way the split does damage. That a report
@@ -1266,6 +1276,15 @@ order to choose correctly has already chosen by the time a result exists. When
 in doubt the text stays in the description: the cost of leaving it there is
 tokens, and the cost of moving it wrongly is a caller acting on an answer it
 would not have asked for.
+
+**A cross-tool pointer may legitimately end up in BOTH, and the follow-up is
+where that is honoured.** Because the guidance is a contiguous suffix, it
+carries some sentences that are selection class — "this tool cannot answer that,
+`audit_config` is the one that reads it", "who may reach one share is
+`share_access`". Those tell a caller the tool is the wrong choice, which is
+worth knowing before the call, so the removal must leave them in `description`
+rather than deleting the whole reference. The const's own comment in each file
+names the ones it carries.
 
 **Once per session, not once per call, and that is a cost decision with a
 scoping assumption.** Guidance in a result is paid at full price when it arrives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1228,6 +1228,67 @@ guarantee this check cannot make) would have passed every test. **A redefinition
 that lives only in prose is one edit away from being undone** — where the rule
 is enforced by a message rather than by a type, pin the message.
 
+### Interpretation guidance travels with the result, not with the catalog (#131)
+
+`tools/list` is rendered into every host's context on every session, before a
+single tool is called, and what it costs is the whole catalog rather than the
+tools used. Measured at 55 tools: **215,278 bytes, of which descriptions were
+87%** — around 52,600 tokens. That is more than the entire context window of a
+default-configured local model (ollama defaults `num_ctx` to 4096 whatever the
+model supports), so every request from one was refused outright with
+`request (32892 tokens) exceeds the available context size` — the failure that
+took the server repo's tier-3 nightly down for two runs.
+
+**Caching does not answer this, and reaching for it is the trap.** Tool
+definitions render at position 0 of the cached prefix and cache reads bill at
+about 0.1x, so the cost of those descriptions on a caching host is roughly a
+tenth of the raw number. But caching discounts input tokens; it does not remove
+them from the window. The constraint is the window, so the cost argument is the
+weaker half of this and must not be the one a change here is justified by.
+
+`ToolBase.resultGuidance` is where the interpretation half now lives: delivered
+with the result, once per tool per session, and never advertised.
+
+**The line is drawn by WHEN the text becomes actionable, not by length.**
+Interpretation guidance cannot be acted on at selection time — a caller cannot
+use "null means not read" before it holds a null. So this is not a summary of
+the description with the detail cut; it is the half that was addressed to the
+wrong moment, moved to the moment it can be used. That is also why it reads
+better there: the null/empty/unreadable conventions this repository is most
+careful about now arrive attached to the nulls they are about.
+
+**What stays in `description` is anything that bears on whether to call the tool
+at all**, and getting this wrong is the way the split does damage. That a report
+states no compliance verdict (#47), that a listing covers only data pools (#95),
+that a physical side effect is unestablished (#120), which ids a mutating tool
+takes and from where (#119, #121, #126) — a caller that needed the caveat in
+order to choose correctly has already chosen by the time a result exists. When
+in doubt the text stays in the description: the cost of leaving it there is
+tokens, and the cost of moving it wrongly is a caller acting on an answer it
+would not have asked for.
+
+**Once per session, not once per call, and that is a cost decision with a
+scoping assumption.** Guidance in a result is paid at full price when it arrives
+and cached at 0.1x thereafter, so a copy per call would accumulate — five calls
+to `fleet_compliance_report` would carry five copies of its guidance, where the
+description form had exactly one, discounted. The delivered set is held on the
+`ToolExecutor` instance, which makes "per session" true only because both
+deployment modes build one executor per session — the same assumption
+`ConfirmationService` already makes about pending tokens, and stated in both
+places. **A deployment sharing one executor across sessions would have to
+re-scope both in the same change.**
+
+**Guidance is attached only to a result carrying at least one SUCCESS.** A
+result with no data has nothing to read, and spending the one delivery on it
+would leave the caller unguided for every later call that does carry data. It
+falls out of that rule, rather than being handled separately, that a mutating
+plan which failed on every system — returned as RESULTS rather than as an
+approvable plan — never consumes it.
+
+**The load-bearing property is that `list()` never carries the field**, and it is
+pinned by a test rather than left to the mapping. A leak there would restore
+exactly the cost this was cut to remove and would do it silently: every other
+test in the repository would still pass.
 ### A credential is named by an allowlist, and that is what makes it readable (#132)
 
 `replication_topology` reports the peer on the far end of each replication task,
@@ -1990,7 +2051,10 @@ a guessed side effect is worse than saying nothing (#120).
   This is the single most common review finding in this repository. State what
   a nullable field means when it is null, keep "unreadable", "absent" and
   "empty" distinct, and keep that distinction consistent with the sibling
-  fields in the same file.
+  fields in the same file. Since #131 that account of the fields lives in
+  `resultGuidance` rather than in `description` — **the rule is unchanged and
+  the field it applies to is not**, so check which of the two a sentence
+  belongs in before writing it.
 - **Map API rows through an allowlist of named fields**, never by trimming: it
   is what keeps a field a later TrueNAS release adds out of a tool result.
 - **Partial failure is data, not an exception** — see `fanOut` and the

--- a/src/catalog/catalog.spec.ts
+++ b/src/catalog/catalog.spec.ts
@@ -115,3 +115,32 @@ describe('ToolCatalog', () => {
     expect(tool.inputSchema['properties']).toEqual({});
   });
 });
+
+describe('ToolCatalog — result guidance is never advertised', () => {
+  /**
+   * The load-bearing property of the split. `resultGuidance` exists because
+   * `tools/list` is rendered into every host's context on every session; a
+   * field that leaked into the advertised shape would restore exactly the cost
+   * it was cut to remove, and would do it silently — every test above would
+   * still pass. `list()` maps named fields, so this holds structurally; it is
+   * pinned because the failure is invisible rather than because the mapping
+   * looks fragile.
+   */
+  it('omits it from the advertised tool, which still carries the description', () => {
+    const catalog = new ToolCatalog();
+    catalog.register({
+      name: 'guided',
+      description: 'selection text',
+      resultGuidance: 'interpretation text',
+      inputSchema: { type: 'object', properties: {} },
+      requiredRole: Role.ReadOnly,
+      mutating: false,
+      handler: async () => null,
+    } satisfies ReadOnlyTool);
+
+    const [advertised] = catalog.list(Role.Full);
+    expect(advertised?.description).toBe('selection text');
+    expect(advertised).not.toHaveProperty('resultGuidance');
+    expect(JSON.stringify(advertised)).not.toContain('interpretation text');
+  });
+});

--- a/src/catalog/tool.ts
+++ b/src/catalog/tool.ts
@@ -90,6 +90,11 @@ interface ToolBase {
    * to choose it or not choose it. Guidance about reading a RESULT belongs in
    * {@link ToolBase.resultGuidance} — see there for where the line falls and
    * why it is drawn at all.
+   *
+   * A tool that has been split carries the interpretation half in BOTH for now:
+   * one hoisted const, referenced here and there, so nothing is missing from
+   * what hosts render today. It stops being appended here only once an adapter
+   * renders the other field.
    */
   description: string;
   /**
@@ -123,6 +128,12 @@ interface ToolBase {
    * Once per tool per session, not once per call: see
    * {@link ToolExecutor} for that decision and what it assumes about
    * deployment.
+   *
+   * **A cross-tool pointer may sit in both fields.** Where the guidance is a
+   * contiguous suffix of the description it will carry sentences of the class
+   * above — "this tool cannot answer that, X is the tool that reads it". Those
+   * stay in `description` when the removal lands, because a caller needs them
+   * while choosing; each tool's const says which ones it carries.
    */
   resultGuidance?: string;
   /**

--- a/src/catalog/tool.ts
+++ b/src/catalog/tool.ts
@@ -83,8 +83,48 @@ interface ToolBase {
    * to `[a-zA-Z0-9_-]`, so dotted names only work if the host sanitizes them.
    */
   name: string;
-  /** Natural-language description for the LLM. */
+  /**
+   * Natural-language description for the LLM, carried in every `tools/list`.
+   *
+   * This is SELECTION text: what the tool is for, and what a caller must know
+   * to choose it or not choose it. Guidance about reading a RESULT belongs in
+   * {@link ToolBase.resultGuidance} — see there for where the line falls and
+   * why it is drawn at all.
+   */
   description: string;
+  /**
+   * How to READ this tool's result — the null/empty/unreadable conventions,
+   * what a field does not establish, what the tool states no verdict about.
+   * Delivered with the result rather than advertised, and only the first time
+   * the tool answers in a session.
+   *
+   * **Why this is separate from `description` at all.** `tools/list` is
+   * rendered into every host's context on every session, before anything is
+   * called, and its cost is the whole catalog rather than the tools used.
+   * Measured at 55 tools: 215,278 bytes, of which descriptions were 87%. That
+   * exceeded the entire context window of a default-configured local model,
+   * which is not a budget question — the request is refused outright and no
+   * amount of caching helps, because caching discounts input tokens without
+   * removing them from the window.
+   *
+   * **Why the split is at THIS line rather than anywhere shorter.**
+   * Interpretation guidance cannot be acted on at selection time: a caller
+   * cannot use "null means not read" before it holds a null. Moving it to the
+   * result is where it becomes actionable, so this is not a summary of the
+   * description — it is the half that was addressed to the wrong moment.
+   *
+   * **What must NOT move here.** Anything that bears on whether to call the
+   * tool at all: that it states no compliance verdict (#47), that it reports
+   * only data pools (#95), that a physical side effect is unestablished
+   * (#120), which ids it takes and from where (#119, #121, #126). A caller
+   * that needed the caveat in order to choose correctly has already chosen by
+   * the time a result exists.
+   *
+   * Once per tool per session, not once per call: see
+   * {@link ToolExecutor} for that decision and what it assumes about
+   * deployment.
+   */
+  resultGuidance?: string;
   /**
    * JSON Schema for the tool's own arguments. The executor-level arguments
    * (`systems`, `confirmation_token`) are reserved and injected into the

--- a/src/execution/confirmation.ts
+++ b/src/execution/confirmation.ts
@@ -63,6 +63,14 @@ export interface ConfirmationServiceOptions {
  * or a different instance cannot confirm a previously minted plan; that fails
  * closed (the LLM is told to request a fresh plan and approval), which suits
  * the single-process/browser deployment modes.
+ *
+ * {@link ToolExecutor} now makes the same per-instance assumption, for the
+ * once-per-session delivery of a tool's result guidance (#131) — and its
+ * failure mode is the opposite of this one. A shared instance would fail
+ * CLOSED here (a token minted by another session is simply unknown) and OPEN
+ * there (a second session is told the guidance was already delivered when it
+ * never saw it). So a deployment that shares one instance across sessions has
+ * to re-scope both, and only one of the two announces itself when it breaks.
  */
 export class ConfirmationService {
   private readonly ttlMs: number;

--- a/src/execution/executor.spec.ts
+++ b/src/execution/executor.spec.ts
@@ -593,6 +593,9 @@ describe('ToolExecutor — result guidance', () => {
     for (const name of ['a', 'b']) {
       registry.add({ name, client: {} as TrueNasApiClient } as SystemHandle);
     }
+    // Mutable, and returned below: the withholding invariant is about ONE
+    // executor's delivered set across two calls, so the failure has to be
+    // switched off between them rather than a second executor built.
     const failOn = options.failOn ?? [];
     const tool: ReadOnlyTool = {
       name: 'guided',
@@ -612,7 +615,7 @@ describe('ToolExecutor — result guidance', () => {
     catalog.register(tool);
     const build = (): ToolExecutor =>
       new ToolExecutor({ catalog, registry, confirmations: new ConfirmationService() });
-    return { build, executor: build() };
+    return { build, executor: build(), failOn };
   }
 
   /** Narrowing helper: every outcome below is a RESULTS one. */
@@ -650,11 +653,19 @@ describe('ToolExecutor — result guidance', () => {
     // The point of the SUCCESS requirement: a result with nothing to read must
     // not spend the one delivery, or every later call that does carry data is
     // unguided.
-    const failing = guidedSetup({ guidance: 'kept', failOn: ['a', 'b'] });
-    expect((await run(failing.executor)).guidance).toBeUndefined();
+    //
+    // BOTH halves run on the SAME executor deliberately. An earlier version
+    // built a second one for the success, which re-asserted only what the
+    // first test already covers and left `guidanceDelivered` unread — so
+    // moving the `add` above the SUCCESS gate broke the invariant with every
+    // test still green.
+    const { executor, failOn } = guidedSetup({ guidance: 'kept', failOn: ['a', 'b'] });
+    expect((await run(executor)).guidance).toBeUndefined();
 
-    const healthy = guidedSetup({ guidance: 'kept' });
-    expect((await run(healthy.executor)).guidance).toBe('kept');
+    failOn.length = 0;
+    expect((await run(executor)).guidance).toBe('kept');
+    // And having now been spent, it is not repeated.
+    expect((await run(executor)).guidance).toBeUndefined();
   });
 
   it('is per executor, so a new session receives it again', async () => {
@@ -674,6 +685,9 @@ describe('ToolExecutor — result guidance on the mutating paths', () => {
    * falling out of that gate rather than being handled separately.
    */
   function mutatingSetup(options: { planFails?: boolean } = {}) {
+    // `planFails` is read through this box rather than captured, so a test can
+    // switch it off and come back for the delivery on the same executor.
+    const state = { planFails: options.planFails === true };
     const registry = new SystemRegistry();
     for (const name of ['a', 'b']) {
       registry.add({ name, client: {} as TrueNasApiClient } as SystemHandle);
@@ -687,7 +701,7 @@ describe('ToolExecutor — result guidance on the mutating paths', () => {
       mutating: true,
       destructiveness: 'reversible',
       plan: async ({ system }) => {
-        if (options.planFails) {
+        if (state.planFails) {
           throw new Error(`cannot plan on ${system.name}`);
         }
         return [{ method: 'write', params: {}, description: `write on ${system.name}` }];
@@ -699,20 +713,36 @@ describe('ToolExecutor — result guidance on the mutating paths', () => {
     const confirmations = new ConfirmationService();
     return {
       confirmations,
+      state,
       executor: new ToolExecutor({ catalog, registry, confirmations }),
     };
   }
 
   it('does not spend the delivery on a plan that failed on every system', async () => {
-    // The all-ERROR gate reaching the path that returns steps as RESULTS.
-    const { executor } = mutatingSetup({ planFails: true });
+    // The all-ERROR gate reaching the path that returns steps as RESULTS. The
+    // second half is what makes "does not spend" a claim rather than a
+    // restatement of the absence: the same executor must still owe it.
+    const { executor, state, confirmations } = mutatingSetup({ planFails: true });
     const outcome = await executor.execute('guided_write', { systems: 'all' });
-    expect(outcome.type).toBe('RESULTS');
     if (outcome.type !== 'RESULTS') {
       throw new Error('expected RESULTS');
     }
     expect(outcome.results.every((r) => r.status === 'ERROR')).toBe(true);
     expect(outcome.guidance).toBeUndefined();
+
+    state.planFails = false;
+    const planned = await executor.execute('guided_write', { systems: 'all' });
+    if (planned.type !== 'PLAN') {
+      throw new Error('expected PLAN');
+    }
+    const executed = await executor.execute('guided_write', {
+      systems: 'all',
+      confirmation_token: confirmations.mint(planned.key),
+    });
+    if (executed.type !== 'RESULTS') {
+      throw new Error('expected RESULTS');
+    }
+    expect(executed.guidance).toBe('how to read what came back');
   });
 
   it('attaches it to the confirmed execution, and not to the plan before it', async () => {

--- a/src/execution/executor.spec.ts
+++ b/src/execution/executor.spec.ts
@@ -581,3 +581,87 @@ describe('ToolExecutor — audit', () => {
     ]);
   });
 });
+
+describe('ToolExecutor — result guidance', () => {
+  /**
+   * A read-only tool whose handler succeeds or fails per system, so a test can
+   * produce a result carrying no data without reaching for the role gate —
+   * which would report a denial rather than a handler failure.
+   */
+  function guidedSetup(options: { guidance?: string; failOn?: string[] } = {}) {
+    const registry = new SystemRegistry();
+    for (const name of ['a', 'b']) {
+      registry.add({ name, client: {} as TrueNasApiClient } as SystemHandle);
+    }
+    const failOn = options.failOn ?? [];
+    const tool: ReadOnlyTool = {
+      name: 'guided',
+      description: 'selection text',
+      ...(options.guidance !== undefined ? { resultGuidance: options.guidance } : {}),
+      inputSchema: { type: 'object', properties: {} },
+      requiredRole: Role.ReadOnly,
+      mutating: false,
+      handler: async ({ system }) => {
+        if (failOn.includes(system.name)) {
+          throw new Error(`down: ${system.name}`);
+        }
+        return `${system.name}-ok`;
+      },
+    };
+    const catalog = new ToolCatalog();
+    catalog.register(tool);
+    const build = (): ToolExecutor =>
+      new ToolExecutor({ catalog, registry, confirmations: new ConfirmationService() });
+    return { build, executor: build() };
+  }
+
+  /** Narrowing helper: every outcome below is a RESULTS one. */
+  async function run(executor: ToolExecutor): Promise<{ guidance?: string }> {
+    const outcome = await executor.execute('guided', { systems: 'all' });
+    if (outcome.type !== 'RESULTS') {
+      throw new Error('expected RESULTS');
+    }
+    return outcome;
+  }
+
+  it('attaches the guidance to the first result that carries data', async () => {
+    const { executor } = guidedSetup({ guidance: 'read nulls as not-read' });
+    expect((await run(executor)).guidance).toBe('read nulls as not-read');
+  });
+
+  it('does not repeat it on later calls in the same session', async () => {
+    const { executor } = guidedSetup({ guidance: 'read nulls as not-read' });
+    await run(executor);
+    expect((await run(executor)).guidance).toBeUndefined();
+    expect((await run(executor)).guidance).toBeUndefined();
+  });
+
+  it('omits it entirely for a tool that declares none', async () => {
+    const { executor } = guidedSetup();
+    expect((await run(executor)).guidance).toBeUndefined();
+  });
+
+  it('still attaches it when only some systems answered', async () => {
+    const { executor } = guidedSetup({ guidance: 'partial', failOn: ['b'] });
+    expect((await run(executor)).guidance).toBe('partial');
+  });
+
+  it('withholds it from an all-error result and keeps it for the next success', async () => {
+    // The point of the SUCCESS requirement: a result with nothing to read must
+    // not spend the one delivery, or every later call that does carry data is
+    // unguided.
+    const failing = guidedSetup({ guidance: 'kept', failOn: ['a', 'b'] });
+    expect((await run(failing.executor)).guidance).toBeUndefined();
+
+    const healthy = guidedSetup({ guidance: 'kept' });
+    expect((await run(healthy.executor)).guidance).toBe('kept');
+  });
+
+  it('is per executor, so a new session receives it again', async () => {
+    const { build } = guidedSetup({ guidance: 'fresh' });
+    const first = build();
+    await run(first);
+    expect((await run(first)).guidance).toBeUndefined();
+    expect((await run(build())).guidance).toBe('fresh');
+  });
+});

--- a/src/execution/executor.spec.ts
+++ b/src/execution/executor.spec.ts
@@ -665,3 +665,74 @@ describe('ToolExecutor — result guidance', () => {
     expect((await run(build())).guidance).toBe('fresh');
   });
 });
+
+describe('ToolExecutor — result guidance on the mutating paths', () => {
+  /**
+   * A mutating tool whose plan can be made to fail everywhere. The read-only
+   * block above covers the SUCCESS gate; these cover the two other routes that
+   * reach a RESULTS outcome, one of which `results()` names in its comment as
+   * falling out of that gate rather than being handled separately.
+   */
+  function mutatingSetup(options: { planFails?: boolean } = {}) {
+    const registry = new SystemRegistry();
+    for (const name of ['a', 'b']) {
+      registry.add({ name, client: {} as TrueNasApiClient } as SystemHandle);
+    }
+    const tool: MutatingTool = {
+      name: 'guided_write',
+      description: 'selection text',
+      resultGuidance: 'how to read what came back',
+      inputSchema: { type: 'object', properties: {} },
+      requiredRole: Role.Full,
+      mutating: true,
+      destructiveness: 'reversible',
+      plan: async ({ system }) => {
+        if (options.planFails) {
+          throw new Error(`cannot plan on ${system.name}`);
+        }
+        return [{ method: 'write', params: {}, description: `write on ${system.name}` }];
+      },
+      execute: async ({ system }) => ({ written: system.name }),
+    };
+    const catalog = new ToolCatalog();
+    catalog.register(tool);
+    const confirmations = new ConfirmationService();
+    return {
+      confirmations,
+      executor: new ToolExecutor({ catalog, registry, confirmations }),
+    };
+  }
+
+  it('does not spend the delivery on a plan that failed on every system', async () => {
+    // The all-ERROR gate reaching the path that returns steps as RESULTS.
+    const { executor } = mutatingSetup({ planFails: true });
+    const outcome = await executor.execute('guided_write', { systems: 'all' });
+    expect(outcome.type).toBe('RESULTS');
+    if (outcome.type !== 'RESULTS') {
+      throw new Error('expected RESULTS');
+    }
+    expect(outcome.results.every((r) => r.status === 'ERROR')).toBe(true);
+    expect(outcome.guidance).toBeUndefined();
+  });
+
+  it('attaches it to the confirmed execution, and not to the plan before it', async () => {
+    const { executor, confirmations } = mutatingSetup();
+    const planned = await executor.execute('guided_write', { systems: 'all' });
+    if (planned.type !== 'PLAN') {
+      throw new Error('expected PLAN');
+    }
+    // A plan is approval text, not data — guidance is about reading a result,
+    // and the PLAN arm has nowhere to carry it.
+    expect(planned).not.toHaveProperty('guidance');
+
+    const token = confirmations.mint(planned.key);
+    const executed = await executor.execute('guided_write', {
+      systems: 'all',
+      confirmation_token: token,
+    });
+    if (executed.type !== 'RESULTS') {
+      throw new Error('expected RESULTS');
+    }
+    expect(executed.guidance).toBe('how to read what came back');
+  });
+});

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -37,7 +37,18 @@ export type ExecutionOutcome =
       key: string;
       message: string;
     }
-  | { type: 'RESULTS'; tool: string; results: SystemResult<unknown>[] };
+  | {
+      type: 'RESULTS';
+      tool: string;
+      results: SystemResult<unknown>[];
+      /**
+       * The tool's {@link Tool.resultGuidance}, present only on the first
+       * result this executor returns for it that carries any data. An adapter
+       * renders it alongside the results; absent means it has already been
+       * delivered in this session, or the tool declares none.
+       */
+      guidance?: string;
+    };
 
 export interface ToolExecutorOptions {
   catalog: ToolCatalog;
@@ -69,6 +80,16 @@ export class ToolExecutor {
   private readonly roleMapper: RoleMapper;
   private readonly now: () => number;
   private readonly onAuditError: (error: unknown, event: AuditEvent) => void;
+  /**
+   * Tools whose {@link Tool.resultGuidance} has already been delivered. Held
+   * on the instance, which is what makes "once per session" true: both
+   * deployment modes build one executor per session, the same assumption
+   * {@link ConfirmationService} already makes about pending tokens. A
+   * deployment that shared one executor across sessions would leak this — and
+   * would have to re-scope the confirmation store in the same change, so the
+   * two move together or neither does.
+   */
+  private readonly guidanceDelivered = new Set<string>();
 
   constructor(options: ToolExecutorOptions) {
     this.catalog = options.catalog;
@@ -124,7 +145,7 @@ export class ToolExecutor {
       if (fanned.length > 0) {
         this.record(tool, 'read', rawToolArgs, fanned);
       }
-      return { type: 'RESULTS', tool: tool.name, results };
+      return this.results(tool, results);
     }
 
     // Mutating: the role gate is all-or-nothing — the plan the user approves
@@ -173,7 +194,7 @@ export class ToolExecutor {
       // returning a confirmable PLAN would let the LLM mint a token for an
       // execution the core already knows cannot proceed as planned.
       if (steps.every((step) => step.status === 'ERROR')) {
-        return { type: 'RESULTS', tool: tool.name, results: steps };
+        return this.results(tool, steps);
       }
       const planned = steps
         .filter((step) => step.status === 'SUCCESS')
@@ -226,7 +247,33 @@ export class ToolExecutor {
     }
     const results = await fanOut(targets, (system) => tool.execute({ system }, args));
     this.record(tool, 'execute', args, results);
-    return { type: 'RESULTS', tool: tool.name, results };
+    return this.results(tool, results);
+  }
+
+  /**
+   * Builds a RESULTS outcome, attaching the tool's result guidance the first
+   * time in this session that it answers with any data.
+   *
+   * **At least one SUCCESS is required, and that is the whole rule.** Guidance
+   * says how to read values; a result carrying none has nothing to read, so
+   * spending the one delivery on it would leave the caller unguided for every
+   * later call that does carry data. It also means a plan that failed on every
+   * system — returned as RESULTS above rather than as an approvable plan —
+   * never consumes it, without that path needing to know this exists.
+   *
+   * Marked delivered only when it is actually attached, so a tool that never
+   * succeeds keeps its guidance for the call that eventually does.
+   */
+  private results(tool: Tool, results: SystemResult<unknown>[]): ExecutionOutcome {
+    const outcome = { type: 'RESULTS' as const, tool: tool.name, results };
+    if (tool.resultGuidance === undefined || this.guidanceDelivered.has(tool.name)) {
+      return outcome;
+    }
+    if (!results.some((result) => result.status === 'SUCCESS')) {
+      return outcome;
+    }
+    this.guidanceDelivered.add(tool.name);
+    return { ...outcome, guidance: tool.resultGuidance };
   }
 
   /** Splits targets into role-satisfying systems and structured denials. */

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -44,8 +44,13 @@ export type ExecutionOutcome =
       /**
        * The tool's {@link Tool.resultGuidance}, present only on the first
        * result this executor returns for it that carries any data. An adapter
-       * renders it alongside the results; absent means it has already been
-       * delivered in this session, or the tool declares none.
+       * renders it alongside the results.
+       *
+       * **Absent has three causes and they are not equivalent.** The tool
+       * declares none; it was already delivered earlier in this session; or
+       * this particular result carried no SUCCESS, in which case it is STILL
+       * OWED and arrives with the next result that does. An adapter must not
+       * read absence as "the caller has it".
        */
       guidance?: string;
     };

--- a/src/tools/fleet.spec.ts
+++ b/src/tools/fleet.spec.ts
@@ -1111,14 +1111,17 @@ describe('fleet_compliance_report — result guidance', () => {
    * text, so nothing could catch it. These pin the two properties that would
    * have. Fifty-three more tools take the same edit.
    */
-  it('carries guidance that is a verbatim slice of the description', () => {
-    // While the two overlap this is the whole integrity check: any reflow that
-    // reworded, rewrapped or dropped a line breaks it. The follow-up that
-    // removes the text from `description` replaces this with the assertions
-    // below, which stand on their own.
+  it('appends the same guidance text it delivers, from one source', () => {
+    // Structural rather than held here: both fields reference one hoisted
+    // const, so a reflow cannot drop a line from one copy — there is no second
+    // copy. This asserts the arrangement rather than the text, and it is what
+    // fails if someone reintroduces a literal in either field.
     expect(fleetComplianceReport.description).toContain(
       fleetComplianceReport.resultGuidance ?? '',
     );
+    expect(fleetComplianceReport.description.endsWith(
+      fleetComplianceReport.resultGuidance ?? '',
+    )).toBe(true);
   });
 
   it('states the expiry horizon and the entry cap, both interpolated', () => {

--- a/src/tools/fleet.spec.ts
+++ b/src/tools/fleet.spec.ts
@@ -1102,3 +1102,53 @@ describe('fleet_health_rollup', () => {
     expect(fleetHealthRollup.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 });
+
+describe('fleet_compliance_report — result guidance', () => {
+  /**
+   * The prose split (#131) is a text edit over a 10KB literal, and the first
+   * attempt at it silently dropped two lines built from template literals with
+   * all four CI jobs green — nothing in the repository asserted description
+   * text, so nothing could catch it. These pin the two properties that would
+   * have. Fifty-three more tools take the same edit.
+   */
+  it('carries guidance that is a verbatim slice of the description', () => {
+    // While the two overlap this is the whole integrity check: any reflow that
+    // reworded, rewrapped or dropped a line breaks it. The follow-up that
+    // removes the text from `description` replaces this with the assertions
+    // below, which stand on their own.
+    expect(fleetComplianceReport.description).toContain(
+      fleetComplianceReport.resultGuidance ?? '',
+    );
+  });
+
+  it('states the expiry horizon and the entry cap, both interpolated', () => {
+    // Exactly the two lines round one lost: each is a template literal, so a
+    // pass that handles only quoted strings drops them and leaves prose that
+    // still reads as a sentence.
+    const guidance = fleetComplianceReport.resultGuidance ?? '';
+    expect(guidance).toContain('`expiring_soon` how many have 30 days or fewer left');
+    expect(guidance).toContain('are capped, at 10 entries each');
+  });
+
+  it('keeps the readings a caller cannot take from a value it does not have', () => {
+    const guidance = fleetComplianceReport.resultGuidance ?? '';
+    expect(guidance).toContain('A HOLE IS NEVER A PASS');
+    expect(guidance).toContain('NULL IS NEVER "AUDITING IS OFF"');
+    expect(guidance).toContain('NO CERTIFICATE OR PRIVATE KEY MATERIAL IS RETURNED');
+  });
+
+  it('leaves the no-verdict claim where a caller reads it before choosing', () => {
+    // The one caveat that must NOT move: someone asking "are we compliant?"
+    // has already chosen this tool by the time a result exists.
+    expect(fleetComplianceReport.description).toContain(
+      'THIS TOOL STATES NO COMPLIANCE VERDICT AND NEVER WILL',
+    );
+  });
+
+  it('renders no stray escape into either field', () => {
+    // Round one double-escaped apostrophes, which `--word-diff` cannot see:
+    // backslashes fall outside its word regex.
+    expect(fleetComplianceReport.description).not.toContain('\\');
+    expect(fleetComplianceReport.resultGuidance).not.toContain('\\');
+  });
+});

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -897,7 +897,148 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'being audited against — the framework, the policy, the customer ' +
     'contract — is not this tool\'s to assert, so it reports the facts and the ' +
     'auditor decides. Any pass/fail reading of this report is the READER\'s ' +
-    'judgement and not the system\'s.',
+    'judgement and not the system\'s. `system` is the system every fact below ' +
+    'came from, repeated on each entry of `unreadable` so that lines collected ' +
+    'from several systems stay attributable one by one. `unreadable` is every ' +
+    'fact this report could NOT establish, each with the `section` it belongs ' +
+    'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
+    'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
+    '`unreadable` is the narrow claim that every fact below was actually read. ' +
+    'Each of the five sections carries `unavailable`: null where it was read, ' +
+    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
+    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
+    'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
+    'SUBSYSTEM DID. ' +
+    '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
+    'matters here more than anywhere else in this report. `recording` is true ' +
+    'ONLY where the audit trail was read and held at least one entry, which is ' +
+    'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
+    'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
+    'nothing and is indistinguishable from a system that is not auditing at ' +
+    'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
+    'that setting is `audit.config` on the middleware, and `audit_config` is ' +
+    'the tool that reads it. CALL IT ON A NULL `recording` rather than reading ' +
+    'the null as an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
+    '`MIDDLEWARE` TRAIL: every tool in this catalog reaches the system through ' +
+    'the middleware API, so a call this assistant makes lands in the trail this ' +
+    'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
+    'assistant has been used inside the window. The trails that carry evidence ' +
+    'of activity this assistant did not generate are the other ones. ' +
+    '`entries_seen` is how many entries came ' +
+    'back inside the window and `by_service` counts them per trail, busiest ' +
+    'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
+    '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
+    'null on entries whose own trail the system did not name, which is one ' +
+    'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
+    'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
+    '`truncated`. `window_start` is the instant the ' +
+    'trail was read from — the last 24 hours — and `truncated` says the trail ' +
+    'holds more entries in that window than were counted, because the read ' +
+    'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
+    'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
+    'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
+    'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
+    '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
+    'inside the window. Call `audit_log_query` narrowed to one service to ' +
+    'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
+    'what they did, which is `audit_log_query`\'s answer and not this one. ' +
+    '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
+    'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
+    'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
+    'certificate the system calls expired is counted and listed as expired ' +
+    'however many days its date appears to leave, because the two can disagree ' +
+    'and being silent about one the system itself calls expired is the one ' +
+    'answer this section must never give. `reported` is how many certificates ' +
+    'the ' +
+    'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
+    `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
+    '`expiry_unknown` how many reported no expiry date this report could read ' +
+    '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
+    'the ones to look at by hand. The three counts and `reported` are over ' +
+    'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
+    'was counted against, so the count is readable against the window it was ' +
+    'taken from; it is fixed rather than an argument, so that one system\'s ' +
+    'report can be compared with another\'s. `entries` lists the certificates ' +
+    'in those three ' +
+    'categories individually and lists no comfortably-valid one, ALREADY-' +
+    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
+    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
+    'found; certificates in the same category keep the order the system listed ' +
+    'them in, which is not an ordering by date. Each entry carries its ' +
+    '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
+    '`days_until_expiry` — negative where it has already expired, by that many ' +
+    'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
+    'with the day count beside it, in which case both are worth reading and ' +
+    'neither is corrected here; `expired` is null where the system gave no ' +
+    'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
+    'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
+    'RETURNED. `directory_service` reports where this system gets its ' +
+    'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
+    'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
+    'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
+    '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
+    'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
+    'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
+    'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
+    '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
+    'the configuration was read and did not say — again named in `unreadable`. ' +
+    '`domain`, `server_urls` and ' +
+    '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
+    'identified by `server_urls` instead, and `server_urls` is null for Active ' +
+    'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
+    'holding an entry this report could not read is null rather than the ' +
+    'readable part of it, since a partial list names a different set of servers ' +
+    'from the one the system holds — and `unreadable` says when that happened, ' +
+    'so a null there can be told from the Active Directory case where the ' +
+    'system carries no such list at all. `credential_type` names HOW the system ' +
+    'binds and NEVER ' +
+    'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
+    'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
+    'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
+    '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
+    'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
+    'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
+    'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
+    'and NFS shares the system holds, `enabled` how many are switched on, ' +
+    '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
+    'switch this report could read — counted apart from `disabled` because a ' +
+    'share not shown to be off must not be counted as one. `by_protocol` ' +
+    'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
+    'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
+    'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
+    'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
+    '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
+    'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
+    'share, and nothing in this section is evidence that a share is reachable ' +
+    'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
+    'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
+    'STAYS NULL — the other protocol was read — and every count and entry here ' +
+    'is over the protocol that answered. `unreadable` names the one that did ' +
+    'not, and while it does, `reported` is a floor rather than a total and a ' +
+    'share not appearing is not evidence it does not exist. `unavailable` is ' +
+    'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
+    'devices rather than filesystem paths and are not counted as shares — see ' +
+    '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
+    'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
+    'NOT COMPLETE, which is not "no update available" — that system may have ' +
+    'gone unchecked for months. `current_version` is what it runs now and comes ' +
+    'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
+    '`train` are null while `update_available` is null, because they come from ' +
+    'the status the check did not produce. `check_error` and `version_error` ' +
+    'name those two failures independently, and `current_version` null with ' +
+    '`version_error` null is a THIRD case — the read worked and named no ' +
+    'version — which `unreadable` states rather than leaving as a bare null. ' +
+    'EVERY COUNT IS COMPUTED OVER ' +
+    'EVERYTHING THE SECTION READ, and only the two lists — ' +
+    '`certificates.entries` and `shares.entries` — are capped, at ' +
+    `${MAX_LISTED} entries each with a ` +
+    '`truncated` flag saying whether anything was left out. So ' +
+    'truncation can drop the line describing a certificate or a share and can ' +
+    'never drop it from the counts. This tool only reads. It does not change a ' +
+    'setting, renew a certificate, join or leave a directory, alter a share, ' +
+    'change what is audited, or install an update. NO field beyond those named ' +
+    'here is returned, whatever a later TrueNAS release adds to any of the five ' +
+    'underlying responses.',
   resultGuidance:
     '`system` is the system every fact below ' +
     'came from, repeated on each entry of `unreadable` so that lines collected ' +

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -888,32 +888,35 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'composes five read-only tools and adds nothing of its own — ' +
     '`audit_log_query` for the audit trail, `certificates_list` for expiry, ' +
     '`directory_services_status` for where identities come from, `shares_list` ' +
-    'for what is exposed to the network, and `system_update_status` for ' +
-    'whether the system is patched. Each of those reports its subject in far ' +
-    'more detail; this reports the part an auditor asks about, and a fact ' +
-    'worth following up is the cue to call that tool for the rest. THIS TOOL ' +
-    'STATES NO COMPLIANCE VERDICT AND NEVER WILL. It does not say whether a ' +
-    'system passes, and there is no field here that scores one: the standard ' +
-    'being audited against — the framework, the policy, the customer ' +
-    'contract — is not this tool\'s to assert, so it reports the facts and the ' +
-    'auditor decides. Any pass/fail reading of this report is the READER\'s ' +
-    'judgement and not the system\'s. `system` is the system every fact below ' +
-    'came from, repeated on each entry of `unreadable` so that lines collected ' +
-    'from several systems stay attributable one by one. `unreadable` is every ' +
-    'fact this report could NOT establish, each with the `section` it belongs ' +
-    'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
-    'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
-    '`unreadable` is the narrow claim that every fact below was actually read. ' +
-    'Each of the five sections carries `unavailable`: null where it was read, ' +
-    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
-    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
-    'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
-    'SUBSYSTEM DID. ' +
-    '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
-    'matters here more than anywhere else in this report. `recording` is true ' +
-    'ONLY where the audit trail was read and held at least one entry, which is ' +
-    'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
-    'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
+    'for what is exposed to the network, and `system_update_status` for whether ' +
+    'the system is patched. Each of those reports its subject in far more ' +
+    'detail; this reports the part an auditor asks about, and a fact worth ' +
+    'following up is the cue to call that tool for the rest. THIS TOOL STATES ' +
+    'NO COMPLIANCE VERDICT AND NEVER WILL. It does not say whether a system ' +
+    'passes, and there is no field here that scores one: the standard being ' +
+    'audited against — the framework, the policy, the customer contract — is ' +
+    'not this tool\\\'s to assert, so it reports the facts and the auditor ' +
+    'decides. Any pass/fail reading of this report is the READER\\\'s judgement ' +
+    'and not the system\\\'s. This tool only reads. It does not change a setting, ' +
+    'renew a certificate, join or leave a directory, alter a share, change what ' +
+    'is audited, or install an update.',
+  resultGuidance:
+    '`system` is the system every fact below came from, repeated on each entry ' +
+    'of `unreadable` so that lines collected from several systems stay ' +
+    'attributable one by one. `unreadable` is every fact this report could NOT ' +
+    'establish, each with the `section` it belongs to and a `detail` stating it ' +
+    'in words. IT IS NOT A LIST OF FAULTS — it is the list of holes in the ' +
+    'report, and A HOLE IS NEVER A PASS: an empty `unreadable` is the narrow ' +
+    'claim that every fact below was actually read. Each of the five sections ' +
+    'carries `unavailable`: null where it was read, and otherwise the reason it ' +
+    'could not be, IN WHICH CASE EVERY OTHER FIELD OF THAT SECTION IS NULL — ' +
+    'null there means "not read", never "nothing to report" and never "nothing ' +
+    'wrong". THIS TOOL NEVER FAILS BECAUSE ONE SUBSYSTEM DID. `auditing` ' +
+    'REPORTS THE TRAIL AND NOT THE SETTING, and the difference matters here ' +
+    'more than anywhere else in this report. `recording` is true ONLY where the ' +
+    'audit trail was read and held at least one entry, which is proof the ' +
+    'system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS NEVER ' +
+    '"AUDITING IS OFF": a system nobody touched inside the window records ' +
     'nothing and is indistinguishable from a system that is not auditing at ' +
     'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
     'that setting is `audit.config` on the middleware, and `audit_config` is ' +
@@ -924,65 +927,61 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
     'assistant has been used inside the window. The trails that carry evidence ' +
     'of activity this assistant did not generate are the other ones. ' +
-    '`entries_seen` is how many entries came ' +
-    'back inside the window and `by_service` counts them per trail, busiest ' +
-    'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
-    '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
-    'null on entries whose own trail the system did not name, which is one ' +
-    'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
-    'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
-    '`truncated`. `window_start` is the instant the ' +
-    'trail was read from — the last 24 hours — and `truncated` says the trail ' +
-    'holds more entries in that window than were counted, because the read ' +
-    'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
-    'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
-    'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
-    'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
-    '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
-    'inside the window. Call `audit_log_query` narrowed to one service to ' +
-    'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
-    'what they did, which is `audit_log_query`\'s answer and not this one. ' +
-    '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
-    'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
-    'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
+    '`entries_seen` is how many entries came back inside the window and ' +
+    '`by_service` counts them per trail, busiest first, so a trail that IS ' +
+    'recording can be named — `MIDDLEWARE`, `SMB`, `SUDO`, `SYSTEM`, or a name ' +
+    'a later TrueNAS release adds; `service` is null on entries whose own trail ' +
+    'the system did not name, which is one count and not a missing one. A ' +
+    'SERVICE MISSING FROM `by_service` IS NEVER EVIDENCE THAT IT IS NOT ' +
+    'AUDITED, and what its absence DOES mean depends on `truncated`. ' +
+    '`window_start` is the instant the trail was read from — the last 24 hours ' +
+    '— and `truncated` says the trail holds more entries in that window than ' +
+    'were counted, because the read stops at a fixed bound. WHILE `truncated` ' +
+    'IS TRUE, `entries_seen` AND EVERY COUNT IN `by_service` ARE FLOORS, and a ' +
+    'service missing from it may simply not have fitted — a busy `MIDDLEWARE` ' +
+    'trail can fill the bound on its own and push every `SMB` entry out of the ' +
+    'answer. ONLY WHERE `truncated` IS FALSE does a missing service mean it ' +
+    'recorded nothing inside the window. Call `audit_log_query` narrowed to one ' +
+    'service to settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those ' +
+    'name people and what they did, which is `audit_log_query`\\\'s answer and ' +
+    'not this one. `certificates` reports expiry. EACH CERTIFICATE IS PLACED BY ' +
+    'THE SYSTEM\\\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ' +
+    'ONLY WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
     'certificate the system calls expired is counted and listed as expired ' +
     'however many days its date appears to leave, because the two can disagree ' +
     'and being silent about one the system itself calls expired is the one ' +
     'answer this section must never give. `reported` is how many certificates ' +
-    'the ' +
-    'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
-    `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
-    '`expiry_unknown` how many reported no expiry date this report could read ' +
-    '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
-    'the ones to look at by hand. The three counts and `reported` are over ' +
-    'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
-    'was counted against, so the count is readable against the window it was ' +
-    'taken from; it is fixed rather than an argument, so that one system\'s ' +
-    'report can be compared with another\'s. `entries` lists the certificates ' +
-    'in those three ' +
-    'categories individually and lists no comfortably-valid one, ALREADY-' +
-    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
-    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
-    'found; certificates in the same category keep the order the system listed ' +
-    'them in, which is not an ordering by date. Each entry carries its ' +
-    '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
-    '`days_until_expiry` — negative where it has already expired, by that many ' +
-    'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
-    'with the day count beside it, in which case both are worth reading and ' +
-    'neither is corrected here; `expired` is null where the system gave no ' +
-    'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
-    'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
-    'RETURNED. `directory_service` reports where this system gets its ' +
-    'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
-    'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
-    'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
-    '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
-    'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
-    'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
-    'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
-    '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
-    'the configuration was read and did not say — again named in `unreadable`. ' +
-    '`domain`, `server_urls` and ' +
+    'the system holds; `expired` how many have already lapsed, `expiring_soon` ' +
+    'how `expiry_unknown` how many reported no expiry date this report could ' +
+    'read — WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and ' +
+    'those are the ones to look at by hand. The three counts and `reported` are ' +
+    'over EVERY certificate. `expiring_within_days` is the horizon ' +
+    '`expiring_soon` was counted against, so the count is readable against the ' +
+    'window it was taken from; it is fixed rather than an argument, so that one ' +
+    'system\\\'s report can be compared with another\\\'s. `entries` lists the ' +
+    'certificates in those three categories individually and lists no ' +
+    'comfortably-valid one, ALREADY-EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY ' +
+    'COULD NOT BE READ, THEN THOSE EXPIRING SOON, so that what survives ' +
+    'truncation is the worst of what was found; certificates in the same ' +
+    'category keep the order the system listed them in, which is not an ' +
+    'ordering by date. Each entry carries its `name`, `common_name`, ' +
+    '`not_after` exactly as the system formatted it, `days_until_expiry` — ' +
+    'negative where it has already expired, by that many days — and `expired`, ' +
+    'WHICH IS THE SYSTEM\\\'S OWN VERDICT and can disagree with the day count ' +
+    'beside it, in which case both are worth reading and neither is corrected ' +
+    'here; `expired` is null where the system gave no verdict, WHICH IS NOT ' +
+    '"NOT EXPIRED" — the day count beside it is then the only reading there is. ' +
+    'NO CERTIFICATE OR PRIVATE KEY MATERIAL IS RETURNED. `directory_service` ' +
+    'reports where this system gets its identities. `service_type` is which of ' +
+    'Active Directory, IPA or LDAP is configured and NULL MEANS NONE IS, which ' +
+    'is the ordinary case and is not a fault; `status` is the live state of the ' +
+    'join — `HEALTHY`, `FAULTED`, `JOINING`, `LEAVING` or `DISABLED` — and ' +
+    '`status_message` what the system said about it. A NULL `status` IS NOT ' +
+    '`HEALTHY`: the system reported no state, and `unreadable` says so. ' +
+    '`enabled` is the SETTING rather than the state, and a service can be ' +
+    'enabled and `FAULTED` at once; A NULL `enabled` IS NOT `false`, and where ' +
+    'it is null with `config_error` null the configuration was read and did not ' +
+    'say — again named in `unreadable`. `domain`, `server_urls` and ' +
     '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
     'identified by `server_urls` instead, and `server_urls` is null for Active ' +
     'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
@@ -991,54 +990,49 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'from the one the system holds — and `unreadable` says when that happened, ' +
     'so a null there can be told from the Active Directory case where the ' +
     'system carries no such list at all. `credential_type` names HOW the system ' +
-    'binds and NEVER ' +
-    'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
-    'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
-    'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
-    '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
-    'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
-    'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
-    'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
-    'and NFS shares the system holds, `enabled` how many are switched on, ' +
-    '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
-    'switch this report could read — counted apart from `disabled` because a ' +
-    'share not shown to be off must not be counted as one. `by_protocol` ' +
-    'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
-    'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
-    'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
-    'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
-    '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
-    'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
-    'share, and nothing in this section is evidence that a share is reachable ' +
-    'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
-    'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
-    'STAYS NULL — the other protocol was read — and every count and entry here ' +
-    'is over the protocol that answered. `unreadable` names the one that did ' +
-    'not, and while it does, `reported` is a floor rather than a total and a ' +
-    'share not appearing is not evidence it does not exist. `unavailable` is ' +
-    'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
-    'devices rather than filesystem paths and are not counted as shares — see ' +
-    '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
-    'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
-    'NOT COMPLETE, which is not "no update available" — that system may have ' +
-    'gone unchecked for months. `current_version` is what it runs now and comes ' +
-    'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
-    '`train` are null while `update_available` is null, because they come from ' +
-    'the status the check did not produce. `check_error` and `version_error` ' +
-    'name those two failures independently, and `current_version` null with ' +
-    '`version_error` null is a THIRD case — the read worked and named no ' +
-    'version — which `unreadable` states rather than leaving as a bare null. ' +
-    'EVERY COUNT IS COMPUTED OVER ' +
+    'binds and NEVER WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR ' +
+    'CERTIFICATE PASSES THROUGH THIS TOOL. `config_error` names what the system ' +
+    'said when the configuration read failed, and while it is non-null ' +
+    '`enabled`, `domain`, `server_urls`, `kerberos_realm` and `credential_type` ' +
+    'are all null BECAUSE THEY COULD NOT BE READ rather than because they are ' +
+    'unset — that is a separate read from the status beside it. `shares` ' +
+    'reports WHAT IS EXPOSED AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. ' +
+    '`reported` is how many SMB and NFS shares the system holds, `enabled` how ' +
+    'many are switched on, `disabled` how many are off, and ' +
+    '`enablement_unknown` how many reported no switch this report could read — ' +
+    'counted apart from `disabled` because a share not shown to be off must not ' +
+    'be counted as one. `by_protocol` counts them per protocol. `entries` lists ' +
+    'them individually, SWITCHED-ON SHARES FIRST so that what survives ' +
+    'truncation is what is actually exposed, each with its `protocol`, its `id` ' +
+    '— which is unique only WITHIN a protocol — its `name`, ALWAYS null on an ' +
+    'NFS export, its `path`, and `enabled`. THE HOST RESTRICTIONS, THE SHARE ' +
+    'ACL AND THE FILESYSTEM ACL ARE NOT REPORTED HERE: who may reach one share ' +
+    'is `share_access`, called per share, and nothing in this section is ' +
+    'evidence that a share is reachable by anyone in particular or by everyone. ' +
+    'SMB AND NFS ARE LISTED BY TWO SEPARATE READS AND EITHER CAN FAIL ON ITS ' +
+    'OWN, in which case `unavailable` STAYS NULL — the other protocol was read ' +
+    '— and every count and entry here is over the protocol that answered. ' +
+    '`unreadable` names the one that did not, and while it does, `reported` is ' +
+    'a floor rather than a total and a share not appearing is not evidence it ' +
+    'does not exist. `unavailable` is set only where NEITHER could be listed. ' +
+    'iSCSI and NVMe-oF export block devices rather than filesystem paths and ' +
+    'are not counted as shares — see `iscsi_list` and `nvmeof_list`. `updates` ' +
+    'reports whether the system is patched. `update_available` is true, false, ' +
+    'or NULL WHERE THE CHECK DID NOT COMPLETE, which is not "no update ' +
+    'available" — that system may have gone unchecked for months. ' +
+    '`current_version` is what it runs now and comes from a SEPARATE read, so ' +
+    'it survives a failed check; `new_version` and `train` are null while ' +
+    '`update_available` is null, because they come from the status the check ' +
+    'did not produce. `check_error` and `version_error` name those two failures ' +
+    'independently, and `current_version` null with `version_error` null is a ' +
+    'THIRD case — the read worked and named no version — which `unreadable` ' +
+    'states rather than leaving as a bare null. EVERY COUNT IS COMPUTED OVER ' +
     'EVERYTHING THE SECTION READ, and only the two lists — ' +
-    '`certificates.entries` and `shares.entries` — are capped, at ' +
-    `${MAX_LISTED} entries each with a ` +
-    '`truncated` flag saying whether anything was left out. So ' +
-    'truncation can drop the line describing a certificate or a share and can ' +
-    'never drop it from the counts. This tool only reads. It does not change a ' +
-    'setting, renew a certificate, join or leave a directory, alter a share, ' +
-    'change what is audited, or install an update. NO field beyond those named ' +
-    'here is returned, whatever a later TrueNAS release adds to any of the five ' +
-    'underlying responses.',
+    '`certificates.entries` and `shares.entries` — are capped, at `truncated` ' +
+    'flag saying whether anything was left out. So truncation can drop the line ' +
+    'describing a certificate or a share and can never drop it from the counts. ' +
+    'NO field beyond those named here is returned, whatever a later TrueNAS ' +
+    'release adds to any of the five underlying responses.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -888,35 +888,34 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'composes five read-only tools and adds nothing of its own — ' +
     '`audit_log_query` for the audit trail, `certificates_list` for expiry, ' +
     '`directory_services_status` for where identities come from, `shares_list` ' +
-    'for what is exposed to the network, and `system_update_status` for whether ' +
-    'the system is patched. Each of those reports its subject in far more ' +
-    'detail; this reports the part an auditor asks about, and a fact worth ' +
-    'following up is the cue to call that tool for the rest. THIS TOOL STATES ' +
-    'NO COMPLIANCE VERDICT AND NEVER WILL. It does not say whether a system ' +
-    'passes, and there is no field here that scores one: the standard being ' +
-    'audited against — the framework, the policy, the customer contract — is ' +
-    'not this tool\\\'s to assert, so it reports the facts and the auditor ' +
-    'decides. Any pass/fail reading of this report is the READER\\\'s judgement ' +
-    'and not the system\\\'s. This tool only reads. It does not change a setting, ' +
-    'renew a certificate, join or leave a directory, alter a share, change what ' +
-    'is audited, or install an update.',
+    'for what is exposed to the network, and `system_update_status` for ' +
+    'whether the system is patched. Each of those reports its subject in far ' +
+    'more detail; this reports the part an auditor asks about, and a fact ' +
+    'worth following up is the cue to call that tool for the rest. THIS TOOL ' +
+    'STATES NO COMPLIANCE VERDICT AND NEVER WILL. It does not say whether a ' +
+    'system passes, and there is no field here that scores one: the standard ' +
+    'being audited against — the framework, the policy, the customer ' +
+    'contract — is not this tool\'s to assert, so it reports the facts and the ' +
+    'auditor decides. Any pass/fail reading of this report is the READER\'s ' +
+    'judgement and not the system\'s.',
   resultGuidance:
-    '`system` is the system every fact below came from, repeated on each entry ' +
-    'of `unreadable` so that lines collected from several systems stay ' +
-    'attributable one by one. `unreadable` is every fact this report could NOT ' +
-    'establish, each with the `section` it belongs to and a `detail` stating it ' +
-    'in words. IT IS NOT A LIST OF FAULTS — it is the list of holes in the ' +
-    'report, and A HOLE IS NEVER A PASS: an empty `unreadable` is the narrow ' +
-    'claim that every fact below was actually read. Each of the five sections ' +
-    'carries `unavailable`: null where it was read, and otherwise the reason it ' +
-    'could not be, IN WHICH CASE EVERY OTHER FIELD OF THAT SECTION IS NULL — ' +
-    'null there means "not read", never "nothing to report" and never "nothing ' +
-    'wrong". THIS TOOL NEVER FAILS BECAUSE ONE SUBSYSTEM DID. `auditing` ' +
-    'REPORTS THE TRAIL AND NOT THE SETTING, and the difference matters here ' +
-    'more than anywhere else in this report. `recording` is true ONLY where the ' +
-    'audit trail was read and held at least one entry, which is proof the ' +
-    'system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS NEVER ' +
-    '"AUDITING IS OFF": a system nobody touched inside the window records ' +
+    '`system` is the system every fact below ' +
+    'came from, repeated on each entry of `unreadable` so that lines collected ' +
+    'from several systems stay attributable one by one. `unreadable` is every ' +
+    'fact this report could NOT establish, each with the `section` it belongs ' +
+    'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
+    'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
+    '`unreadable` is the narrow claim that every fact below was actually read. ' +
+    'Each of the five sections carries `unavailable`: null where it was read, ' +
+    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
+    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
+    'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
+    'SUBSYSTEM DID. ' +
+    '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
+    'matters here more than anywhere else in this report. `recording` is true ' +
+    'ONLY where the audit trail was read and held at least one entry, which is ' +
+    'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
+    'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
     'nothing and is indistinguishable from a system that is not auditing at ' +
     'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
     'that setting is `audit.config` on the middleware, and `audit_config` is ' +
@@ -927,61 +926,65 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
     'assistant has been used inside the window. The trails that carry evidence ' +
     'of activity this assistant did not generate are the other ones. ' +
-    '`entries_seen` is how many entries came back inside the window and ' +
-    '`by_service` counts them per trail, busiest first, so a trail that IS ' +
-    'recording can be named — `MIDDLEWARE`, `SMB`, `SUDO`, `SYSTEM`, or a name ' +
-    'a later TrueNAS release adds; `service` is null on entries whose own trail ' +
-    'the system did not name, which is one count and not a missing one. A ' +
-    'SERVICE MISSING FROM `by_service` IS NEVER EVIDENCE THAT IT IS NOT ' +
-    'AUDITED, and what its absence DOES mean depends on `truncated`. ' +
-    '`window_start` is the instant the trail was read from — the last 24 hours ' +
-    '— and `truncated` says the trail holds more entries in that window than ' +
-    'were counted, because the read stops at a fixed bound. WHILE `truncated` ' +
-    'IS TRUE, `entries_seen` AND EVERY COUNT IN `by_service` ARE FLOORS, and a ' +
-    'service missing from it may simply not have fitted — a busy `MIDDLEWARE` ' +
-    'trail can fill the bound on its own and push every `SMB` entry out of the ' +
-    'answer. ONLY WHERE `truncated` IS FALSE does a missing service mean it ' +
-    'recorded nothing inside the window. Call `audit_log_query` narrowed to one ' +
-    'service to settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those ' +
-    'name people and what they did, which is `audit_log_query`\\\'s answer and ' +
-    'not this one. `certificates` reports expiry. EACH CERTIFICATE IS PLACED BY ' +
-    'THE SYSTEM\\\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ' +
-    'ONLY WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
+    '`entries_seen` is how many entries came ' +
+    'back inside the window and `by_service` counts them per trail, busiest ' +
+    'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
+    '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
+    'null on entries whose own trail the system did not name, which is one ' +
+    'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
+    'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
+    '`truncated`. `window_start` is the instant the ' +
+    'trail was read from — the last 24 hours — and `truncated` says the trail ' +
+    'holds more entries in that window than were counted, because the read ' +
+    'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
+    'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
+    'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
+    'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
+    '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
+    'inside the window. Call `audit_log_query` narrowed to one service to ' +
+    'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
+    'what they did, which is `audit_log_query`\'s answer and not this one. ' +
+    '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
+    'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
+    'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
     'certificate the system calls expired is counted and listed as expired ' +
     'however many days its date appears to leave, because the two can disagree ' +
     'and being silent about one the system itself calls expired is the one ' +
     'answer this section must never give. `reported` is how many certificates ' +
-    'the system holds; `expired` how many have already lapsed, `expiring_soon` ' +
-    'how `expiry_unknown` how many reported no expiry date this report could ' +
-    'read — WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and ' +
-    'those are the ones to look at by hand. The three counts and `reported` are ' +
-    'over EVERY certificate. `expiring_within_days` is the horizon ' +
-    '`expiring_soon` was counted against, so the count is readable against the ' +
-    'window it was taken from; it is fixed rather than an argument, so that one ' +
-    'system\\\'s report can be compared with another\\\'s. `entries` lists the ' +
-    'certificates in those three categories individually and lists no ' +
-    'comfortably-valid one, ALREADY-EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY ' +
-    'COULD NOT BE READ, THEN THOSE EXPIRING SOON, so that what survives ' +
-    'truncation is the worst of what was found; certificates in the same ' +
-    'category keep the order the system listed them in, which is not an ' +
-    'ordering by date. Each entry carries its `name`, `common_name`, ' +
-    '`not_after` exactly as the system formatted it, `days_until_expiry` — ' +
-    'negative where it has already expired, by that many days — and `expired`, ' +
-    'WHICH IS THE SYSTEM\\\'S OWN VERDICT and can disagree with the day count ' +
-    'beside it, in which case both are worth reading and neither is corrected ' +
-    'here; `expired` is null where the system gave no verdict, WHICH IS NOT ' +
-    '"NOT EXPIRED" — the day count beside it is then the only reading there is. ' +
-    'NO CERTIFICATE OR PRIVATE KEY MATERIAL IS RETURNED. `directory_service` ' +
-    'reports where this system gets its identities. `service_type` is which of ' +
-    'Active Directory, IPA or LDAP is configured and NULL MEANS NONE IS, which ' +
-    'is the ordinary case and is not a fault; `status` is the live state of the ' +
-    'join — `HEALTHY`, `FAULTED`, `JOINING`, `LEAVING` or `DISABLED` — and ' +
-    '`status_message` what the system said about it. A NULL `status` IS NOT ' +
-    '`HEALTHY`: the system reported no state, and `unreadable` says so. ' +
-    '`enabled` is the SETTING rather than the state, and a service can be ' +
-    'enabled and `FAULTED` at once; A NULL `enabled` IS NOT `false`, and where ' +
-    'it is null with `config_error` null the configuration was read and did not ' +
-    'say — again named in `unreadable`. `domain`, `server_urls` and ' +
+    'the ' +
+    'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
+    `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
+    '`expiry_unknown` how many reported no expiry date this report could read ' +
+    '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
+    'the ones to look at by hand. The three counts and `reported` are over ' +
+    'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
+    'was counted against, so the count is readable against the window it was ' +
+    'taken from; it is fixed rather than an argument, so that one system\'s ' +
+    'report can be compared with another\'s. `entries` lists the certificates ' +
+    'in those three ' +
+    'categories individually and lists no comfortably-valid one, ALREADY-' +
+    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
+    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
+    'found; certificates in the same category keep the order the system listed ' +
+    'them in, which is not an ordering by date. Each entry carries its ' +
+    '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
+    '`days_until_expiry` — negative where it has already expired, by that many ' +
+    'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
+    'with the day count beside it, in which case both are worth reading and ' +
+    'neither is corrected here; `expired` is null where the system gave no ' +
+    'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
+    'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
+    'RETURNED. `directory_service` reports where this system gets its ' +
+    'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
+    'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
+    'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
+    '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
+    'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
+    'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
+    'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
+    '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
+    'the configuration was read and did not say — again named in `unreadable`. ' +
+    '`domain`, `server_urls` and ' +
     '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
     'identified by `server_urls` instead, and `server_urls` is null for Active ' +
     'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
@@ -990,49 +993,54 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'from the one the system holds — and `unreadable` says when that happened, ' +
     'so a null there can be told from the Active Directory case where the ' +
     'system carries no such list at all. `credential_type` names HOW the system ' +
-    'binds and NEVER WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR ' +
-    'CERTIFICATE PASSES THROUGH THIS TOOL. `config_error` names what the system ' +
-    'said when the configuration read failed, and while it is non-null ' +
-    '`enabled`, `domain`, `server_urls`, `kerberos_realm` and `credential_type` ' +
-    'are all null BECAUSE THEY COULD NOT BE READ rather than because they are ' +
-    'unset — that is a separate read from the status beside it. `shares` ' +
-    'reports WHAT IS EXPOSED AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. ' +
-    '`reported` is how many SMB and NFS shares the system holds, `enabled` how ' +
-    'many are switched on, `disabled` how many are off, and ' +
-    '`enablement_unknown` how many reported no switch this report could read — ' +
-    'counted apart from `disabled` because a share not shown to be off must not ' +
-    'be counted as one. `by_protocol` counts them per protocol. `entries` lists ' +
-    'them individually, SWITCHED-ON SHARES FIRST so that what survives ' +
-    'truncation is what is actually exposed, each with its `protocol`, its `id` ' +
-    '— which is unique only WITHIN a protocol — its `name`, ALWAYS null on an ' +
-    'NFS export, its `path`, and `enabled`. THE HOST RESTRICTIONS, THE SHARE ' +
-    'ACL AND THE FILESYSTEM ACL ARE NOT REPORTED HERE: who may reach one share ' +
-    'is `share_access`, called per share, and nothing in this section is ' +
-    'evidence that a share is reachable by anyone in particular or by everyone. ' +
-    'SMB AND NFS ARE LISTED BY TWO SEPARATE READS AND EITHER CAN FAIL ON ITS ' +
-    'OWN, in which case `unavailable` STAYS NULL — the other protocol was read ' +
-    '— and every count and entry here is over the protocol that answered. ' +
-    '`unreadable` names the one that did not, and while it does, `reported` is ' +
-    'a floor rather than a total and a share not appearing is not evidence it ' +
-    'does not exist. `unavailable` is set only where NEITHER could be listed. ' +
-    'iSCSI and NVMe-oF export block devices rather than filesystem paths and ' +
-    'are not counted as shares — see `iscsi_list` and `nvmeof_list`. `updates` ' +
-    'reports whether the system is patched. `update_available` is true, false, ' +
-    'or NULL WHERE THE CHECK DID NOT COMPLETE, which is not "no update ' +
-    'available" — that system may have gone unchecked for months. ' +
-    '`current_version` is what it runs now and comes from a SEPARATE read, so ' +
-    'it survives a failed check; `new_version` and `train` are null while ' +
-    '`update_available` is null, because they come from the status the check ' +
-    'did not produce. `check_error` and `version_error` name those two failures ' +
-    'independently, and `current_version` null with `version_error` null is a ' +
-    'THIRD case — the read worked and named no version — which `unreadable` ' +
-    'states rather than leaving as a bare null. EVERY COUNT IS COMPUTED OVER ' +
+    'binds and NEVER ' +
+    'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
+    'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
+    'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
+    '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
+    'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
+    'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
+    'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
+    'and NFS shares the system holds, `enabled` how many are switched on, ' +
+    '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
+    'switch this report could read — counted apart from `disabled` because a ' +
+    'share not shown to be off must not be counted as one. `by_protocol` ' +
+    'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
+    'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
+    'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
+    'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
+    '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
+    'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
+    'share, and nothing in this section is evidence that a share is reachable ' +
+    'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
+    'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
+    'STAYS NULL — the other protocol was read — and every count and entry here ' +
+    'is over the protocol that answered. `unreadable` names the one that did ' +
+    'not, and while it does, `reported` is a floor rather than a total and a ' +
+    'share not appearing is not evidence it does not exist. `unavailable` is ' +
+    'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
+    'devices rather than filesystem paths and are not counted as shares — see ' +
+    '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
+    'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
+    'NOT COMPLETE, which is not "no update available" — that system may have ' +
+    'gone unchecked for months. `current_version` is what it runs now and comes ' +
+    'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
+    '`train` are null while `update_available` is null, because they come from ' +
+    'the status the check did not produce. `check_error` and `version_error` ' +
+    'name those two failures independently, and `current_version` null with ' +
+    '`version_error` null is a THIRD case — the read worked and named no ' +
+    'version — which `unreadable` states rather than leaving as a bare null. ' +
+    'EVERY COUNT IS COMPUTED OVER ' +
     'EVERYTHING THE SECTION READ, and only the two lists — ' +
-    '`certificates.entries` and `shares.entries` — are capped, at `truncated` ' +
-    'flag saying whether anything was left out. So truncation can drop the line ' +
-    'describing a certificate or a share and can never drop it from the counts. ' +
-    'NO field beyond those named here is returned, whatever a later TrueNAS ' +
-    'release adds to any of the five underlying responses.',
+    '`certificates.entries` and `shares.entries` — are capped, at ' +
+    `${MAX_LISTED} entries each with a ` +
+    '`truncated` flag saying whether anything was left out. So ' +
+    'truncation can drop the line describing a certificate or a share and can ' +
+    'never drop it from the counts. This tool only reads. It does not change a ' +
+    'setting, renew a certificate, join or leave a directory, alter a share, ' +
+    'change what is audited, or install an update. NO field beyond those named ' +
+    'here is returned, whatever a later TrueNAS release adds to any of the five ' +
+    'underlying responses.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/fleet.ts
+++ b/src/tools/fleet.ts
@@ -879,6 +879,164 @@ function updateUnreadable(read: UpdateRead, system: string): Unreadable[] {
  * health composite may, and for what `auditing` is measuring instead of the
  * setting it was asked for.
  */
+/**
+ * The interpretation half of this tool's description (#131), hoisted so the two
+ * fields cannot drift: `description` is this text appended to the selection half,
+ * and `resultGuidance` is this text. One copy means a reflow cannot drop a line
+ * from one of them — the round-one failure on this very literal — and the
+ * follow-up that stops advertising it deletes a reference rather than 140 lines.
+ *
+ * **It ends at the literal's end, so it carries four sentences that are selection
+ * class by `resultGuidance`'s own rule** — the pointers at `audit_config`,
+ * `audit_log_query`, `share_access` and `iscsi_list`/`nvmeof_list`, plus the
+ * read-only statement. A cross-tool pointer tells a caller this tool cannot
+ * answer their question, which is worth knowing BEFORE choosing it. The follow-up
+ * must leave those in `description` rather than deleting the whole reference.
+ */
+const COMPLIANCE_RESULT_GUIDANCE =
+  '`system` is the system every fact below ' +
+  'came from, repeated on each entry of `unreadable` so that lines collected ' +
+  'from several systems stay attributable one by one. `unreadable` is every ' +
+  'fact this report could NOT establish, each with the `section` it belongs ' +
+  'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
+  'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
+  '`unreadable` is the narrow claim that every fact below was actually read. ' +
+  'Each of the five sections carries `unavailable`: null where it was read, ' +
+  'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
+  'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
+  'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
+  'SUBSYSTEM DID. ' +
+  '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
+  'matters here more than anywhere else in this report. `recording` is true ' +
+  'ONLY where the audit trail was read and held at least one entry, which is ' +
+  'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
+  'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
+  'nothing and is indistinguishable from a system that is not auditing at ' +
+  'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
+  'that setting is `audit.config` on the middleware, and `audit_config` is ' +
+  'the tool that reads it. CALL IT ON A NULL `recording` rather than reading ' +
+  'the null as an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
+  '`MIDDLEWARE` TRAIL: every tool in this catalog reaches the system through ' +
+  'the middleware API, so a call this assistant makes lands in the trail this ' +
+  'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
+  'assistant has been used inside the window. The trails that carry evidence ' +
+  'of activity this assistant did not generate are the other ones. ' +
+  '`entries_seen` is how many entries came ' +
+  'back inside the window and `by_service` counts them per trail, busiest ' +
+  'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
+  '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
+  'null on entries whose own trail the system did not name, which is one ' +
+  'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
+  'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
+  '`truncated`. `window_start` is the instant the ' +
+  'trail was read from — the last 24 hours — and `truncated` says the trail ' +
+  'holds more entries in that window than were counted, because the read ' +
+  'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
+  'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
+  'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
+  'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
+  '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
+  'inside the window. Call `audit_log_query` narrowed to one service to ' +
+  'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
+  'what they did, which is `audit_log_query`\'s answer and not this one. ' +
+  '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
+  'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
+  'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
+  'certificate the system calls expired is counted and listed as expired ' +
+  'however many days its date appears to leave, because the two can disagree ' +
+  'and being silent about one the system itself calls expired is the one ' +
+  'answer this section must never give. `reported` is how many certificates ' +
+  'the ' +
+  'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
+  `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
+  '`expiry_unknown` how many reported no expiry date this report could read ' +
+  '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
+  'the ones to look at by hand. The three counts and `reported` are over ' +
+  'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
+  'was counted against, so the count is readable against the window it was ' +
+  'taken from; it is fixed rather than an argument, so that one system\'s ' +
+  'report can be compared with another\'s. `entries` lists the certificates ' +
+  'in those three ' +
+  'categories individually and lists no comfortably-valid one, ALREADY-' +
+  'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
+  'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
+  'found; certificates in the same category keep the order the system listed ' +
+  'them in, which is not an ordering by date. Each entry carries its ' +
+  '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
+  '`days_until_expiry` — negative where it has already expired, by that many ' +
+  'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
+  'with the day count beside it, in which case both are worth reading and ' +
+  'neither is corrected here; `expired` is null where the system gave no ' +
+  'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
+  'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
+  'RETURNED. `directory_service` reports where this system gets its ' +
+  'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
+  'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
+  'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
+  '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
+  'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
+  'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
+  'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
+  '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
+  'the configuration was read and did not say — again named in `unreadable`. ' +
+  '`domain`, `server_urls` and ' +
+  '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
+  'identified by `server_urls` instead, and `server_urls` is null for Active ' +
+  'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
+  'holding an entry this report could not read is null rather than the ' +
+  'readable part of it, since a partial list names a different set of servers ' +
+  'from the one the system holds — and `unreadable` says when that happened, ' +
+  'so a null there can be told from the Active Directory case where the ' +
+  'system carries no such list at all. `credential_type` names HOW the system ' +
+  'binds and NEVER ' +
+  'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
+  'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
+  'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
+  '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
+  'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
+  'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
+  'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
+  'and NFS shares the system holds, `enabled` how many are switched on, ' +
+  '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
+  'switch this report could read — counted apart from `disabled` because a ' +
+  'share not shown to be off must not be counted as one. `by_protocol` ' +
+  'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
+  'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
+  'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
+  'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
+  '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
+  'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
+  'share, and nothing in this section is evidence that a share is reachable ' +
+  'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
+  'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
+  'STAYS NULL — the other protocol was read — and every count and entry here ' +
+  'is over the protocol that answered. `unreadable` names the one that did ' +
+  'not, and while it does, `reported` is a floor rather than a total and a ' +
+  'share not appearing is not evidence it does not exist. `unavailable` is ' +
+  'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
+  'devices rather than filesystem paths and are not counted as shares — see ' +
+  '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
+  'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
+  'NOT COMPLETE, which is not "no update available" — that system may have ' +
+  'gone unchecked for months. `current_version` is what it runs now and comes ' +
+  'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
+  '`train` are null while `update_available` is null, because they come from ' +
+  'the status the check did not produce. `check_error` and `version_error` ' +
+  'name those two failures independently, and `current_version` null with ' +
+  '`version_error` null is a THIRD case — the read worked and named no ' +
+  'version — which `unreadable` states rather than leaving as a bare null. ' +
+  'EVERY COUNT IS COMPUTED OVER ' +
+  'EVERYTHING THE SECTION READ, and only the two lists — ' +
+  '`certificates.entries` and `shares.entries` — are capped, at ' +
+  `${MAX_LISTED} entries each with a ` +
+  '`truncated` flag saying whether anything was left out. So ' +
+  'truncation can drop the line describing a certificate or a share and can ' +
+  'never drop it from the counts. This tool only reads. It does not change a ' +
+  'setting, renew a certificate, join or leave a directory, alter a share, ' +
+  'change what is audited, or install an update. NO field beyond those named ' +
+  'here is returned, whatever a later TrueNAS release adds to any of the five ' +
+  'underlying responses.';
+
 export const fleetComplianceReport: ReadOnlyTool = {
   name: 'fleet_compliance_report',
   description:
@@ -897,291 +1055,9 @@ export const fleetComplianceReport: ReadOnlyTool = {
     'being audited against — the framework, the policy, the customer ' +
     'contract — is not this tool\'s to assert, so it reports the facts and the ' +
     'auditor decides. Any pass/fail reading of this report is the READER\'s ' +
-    'judgement and not the system\'s. `system` is the system every fact below ' +
-    'came from, repeated on each entry of `unreadable` so that lines collected ' +
-    'from several systems stay attributable one by one. `unreadable` is every ' +
-    'fact this report could NOT establish, each with the `section` it belongs ' +
-    'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
-    'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
-    '`unreadable` is the narrow claim that every fact below was actually read. ' +
-    'Each of the five sections carries `unavailable`: null where it was read, ' +
-    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
-    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
-    'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
-    'SUBSYSTEM DID. ' +
-    '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
-    'matters here more than anywhere else in this report. `recording` is true ' +
-    'ONLY where the audit trail was read and held at least one entry, which is ' +
-    'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
-    'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
-    'nothing and is indistinguishable from a system that is not auditing at ' +
-    'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
-    'that setting is `audit.config` on the middleware, and `audit_config` is ' +
-    'the tool that reads it. CALL IT ON A NULL `recording` rather than reading ' +
-    'the null as an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
-    '`MIDDLEWARE` TRAIL: every tool in this catalog reaches the system through ' +
-    'the middleware API, so a call this assistant makes lands in the trail this ' +
-    'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
-    'assistant has been used inside the window. The trails that carry evidence ' +
-    'of activity this assistant did not generate are the other ones. ' +
-    '`entries_seen` is how many entries came ' +
-    'back inside the window and `by_service` counts them per trail, busiest ' +
-    'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
-    '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
-    'null on entries whose own trail the system did not name, which is one ' +
-    'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
-    'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
-    '`truncated`. `window_start` is the instant the ' +
-    'trail was read from — the last 24 hours — and `truncated` says the trail ' +
-    'holds more entries in that window than were counted, because the read ' +
-    'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
-    'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
-    'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
-    'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
-    '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
-    'inside the window. Call `audit_log_query` narrowed to one service to ' +
-    'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
-    'what they did, which is `audit_log_query`\'s answer and not this one. ' +
-    '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
-    'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
-    'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
-    'certificate the system calls expired is counted and listed as expired ' +
-    'however many days its date appears to leave, because the two can disagree ' +
-    'and being silent about one the system itself calls expired is the one ' +
-    'answer this section must never give. `reported` is how many certificates ' +
-    'the ' +
-    'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
-    `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
-    '`expiry_unknown` how many reported no expiry date this report could read ' +
-    '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
-    'the ones to look at by hand. The three counts and `reported` are over ' +
-    'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
-    'was counted against, so the count is readable against the window it was ' +
-    'taken from; it is fixed rather than an argument, so that one system\'s ' +
-    'report can be compared with another\'s. `entries` lists the certificates ' +
-    'in those three ' +
-    'categories individually and lists no comfortably-valid one, ALREADY-' +
-    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
-    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
-    'found; certificates in the same category keep the order the system listed ' +
-    'them in, which is not an ordering by date. Each entry carries its ' +
-    '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
-    '`days_until_expiry` — negative where it has already expired, by that many ' +
-    'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
-    'with the day count beside it, in which case both are worth reading and ' +
-    'neither is corrected here; `expired` is null where the system gave no ' +
-    'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
-    'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
-    'RETURNED. `directory_service` reports where this system gets its ' +
-    'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
-    'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
-    'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
-    '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
-    'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
-    'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
-    'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
-    '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
-    'the configuration was read and did not say — again named in `unreadable`. ' +
-    '`domain`, `server_urls` and ' +
-    '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
-    'identified by `server_urls` instead, and `server_urls` is null for Active ' +
-    'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
-    'holding an entry this report could not read is null rather than the ' +
-    'readable part of it, since a partial list names a different set of servers ' +
-    'from the one the system holds — and `unreadable` says when that happened, ' +
-    'so a null there can be told from the Active Directory case where the ' +
-    'system carries no such list at all. `credential_type` names HOW the system ' +
-    'binds and NEVER ' +
-    'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
-    'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
-    'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
-    '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
-    'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
-    'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
-    'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
-    'and NFS shares the system holds, `enabled` how many are switched on, ' +
-    '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
-    'switch this report could read — counted apart from `disabled` because a ' +
-    'share not shown to be off must not be counted as one. `by_protocol` ' +
-    'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
-    'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
-    'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
-    'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
-    '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
-    'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
-    'share, and nothing in this section is evidence that a share is reachable ' +
-    'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
-    'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
-    'STAYS NULL — the other protocol was read — and every count and entry here ' +
-    'is over the protocol that answered. `unreadable` names the one that did ' +
-    'not, and while it does, `reported` is a floor rather than a total and a ' +
-    'share not appearing is not evidence it does not exist. `unavailable` is ' +
-    'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
-    'devices rather than filesystem paths and are not counted as shares — see ' +
-    '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
-    'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
-    'NOT COMPLETE, which is not "no update available" — that system may have ' +
-    'gone unchecked for months. `current_version` is what it runs now and comes ' +
-    'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
-    '`train` are null while `update_available` is null, because they come from ' +
-    'the status the check did not produce. `check_error` and `version_error` ' +
-    'name those two failures independently, and `current_version` null with ' +
-    '`version_error` null is a THIRD case — the read worked and named no ' +
-    'version — which `unreadable` states rather than leaving as a bare null. ' +
-    'EVERY COUNT IS COMPUTED OVER ' +
-    'EVERYTHING THE SECTION READ, and only the two lists — ' +
-    '`certificates.entries` and `shares.entries` — are capped, at ' +
-    `${MAX_LISTED} entries each with a ` +
-    '`truncated` flag saying whether anything was left out. So ' +
-    'truncation can drop the line describing a certificate or a share and can ' +
-    'never drop it from the counts. This tool only reads. It does not change a ' +
-    'setting, renew a certificate, join or leave a directory, alter a share, ' +
-    'change what is audited, or install an update. NO field beyond those named ' +
-    'here is returned, whatever a later TrueNAS release adds to any of the five ' +
-    'underlying responses.',
-  resultGuidance:
-    '`system` is the system every fact below ' +
-    'came from, repeated on each entry of `unreadable` so that lines collected ' +
-    'from several systems stay attributable one by one. `unreadable` is every ' +
-    'fact this report could NOT establish, each with the `section` it belongs ' +
-    'to and a `detail` stating it in words. IT IS NOT A LIST OF FAULTS — it is ' +
-    'the list of holes in the report, and A HOLE IS NEVER A PASS: an empty ' +
-    '`unreadable` is the narrow claim that every fact below was actually read. ' +
-    'Each of the five sections carries `unavailable`: null where it was read, ' +
-    'and otherwise the reason it could not be, IN WHICH CASE EVERY OTHER FIELD ' +
-    'OF THAT SECTION IS NULL — null there means "not read", never "nothing to ' +
-    'report" and never "nothing wrong". THIS TOOL NEVER FAILS BECAUSE ONE ' +
-    'SUBSYSTEM DID. ' +
-    '`auditing` REPORTS THE TRAIL AND NOT THE SETTING, and the difference ' +
-    'matters here more than anywhere else in this report. `recording` is true ' +
-    'ONLY where the audit trail was read and held at least one entry, which is ' +
-    'proof the system is writing one. IT IS NULL EVERYWHERE ELSE AND NULL IS ' +
-    'NEVER "AUDITING IS OFF": a system nobody touched inside the window records ' +
-    'nothing and is indistinguishable from a system that is not auditing at ' +
-    'all. WHETHER AUDITING IS CONFIGURED ON CANNOT BE ANSWERED BY THIS TOOL — ' +
-    'that setting is `audit.config` on the middleware, and `audit_config` is ' +
-    'the tool that reads it. CALL IT ON A NULL `recording` rather than reading ' +
-    'the null as an answer. TRUE IS ALSO WEAKER THAN IT LOOKS ON THE ' +
-    '`MIDDLEWARE` TRAIL: every tool in this catalog reaches the system through ' +
-    'the middleware API, so a call this assistant makes lands in the trail this ' +
-    'reads, and `MIDDLEWARE` recording is close to self-fulfilling once the ' +
-    'assistant has been used inside the window. The trails that carry evidence ' +
-    'of activity this assistant did not generate are the other ones. ' +
-    '`entries_seen` is how many entries came ' +
-    'back inside the window and `by_service` counts them per trail, busiest ' +
-    'first, so a trail that IS recording can be named — `MIDDLEWARE`, `SMB`, ' +
-    '`SUDO`, `SYSTEM`, or a name a later TrueNAS release adds; `service` is ' +
-    'null on entries whose own trail the system did not name, which is one ' +
-    'count and not a missing one. A SERVICE MISSING FROM `by_service` IS NEVER ' +
-    'EVIDENCE THAT IT IS NOT AUDITED, and what its absence DOES mean depends on ' +
-    '`truncated`. `window_start` is the instant the ' +
-    'trail was read from — the last 24 hours — and `truncated` says the trail ' +
-    'holds more entries in that window than were counted, because the read ' +
-    'stops at a fixed bound. WHILE `truncated` IS TRUE, `entries_seen` AND ' +
-    'EVERY COUNT IN `by_service` ARE FLOORS, and a service missing from it may ' +
-    'simply not have fitted — a busy `MIDDLEWARE` trail can fill the bound on ' +
-    'its own and push every `SMB` entry out of the answer. ONLY WHERE ' +
-    '`truncated` IS FALSE does a missing service mean it recorded nothing ' +
-    'inside the window. Call `audit_log_query` narrowed to one service to ' +
-    'settle it either way. NO AUDIT ENTRY ITSELF IS RETURNED: those name people and ' +
-    'what they did, which is `audit_log_query`\'s answer and not this one. ' +
-    '`certificates` reports expiry. EACH CERTIFICATE IS PLACED BY THE ' +
-    'SYSTEM\'S OWN `expired` VERDICT FIRST AND BY THE COMPUTED DAY COUNT ONLY ' +
-    'WHERE THE SYSTEM GAVE NO VERDICT OR SAID IT HAS NOT EXPIRED — so a ' +
-    'certificate the system calls expired is counted and listed as expired ' +
-    'however many days its date appears to leave, because the two can disagree ' +
-    'and being silent about one the system itself calls expired is the one ' +
-    'answer this section must never give. `reported` is how many certificates ' +
-    'the ' +
-    'system holds; `expired` how many have already lapsed, `expiring_soon` how ' +
-    `many have ${EXPIRY_HORIZON_DAYS} days or fewer left, and ` +
-    '`expiry_unknown` how many reported no expiry date this report could read ' +
-    '— WHICH IS NOT "DOES NOT EXPIRE", every certificate expires, and those are ' +
-    'the ones to look at by hand. The three counts and `reported` are over ' +
-    'EVERY certificate. `expiring_within_days` is the horizon `expiring_soon` ' +
-    'was counted against, so the count is readable against the window it was ' +
-    'taken from; it is fixed rather than an argument, so that one system\'s ' +
-    'report can be compared with another\'s. `entries` lists the certificates ' +
-    'in those three ' +
-    'categories individually and lists no comfortably-valid one, ALREADY-' +
-    'EXPIRED ONES FIRST, THEN THOSE WHOSE EXPIRY COULD NOT BE READ, THEN THOSE ' +
-    'EXPIRING SOON, so that what survives truncation is the worst of what was ' +
-    'found; certificates in the same category keep the order the system listed ' +
-    'them in, which is not an ordering by date. Each entry carries its ' +
-    '`name`, `common_name`, `not_after` exactly as the system formatted it, ' +
-    '`days_until_expiry` — negative where it has already expired, by that many ' +
-    'days — and `expired`, WHICH IS THE SYSTEM\'S OWN VERDICT and can disagree ' +
-    'with the day count beside it, in which case both are worth reading and ' +
-    'neither is corrected here; `expired` is null where the system gave no ' +
-    'verdict, WHICH IS NOT "NOT EXPIRED" — the day count beside it is then the ' +
-    'only reading there is. NO CERTIFICATE OR PRIVATE KEY MATERIAL IS ' +
-    'RETURNED. `directory_service` reports where this system gets its ' +
-    'identities. `service_type` is which of Active Directory, IPA or LDAP is ' +
-    'configured and NULL MEANS NONE IS, which is the ordinary case and is not a ' +
-    'fault; `status` is the live state of the join — `HEALTHY`, `FAULTED`, ' +
-    '`JOINING`, `LEAVING` or `DISABLED` — and `status_message` what the system ' +
-    'said about it. A NULL `status` IS NOT `HEALTHY`: the system reported no ' +
-    'state, and `unreadable` says so. `enabled` is the SETTING rather than the ' +
-    'state, and a service can be enabled and `FAULTED` at once; A NULL ' +
-    '`enabled` IS NOT `false`, and where it is null with `config_error` null ' +
-    'the configuration was read and did not say — again named in `unreadable`. ' +
-    '`domain`, `server_urls` and ' +
-    '`kerberos_realm` name the directory: `domain` is null for LDAP, which is ' +
-    'identified by `server_urls` instead, and `server_urls` is null for Active ' +
-    'Directory and IPA. `server_urls` IS REPORTED WHOLE OR NOT AT ALL — a list ' +
-    'holding an entry this report could not read is null rather than the ' +
-    'readable part of it, since a partial list names a different set of servers ' +
-    'from the one the system holds — and `unreadable` says when that happened, ' +
-    'so a null there can be told from the Active Directory case where the ' +
-    'system carries no such list at all. `credential_type` names HOW the system ' +
-    'binds and NEVER ' +
-    'WITH WHAT — NO PASSWORD, BIND PASSWORD, KEYTAB OR CERTIFICATE PASSES ' +
-    'THROUGH THIS TOOL. `config_error` names what the system said when the ' +
-    'configuration read failed, and while it is non-null `enabled`, `domain`, ' +
-    '`server_urls`, `kerberos_realm` and `credential_type` are all null BECAUSE ' +
-    'THEY COULD NOT BE READ rather than because they are unset — that is a ' +
-    'separate read from the status beside it. `shares` reports WHAT IS EXPOSED ' +
-    'AND OVER WHICH PROTOCOL, NOT WHO MAY REACH IT. `reported` is how many SMB ' +
-    'and NFS shares the system holds, `enabled` how many are switched on, ' +
-    '`disabled` how many are off, and `enablement_unknown` how many reported no ' +
-    'switch this report could read — counted apart from `disabled` because a ' +
-    'share not shown to be off must not be counted as one. `by_protocol` ' +
-    'counts them per protocol. `entries` lists them individually, SWITCHED-ON ' +
-    'SHARES FIRST so that what survives truncation is what is actually exposed, ' +
-    'each with its `protocol`, its `id` — which is unique only WITHIN a ' +
-    'protocol — its `name`, ALWAYS null on an NFS export, its `path`, and ' +
-    '`enabled`. THE HOST RESTRICTIONS, THE SHARE ACL AND THE FILESYSTEM ACL ARE ' +
-    'NOT REPORTED HERE: who may reach one share is `share_access`, called per ' +
-    'share, and nothing in this section is evidence that a share is reachable ' +
-    'by anyone in particular or by everyone. SMB AND NFS ARE LISTED BY TWO ' +
-    'SEPARATE READS AND EITHER CAN FAIL ON ITS OWN, in which case `unavailable` ' +
-    'STAYS NULL — the other protocol was read — and every count and entry here ' +
-    'is over the protocol that answered. `unreadable` names the one that did ' +
-    'not, and while it does, `reported` is a floor rather than a total and a ' +
-    'share not appearing is not evidence it does not exist. `unavailable` is ' +
-    'set only where NEITHER could be listed. iSCSI and NVMe-oF export block ' +
-    'devices rather than filesystem paths and are not counted as shares — see ' +
-    '`iscsi_list` and `nvmeof_list`. `updates` reports whether the system is ' +
-    'patched. `update_available` is true, false, or NULL WHERE THE CHECK DID ' +
-    'NOT COMPLETE, which is not "no update available" — that system may have ' +
-    'gone unchecked for months. `current_version` is what it runs now and comes ' +
-    'from a SEPARATE read, so it survives a failed check; `new_version` and ' +
-    '`train` are null while `update_available` is null, because they come from ' +
-    'the status the check did not produce. `check_error` and `version_error` ' +
-    'name those two failures independently, and `current_version` null with ' +
-    '`version_error` null is a THIRD case — the read worked and named no ' +
-    'version — which `unreadable` states rather than leaving as a bare null. ' +
-    'EVERY COUNT IS COMPUTED OVER ' +
-    'EVERYTHING THE SECTION READ, and only the two lists — ' +
-    '`certificates.entries` and `shares.entries` — are capped, at ' +
-    `${MAX_LISTED} entries each with a ` +
-    '`truncated` flag saying whether anything was left out. So ' +
-    'truncation can drop the line describing a certificate or a share and can ' +
-    'never drop it from the counts. This tool only reads. It does not change a ' +
-    'setting, renew a certificate, join or leave a directory, alter a share, ' +
-    'change what is audited, or install an update. NO field beyond those named ' +
-    'here is returned, whatever a later TrueNAS release adds to any of the five ' +
-    'underlying responses.',
+    'judgement and not the system\'s. ' +
+    COMPLIANCE_RESULT_GUIDANCE,
+  resultGuidance: COMPLIANCE_RESULT_GUIDANCE,
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/shares.spec.ts
+++ b/src/tools/shares.spec.ts
@@ -1118,3 +1118,29 @@ describe('share_access', () => {
     expect((await oneEntry({ flags: { INHERIT_ONLY: 'yes' } }))['children_only']).toBeNull();
   });
 });
+
+describe('share_access — result guidance', () => {
+  it('carries guidance that is a verbatim slice of the description', () => {
+    expect(shareAccess.description).toContain(shareAccess.resultGuidance ?? '');
+  });
+
+  it('keeps the inversion that makes an empty list mean its opposite', () => {
+    // The reading most costly to lose: two empty NFS lists are unrestricted
+    // access, not none.
+    const guidance = shareAccess.resultGuidance ?? '';
+    expect(guidance).toContain('AN EMPTY LIST MEANS UNRESTRICTED');
+  });
+
+  it('leaves how to name the share where a caller reads it before choosing', () => {
+    // Selection text: which string to pass, and that a non-match or an
+    // ambiguous match is an error rather than an empty result.
+    const description = shareAccess.description;
+    expect(description).toContain('A string matching NO share is an error');
+    expect(description).toContain('A string matching MORE THAN one share is also an error');
+  });
+
+  it('renders no stray escape into either field', () => {
+    expect(shareAccess.description).not.toContain('\\');
+    expect(shareAccess.resultGuidance).not.toContain('\\');
+  });
+});

--- a/src/tools/shares.spec.ts
+++ b/src/tools/shares.spec.ts
@@ -1120,8 +1120,11 @@ describe('share_access', () => {
 });
 
 describe('share_access — result guidance', () => {
-  it('carries guidance that is a verbatim slice of the description', () => {
+  it('appends the same guidance text it delivers, from one source', () => {
+    // See fleet.spec.ts: one hoisted const backs both fields, so this asserts
+    // the arrangement rather than holding the text.
     expect(shareAccess.description).toContain(shareAccess.resultGuidance ?? '');
+    expect(shareAccess.description.endsWith(shareAccess.resultGuidance ?? '')).toBe(true);
   });
 
   it('keeps the inversion that makes an empty list mean its opposite', () => {

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -673,6 +673,132 @@ function ambiguous(selector: Selector, matches: AccessTarget[]): Error {
   );
 }
 
+/**
+ * The interpretation half of this tool's description (#131), hoisted so the two
+ * fields cannot drift: `description` is this text appended to the selection half,
+ * and `resultGuidance` is this text. One copy means a reflow cannot drop a line
+ * from one of them — the round-one failure on this very literal — and the
+ * follow-up that stops advertising it deletes a reference rather than 140 lines.
+ *
+ * **It ends at the literal's end, so it carries four sentences that are selection
+ * class by `resultGuidance`'s own rule** — the pointers at `audit_config`,
+ * `audit_log_query`, `share_access` and `iscsi_list`/`nvmeof_list`, plus the
+ * read-only statement. A cross-tool pointer tells a caller this tool cannot
+ * answer their question, which is worth knowing BEFORE choosing it. The follow-up
+ * must leave those in `description` rather than deleting the whole reference.
+ */
+const SHARE_ACCESS_RESULT_GUIDANCE =
+  '`failures` reports a protocol whose ' +
+  'share list could not be read, as `protocol` and `error`, and is empty ' +
+  'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
+  'ONLY ONE: the search for a second match ran over a list that was never ' +
+  'read, so a share of the protocol named there may also answer to the ' +
+  'string given, and the error this tool would otherwise raise is one it ' +
+  'could not detect. `protocol`, `id`, `name`, `path` ' +
+  'and `enabled` identify the share and mean exactly what they mean in ' +
+  '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
+  'that a disabled share reaches nobody whatever the rest of this says. ' +
+  'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
+  'is reached only by a principal that every layer reporting on it allows. ' +
+  '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
+  'share or export is served read-only whatever its ACLs say — and null is a ' +
+  'switch the system reported no value for, which is not the same as false. ' +
+  '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
+  'applied by the SMB service before either ACL below is consulted, and is ' +
+  'null on an NFS export, which is not served by that service. Within it, ' +
+  '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
+  'addresses or subnets — and where both name a machine the SMB service lets ' +
+  'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
+  'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
+  'here. Null is not that: it means the system reported no list this tool ' +
+  'could read — the field absent, the share\'s `options` absent, or a list ' +
+  'holding something that is not a host pattern — and it is NOT evidence ' +
+  'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
+  'who may reach it, and is null on ' +
+  'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
+  '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
+  'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
+  'mean any machine that can reach this server may mount it, which is the ' +
+  'opposite of nobody. Null is neither: it means the system reported no list ' +
+  'this tool could read — the field absent, or a list holding an entry that ' +
+  'is not a host or a network, since a restriction reported in part is a ' +
+  'different restriction — and it is NOT evidence that the export is ' +
+  'unrestricted. `mapall_user` and `mapall_group`, when ' +
+  'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
+  'that account before the ACL below is consulted, so the ACL then answers ' +
+  'for that one account and not for whoever connected; `maproot_user` and ' +
+  '`maproot_group` do the same for root alone. Each is null where no such ' +
+  'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
+  'front of the filesystem one that can DENY what the path grants, so a ' +
+  'principal allowed below may still be refused here. It and ' +
+  '`share_acl_error` are BOTH null on an NFS export, which has no such layer; ' +
+  'on an SMB share exactly one of them is non-null. Each of its entries names ' +
+  'a principal in whichever of three ways the system had — `name` the ' +
+  'resolved account, `id` with `kind` (`USER` or `GROUP`) the local numeric ' +
+  'id, and `sid` the Windows security identifier of a domain principal — and ' +
+  'an entry that resolved to none of them is reported empty rather than ' +
+  'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
+  '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
+  'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
+  'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
+  'the filesystem ACL on `path`, which ' +
+  'is what decides what each principal may do once connected: over SMB it ' +
+  'applies to whoever the share ACL above already let through, and over NFS ' +
+  'to the ids arriving from a machine the restrictions already let in, after ' +
+  'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
+  'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
+  'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
+  '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
+  'there `entries` is ALWAYS null, whatever list the system reports beside ' +
+  'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
+  'which this tool does not read, so it can say nothing about who has access ' +
+  '— or null where the system named no type, which leaves the entries below ' +
+  'readable but says nothing about which vocabulary they are in. ' +
+  '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
+  'group and everyone else. `owner_user` and `owner_group` are the names of ' +
+  'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
+  'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
+  'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
+  'that holds no entry, and null is either the `DISABLED` path above or a ' +
+  'list the system did not report in a form this tool could read — never ' +
+  'evidence that the ACL grants nothing. `tag` says what kind, and ' +
+  'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
+  'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
+  'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
+  'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
+  'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
+  'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
+  'null on a tag that is its own principal and on `MASK`: the system writes ' +
+  '-1 there, which is reported as null because no account holds it. `name` ' +
+  'is null on those tags too, since they name no separate account for the ' +
+  'system to resolve — a null on one of them is the tag\'s nature rather ' +
+  'than a principal that would not resolve. On a `USER` or `GROUP` ' +
+  'entry `name` is the resolved account or group name and `id` is its raw ' +
+  'numeric id; an id that resolved to no name is reported as `id` beside a ' +
+  'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
+  'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
+  '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
+  '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
+  'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
+  'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
+  '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
+  'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
+  'entry grants only what it and the `MASK` entry both name, so the two are ' +
+  'read together and an entry can appear to hold more than it does. NFS4 has ' +
+  'no mask and no such step. An empty list is an entry that names ' +
+  'permissions and holds none of them; null is one whose permissions could ' +
+  'not be read, and is not evidence that it grants nothing. ' +
+  '`children_only` true means the ' +
+  'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
+  'created inside it, so its principal does not have the access it appears to ' +
+  'have; null is an entry whose inheritance could not be read. This tool ' +
+  'reads access and changes none of it. It does not report Unix mode bits, ' +
+  'the SMB service\'s own bind addresses, which users are members of a group ' +
+  'named here, or whether a dataset is locked by encryption — so a principal ' +
+  'this reports as having access can still be stopped by something outside ' +
+  'these fields, and this is an upper bound on access rather than a proof of ' +
+  'it.';
+
 export const shareAccess: ReadOnlyTool = {
   name: 'share_access',
   description:
@@ -684,227 +810,9 @@ export const shareAccess: ReadOnlyTool = {
     'share nobody can reach are opposite answers. A string matching MORE THAN ' +
     'one share is also an error, listing what it matched — one path can be ' +
     'shared over both protocols at once and the two grant access differently, ' +
-    'so there is no single answer to give. `failures` reports a protocol whose ' +
-    'share list could not be read, as `protocol` and `error`, and is empty ' +
-    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
-    'ONLY ONE: the search for a second match ran over a list that was never ' +
-    'read, so a share of the protocol named there may also answer to the ' +
-    'string given, and the error this tool would otherwise raise is one it ' +
-    'could not detect. `protocol`, `id`, `name`, `path` ' +
-    'and `enabled` identify the share and mean exactly what they mean in ' +
-    '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
-    'that a disabled share reaches nobody whatever the rest of this says. ' +
-    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
-    'is reached only by a principal that every layer reporting on it allows. ' +
-    '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
-    'share or export is served read-only whatever its ACLs say — and null is a ' +
-    'switch the system reported no value for, which is not the same as false. ' +
-    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
-    'applied by the SMB service before either ACL below is consulted, and is ' +
-    'null on an NFS export, which is not served by that service. Within it, ' +
-    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
-    'addresses or subnets — and where both name a machine the SMB service lets ' +
-    'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
-    'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
-    'here. Null is not that: it means the system reported no list this tool ' +
-    'could read — the field absent, the share\'s `options` absent, or a list ' +
-    'holding something that is not a host pattern — and it is NOT evidence ' +
-    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
-    'who may reach it, and is null on ' +
-    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
-    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
-    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
-    'mean any machine that can reach this server may mount it, which is the ' +
-    'opposite of nobody. Null is neither: it means the system reported no list ' +
-    'this tool could read — the field absent, or a list holding an entry that ' +
-    'is not a host or a network, since a restriction reported in part is a ' +
-    'different restriction — and it is NOT evidence that the export is ' +
-    'unrestricted. `mapall_user` and `mapall_group`, when ' +
-    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
-    'that account before the ACL below is consulted, so the ACL then answers ' +
-    'for that one account and not for whoever connected; `maproot_user` and ' +
-    '`maproot_group` do the same for root alone. Each is null where no such ' +
-    'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
-    'front of the filesystem one that can DENY what the path grants, so a ' +
-    'principal allowed below may still be refused here. It and ' +
-    '`share_acl_error` are BOTH null on an NFS export, which has no such layer; ' +
-    'on an SMB share exactly one of them is non-null. Each of its entries names ' +
-    'a principal in whichever of three ways the system had — `name` the ' +
-    'resolved account, `id` with `kind` (`USER` or `GROUP`) the local numeric ' +
-    'id, and `sid` the Windows security identifier of a domain principal — and ' +
-    'an entry that resolved to none of them is reported empty rather than ' +
-    'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
-    '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
-    'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
-    'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
-    'the filesystem ACL on `path`, which ' +
-    'is what decides what each principal may do once connected: over SMB it ' +
-    'applies to whoever the share ACL above already let through, and over NFS ' +
-    'to the ids arriving from a machine the restrictions already let in, after ' +
-    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
-    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
-    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
-    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
-    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
-    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
-    'which this tool does not read, so it can say nothing about who has access ' +
-    '— or null where the system named no type, which leaves the entries below ' +
-    'readable but says nothing about which vocabulary they are in. ' +
-    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
-    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
-    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
-    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
-    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
-    'that holds no entry, and null is either the `DISABLED` path above or a ' +
-    'list the system did not report in a form this tool could read — never ' +
-    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
-    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
-    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
-    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
-    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
-    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
-    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
-    'null on a tag that is its own principal and on `MASK`: the system writes ' +
-    '-1 there, which is reported as null because no account holds it. `name` ' +
-    'is null on those tags too, since they name no separate account for the ' +
-    'system to resolve — a null on one of them is the tag\'s nature rather ' +
-    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
-    'entry `name` is the resolved account or group name and `id` is its raw ' +
-    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
-    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
-    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
-    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
-    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
-    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
-    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
-    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
-    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
-    'entry grants only what it and the `MASK` entry both name, so the two are ' +
-    'read together and an entry can appear to hold more than it does. NFS4 has ' +
-    'no mask and no such step. An empty list is an entry that names ' +
-    'permissions and holds none of them; null is one whose permissions could ' +
-    'not be read, and is not evidence that it grants nothing. ' +
-    '`children_only` true means the ' +
-    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
-    'created inside it, so its principal does not have the access it appears to ' +
-    'have; null is an entry whose inheritance could not be read. This tool ' +
-    'reads access and changes none of it. It does not report Unix mode bits, ' +
-    'the SMB service\'s own bind addresses, which users are members of a group ' +
-    'named here, or whether a dataset is locked by encryption — so a principal ' +
-    'this reports as having access can still be stopped by something outside ' +
-    'these fields, and this is an upper bound on access rather than a proof of ' +
-    'it.',
-  resultGuidance:
-    '`failures` reports a protocol whose ' +
-    'share list could not be read, as `protocol` and `error`, and is empty ' +
-    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
-    'ONLY ONE: the search for a second match ran over a list that was never ' +
-    'read, so a share of the protocol named there may also answer to the ' +
-    'string given, and the error this tool would otherwise raise is one it ' +
-    'could not detect. `protocol`, `id`, `name`, `path` ' +
-    'and `enabled` identify the share and mean exactly what they mean in ' +
-    '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
-    'that a disabled share reaches nobody whatever the rest of this says. ' +
-    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
-    'is reached only by a principal that every layer reporting on it allows. ' +
-    '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
-    'share or export is served read-only whatever its ACLs say — and null is a ' +
-    'switch the system reported no value for, which is not the same as false. ' +
-    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
-    'applied by the SMB service before either ACL below is consulted, and is ' +
-    'null on an NFS export, which is not served by that service. Within it, ' +
-    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
-    'addresses or subnets — and where both name a machine the SMB service lets ' +
-    'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
-    'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
-    'here. Null is not that: it means the system reported no list this tool ' +
-    'could read — the field absent, the share\'s `options` absent, or a list ' +
-    'holding something that is not a host pattern — and it is NOT evidence ' +
-    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
-    'who may reach it, and is null on ' +
-    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
-    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
-    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
-    'mean any machine that can reach this server may mount it, which is the ' +
-    'opposite of nobody. Null is neither: it means the system reported no list ' +
-    'this tool could read — the field absent, or a list holding an entry that ' +
-    'is not a host or a network, since a restriction reported in part is a ' +
-    'different restriction — and it is NOT evidence that the export is ' +
-    'unrestricted. `mapall_user` and `mapall_group`, when ' +
-    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
-    'that account before the ACL below is consulted, so the ACL then answers ' +
-    'for that one account and not for whoever connected; `maproot_user` and ' +
-    '`maproot_group` do the same for root alone. Each is null where no such ' +
-    'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
-    'front of the filesystem one that can DENY what the path grants, so a ' +
-    'principal allowed below may still be refused here. It and ' +
-    '`share_acl_error` are BOTH null on an NFS export, which has no such layer; ' +
-    'on an SMB share exactly one of them is non-null. Each of its entries names ' +
-    'a principal in whichever of three ways the system had — `name` the ' +
-    'resolved account, `id` with `kind` (`USER` or `GROUP`) the local numeric ' +
-    'id, and `sid` the Windows security identifier of a domain principal — and ' +
-    'an entry that resolved to none of them is reported empty rather than ' +
-    'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
-    '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
-    'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
-    'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
-    'the filesystem ACL on `path`, which ' +
-    'is what decides what each principal may do once connected: over SMB it ' +
-    'applies to whoever the share ACL above already let through, and over NFS ' +
-    'to the ids arriving from a machine the restrictions already let in, after ' +
-    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
-    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
-    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
-    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
-    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
-    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
-    'which this tool does not read, so it can say nothing about who has access ' +
-    '— or null where the system named no type, which leaves the entries below ' +
-    'readable but says nothing about which vocabulary they are in. ' +
-    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
-    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
-    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
-    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
-    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
-    'that holds no entry, and null is either the `DISABLED` path above or a ' +
-    'list the system did not report in a form this tool could read — never ' +
-    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
-    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
-    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
-    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
-    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
-    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
-    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
-    'null on a tag that is its own principal and on `MASK`: the system writes ' +
-    '-1 there, which is reported as null because no account holds it. `name` ' +
-    'is null on those tags too, since they name no separate account for the ' +
-    'system to resolve — a null on one of them is the tag\'s nature rather ' +
-    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
-    'entry `name` is the resolved account or group name and `id` is its raw ' +
-    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
-    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
-    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
-    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
-    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
-    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
-    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
-    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
-    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
-    'entry grants only what it and the `MASK` entry both name, so the two are ' +
-    'read together and an entry can appear to hold more than it does. NFS4 has ' +
-    'no mask and no such step. An empty list is an entry that names ' +
-    'permissions and holds none of them; null is one whose permissions could ' +
-    'not be read, and is not evidence that it grants nothing. ' +
-    '`children_only` true means the ' +
-    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
-    'created inside it, so its principal does not have the access it appears to ' +
-    'have; null is an entry whose inheritance could not be read. This tool ' +
-    'reads access and changes none of it. It does not report Unix mode bits, ' +
-    'the SMB service\'s own bind addresses, which users are members of a group ' +
-    'named here, or whether a dataset is locked by encryption — so a principal ' +
-    'this reports as having access can still be stopped by something outside ' +
-    'these fields, and this is an upper bound on access rather than a proof of ' +
-    'it.',
+    'so there is no single answer to give. ' +
+    SHARE_ACCESS_RESULT_GUIDANCE,
+  resultGuidance: SHARE_ACCESS_RESULT_GUIDANCE,
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -677,52 +677,54 @@ export const shareAccess: ReadOnlyTool = {
   name: 'share_access',
   description:
     'Who can reach one share, and with what rights. Names the share by its SMB ' +
-    'share name, or — since an NFS export has no name — by the path it exports; ' +
-    'either string is accepted for either protocol, and `protocol` restricts ' +
-    'the search to one of them. A string matching NO share is an error naming ' +
-    'it, never an empty result: a share that does not exist and a share nobody ' +
-    'can reach are opposite answers. A string matching MORE THAN one share is ' +
-    'also an error, listing what it matched — one path can be shared over both ' +
-    'protocols at once and the two grant access differently, so there is no ' +
-    'single answer to give.',
+    'share name, or — since an NFS export has no name — by the path it ' +
+    'exports; either string is accepted for either protocol, and `protocol` ' +
+    'restricts the search to one of them. A string matching NO share is an ' +
+    'error naming it, never an empty result: a share that does not exist and a ' +
+    'share nobody can reach are opposite answers. A string matching MORE THAN ' +
+    'one share is also an error, listing what it matched — one path can be ' +
+    'shared over both protocols at once and the two grant access differently, ' +
+    'so there is no single answer to give.',
   resultGuidance:
-    '`failures` reports a protocol whose share list could not be read, as ' +
-    '`protocol` and `error`, and is empty when both were read. WHILE IT IS NOT ' +
-    'EMPTY THIS ANSWER MAY NOT BE THE ONLY ONE: the search for a second match ' +
-    'ran over a list that was never read, so a share of the protocol named ' +
-    'there may also answer to the string given, and the error this tool would ' +
-    'otherwise raise is one it could not detect. `protocol`, `id`, `name`, ' +
-    '`path` and `enabled` identify the share and mean exactly what they mean in ' +
+    '`failures` reports a protocol whose ' +
+    'share list could not be read, as `protocol` and `error`, and is empty ' +
+    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
+    'ONLY ONE: the search for a second match ran over a list that was never ' +
+    'read, so a share of the protocol named there may also answer to the ' +
+    'string given, and the error this tool would otherwise raise is one it ' +
+    'could not detect. `protocol`, `id`, `name`, `path` ' +
+    'and `enabled` identify the share and mean exactly what they mean in ' +
     '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
     'that a disabled share reaches nobody whatever the rest of this says. ' +
-    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share is ' +
-    'reached only by a principal that every layer reporting on it allows. ' +
+    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
+    'is reached only by a principal that every layer reporting on it allows. ' +
     '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
     'share or export is served read-only whatever its ACLs say — and null is a ' +
     'switch the system reported no value for, which is not the same as false. ' +
-    '`smb` is the SMB share record\\\'s own say in WHICH MACHINES may reach it, ' +
+    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
     'applied by the SMB service before either ACL below is consulted, and is ' +
     'null on an NFS export, which is not served by that service. Within it, ' +
-    '`hosts_allow` and `hosts_deny` are the share\\\'s host patterns — names, ' +
+    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
     'addresses or subnets — and where both name a machine the SMB service lets ' +
     'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
     'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
     'here. Null is not that: it means the system reported no list this tool ' +
-    'could read — the field absent, the share\\\'s `options` absent, or a list ' +
-    'holding something that is not a host pattern — and it is NOT evidence that ' +
-    'the share is unrestricted. `nfs` is the export record\\\'s own say in who ' +
-    'may reach it, and is null on an SMB share, where the protocol has none of ' +
-    'it. Within it, `hosts` and `networks` are which machines may mount the ' +
-    'export at all. AN EMPTY LIST MEANS UNRESTRICTED — an empty `hosts` and an ' +
-    'empty `networks` together mean any machine that can reach this server may ' +
-    'mount it, which is the opposite of nobody. Null is neither: it means the ' +
-    'system reported no list this tool could read — the field absent, or a list ' +
-    'holding an entry that is not a host or a network, since a restriction ' +
-    'reported in part is a different restriction — and it is NOT evidence that ' +
-    'the export is unrestricted. `mapall_user` and `mapall_group`, when set, ' +
-    'REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with that ' +
-    'account before the ACL below is consulted, so the ACL then answers for ' +
-    'that one account and not for whoever connected; `maproot_user` and ' +
+    'could read — the field absent, the share\'s `options` absent, or a list ' +
+    'holding something that is not a host pattern — and it is NOT evidence ' +
+    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
+    'who may reach it, and is null on ' +
+    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
+    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
+    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
+    'mean any machine that can reach this server may mount it, which is the ' +
+    'opposite of nobody. Null is neither: it means the system reported no list ' +
+    'this tool could read — the field absent, or a list holding an entry that ' +
+    'is not a host or a network, since a restriction reported in part is a ' +
+    'different restriction — and it is NOT evidence that the export is ' +
+    'unrestricted. `mapall_user` and `mapall_group`, when ' +
+    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
+    'that account before the ACL below is consulted, so the ACL then answers ' +
+    'for that one account and not for whoever connected; `maproot_user` and ' +
     '`maproot_group` do the same for root alone. Each is null where no such ' +
     'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
     'front of the filesystem one that can DENY what the path grants, so a ' +
@@ -737,61 +739,63 @@ export const shareAccess: ReadOnlyTool = {
     '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
     'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
     'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
-    'the filesystem ACL on `path`, which is what decides what each principal ' +
-    'may do once connected: over SMB it applies to whoever the share ACL above ' +
-    'already let through, and over NFS to the ids arriving from a machine the ' +
-    'restrictions already let in, after any mapping. EXACTLY ONE of `acl` and ' +
-    '`acl_error` is non-null: `acl_error` says in words why the ACL could not ' +
-    'be read, and an unread ACL is never presented as an empty one. Within ' +
-    '`acl`, `type` is `NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs ' +
-    'are switched off — there `entries` is ALWAYS null, whatever list the ' +
-    'system reports beside it, because no ACL is in force: access is governed ' +
-    'by the Unix mode bits, which this tool does not read, so it can say ' +
-    'nothing about who has access — or null where the system named no type, ' +
-    'which leaves the entries below readable but says nothing about which ' +
-    'vocabulary they are in. `trivial` true means the ACL grants nothing beyond ' +
-    'the owner, the owning group and everyone else. `owner_user` and ' +
-    '`owner_group` are the names of the path\\\'s owner, with `owner_uid` and ' +
-    '`owner_gid` the raw ids, and they are who the `owner@`, `group@`, ' +
-    '`USER_OBJ` and `GROUP_OBJ` entries refer to. Each of `entries` is one ' +
-    'entry of that ACL: an empty list is an ACL that holds no entry, and null ' +
-    'is either the `DISABLED` path above or a list the system did not report in ' +
-    'a form this tool could read — never evidence that the ACL grants nothing. ' +
-    '`tag` says what kind, and the two ACL types use different words for it. On ' +
-    'an NFS4 ACL it is `USER` or `GROUP`, which name a principal, or `owner@`, ' +
-    '`group@` or `everyone@`, where the tag IS the principal. On a POSIX ACL it ' +
-    'is `USER` or `GROUP`, or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\\\'s ' +
-    'owner, its owning group, and everyone else — or `MASK`, which is NOT a ' +
-    'principal at all but a ceiling on the others, described under ' +
-    '`permissions`. `id` is ALWAYS null on a tag that is its own principal and ' +
-    'on `MASK`: the system writes -1 there, which is reported as null because ' +
-    'no account holds it. `name` is null on those tags too, since they name no ' +
-    'separate account for the system to resolve — a null on one of them is the ' +
-    'tag\\\'s nature rather than a principal that would not resolve. On a `USER` ' +
-    'or `GROUP` entry `name` is the resolved account or group name and `id` is ' +
-    'its raw numeric id; an id that resolved to no name is reported as `id` ' +
-    'beside a null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` ' +
-    'entry with neither is one whose principal could not be read. `access` is ' +
-    '`ALLOW` or `DENY` on an NFS4 ACL and null on a POSIX one, which has no ' +
-    'deny entries. `permissions` names what THE ENTRY ITSELF carries, in the ' +
-    'ACL type\\\'s own vocabulary — a single preset such as `FULL_CONTROL` or ' +
-    '`MODIFY`, or individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 ' +
-    'and `READ`, `WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A ' +
-    '`MASK` ENTRY THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or ' +
-    '`GROUP_OBJ` entry grants only what it and the `MASK` entry both name, so ' +
-    'the two are read together and an entry can appear to hold more than it ' +
-    'does. NFS4 has no mask and no such step. An empty list is an entry that ' +
-    'names permissions and holds none of them; null is one whose permissions ' +
-    'could not be read, and is not evidence that it grants nothing. ' +
-    '`children_only` true means the entry GRANTS NOTHING ON THIS PATH and ' +
-    'exists to be inherited by what is created inside it, so its principal does ' +
-    'not have the access it appears to have; null is an entry whose inheritance ' +
-    'could not be read. This tool reads access and changes none of it. It does ' +
-    'not report Unix mode bits, the SMB service\\\'s own bind addresses, which ' +
-    'users are members of a group named here, or whether a dataset is locked by ' +
-    'encryption — so a principal this reports as having access can still be ' +
-    'stopped by something outside these fields, and this is an upper bound on ' +
-    'access rather than a proof of it.',
+    'the filesystem ACL on `path`, which ' +
+    'is what decides what each principal may do once connected: over SMB it ' +
+    'applies to whoever the share ACL above already let through, and over NFS ' +
+    'to the ids arriving from a machine the restrictions already let in, after ' +
+    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
+    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
+    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
+    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
+    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
+    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
+    'which this tool does not read, so it can say nothing about who has access ' +
+    '— or null where the system named no type, which leaves the entries below ' +
+    'readable but says nothing about which vocabulary they are in. ' +
+    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
+    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
+    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
+    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
+    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
+    'that holds no entry, and null is either the `DISABLED` path above or a ' +
+    'list the system did not report in a form this tool could read — never ' +
+    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
+    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
+    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
+    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
+    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
+    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
+    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
+    'null on a tag that is its own principal and on `MASK`: the system writes ' +
+    '-1 there, which is reported as null because no account holds it. `name` ' +
+    'is null on those tags too, since they name no separate account for the ' +
+    'system to resolve — a null on one of them is the tag\'s nature rather ' +
+    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
+    'entry `name` is the resolved account or group name and `id` is its raw ' +
+    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
+    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
+    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
+    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
+    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
+    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
+    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
+    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
+    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
+    'entry grants only what it and the `MASK` entry both name, so the two are ' +
+    'read together and an entry can appear to hold more than it does. NFS4 has ' +
+    'no mask and no such step. An empty list is an entry that names ' +
+    'permissions and holds none of them; null is one whose permissions could ' +
+    'not be read, and is not evidence that it grants nothing. ' +
+    '`children_only` true means the ' +
+    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
+    'created inside it, so its principal does not have the access it appears to ' +
+    'have; null is an entry whose inheritance could not be read. This tool ' +
+    'reads access and changes none of it. It does not report Unix mode bits, ' +
+    'the SMB service\'s own bind addresses, which users are members of a group ' +
+    'named here, or whether a dataset is locked by encryption — so a principal ' +
+    'this reports as having access can still be stopped by something outside ' +
+    'these fields, and this is an upper bound on access rather than a proof of ' +
+    'it.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -677,52 +677,52 @@ export const shareAccess: ReadOnlyTool = {
   name: 'share_access',
   description:
     'Who can reach one share, and with what rights. Names the share by its SMB ' +
-    'share name, or — since an NFS export has no name — by the path it ' +
-    'exports; either string is accepted for either protocol, and `protocol` ' +
-    'restricts the search to one of them. A string matching NO share is an ' +
-    'error naming it, never an empty result: a share that does not exist and a ' +
-    'share nobody can reach are opposite answers. A string matching MORE THAN ' +
-    'one share is also an error, listing what it matched — one path can be ' +
-    'shared over both protocols at once and the two grant access differently, ' +
-    'so there is no single answer to give. `failures` reports a protocol whose ' +
-    'share list could not be read, as `protocol` and `error`, and is empty ' +
-    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
-    'ONLY ONE: the search for a second match ran over a list that was never ' +
-    'read, so a share of the protocol named there may also answer to the ' +
-    'string given, and the error this tool would otherwise raise is one it ' +
-    'could not detect. `protocol`, `id`, `name`, `path` ' +
-    'and `enabled` identify the share and mean exactly what they mean in ' +
+    'share name, or — since an NFS export has no name — by the path it exports; ' +
+    'either string is accepted for either protocol, and `protocol` restricts ' +
+    'the search to one of them. A string matching NO share is an error naming ' +
+    'it, never an empty result: a share that does not exist and a share nobody ' +
+    'can reach are opposite answers. A string matching MORE THAN one share is ' +
+    'also an error, listing what it matched — one path can be shared over both ' +
+    'protocols at once and the two grant access differently, so there is no ' +
+    'single answer to give.',
+  resultGuidance:
+    '`failures` reports a protocol whose share list could not be read, as ' +
+    '`protocol` and `error`, and is empty when both were read. WHILE IT IS NOT ' +
+    'EMPTY THIS ANSWER MAY NOT BE THE ONLY ONE: the search for a second match ' +
+    'ran over a list that was never read, so a share of the protocol named ' +
+    'there may also answer to the string given, and the error this tool would ' +
+    'otherwise raise is one it could not detect. `protocol`, `id`, `name`, ' +
+    '`path` and `enabled` identify the share and mean exactly what they mean in ' +
     '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
     'that a disabled share reaches nobody whatever the rest of this says. ' +
-    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
-    'is reached only by a principal that every layer reporting on it allows. ' +
+    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share is ' +
+    'reached only by a principal that every layer reporting on it allows. ' +
     '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
     'share or export is served read-only whatever its ACLs say — and null is a ' +
     'switch the system reported no value for, which is not the same as false. ' +
-    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
+    '`smb` is the SMB share record\\\'s own say in WHICH MACHINES may reach it, ' +
     'applied by the SMB service before either ACL below is consulted, and is ' +
     'null on an NFS export, which is not served by that service. Within it, ' +
-    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
+    '`hosts_allow` and `hosts_deny` are the share\\\'s host patterns — names, ' +
     'addresses or subnets — and where both name a machine the SMB service lets ' +
     'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
     'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
     'here. Null is not that: it means the system reported no list this tool ' +
-    'could read — the field absent, the share\'s `options` absent, or a list ' +
-    'holding something that is not a host pattern — and it is NOT evidence ' +
-    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
-    'who may reach it, and is null on ' +
-    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
-    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
-    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
-    'mean any machine that can reach this server may mount it, which is the ' +
-    'opposite of nobody. Null is neither: it means the system reported no list ' +
-    'this tool could read — the field absent, or a list holding an entry that ' +
-    'is not a host or a network, since a restriction reported in part is a ' +
-    'different restriction — and it is NOT evidence that the export is ' +
-    'unrestricted. `mapall_user` and `mapall_group`, when ' +
-    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
-    'that account before the ACL below is consulted, so the ACL then answers ' +
-    'for that one account and not for whoever connected; `maproot_user` and ' +
+    'could read — the field absent, the share\\\'s `options` absent, or a list ' +
+    'holding something that is not a host pattern — and it is NOT evidence that ' +
+    'the share is unrestricted. `nfs` is the export record\\\'s own say in who ' +
+    'may reach it, and is null on an SMB share, where the protocol has none of ' +
+    'it. Within it, `hosts` and `networks` are which machines may mount the ' +
+    'export at all. AN EMPTY LIST MEANS UNRESTRICTED — an empty `hosts` and an ' +
+    'empty `networks` together mean any machine that can reach this server may ' +
+    'mount it, which is the opposite of nobody. Null is neither: it means the ' +
+    'system reported no list this tool could read — the field absent, or a list ' +
+    'holding an entry that is not a host or a network, since a restriction ' +
+    'reported in part is a different restriction — and it is NOT evidence that ' +
+    'the export is unrestricted. `mapall_user` and `mapall_group`, when set, ' +
+    'REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with that ' +
+    'account before the ACL below is consulted, so the ACL then answers for ' +
+    'that one account and not for whoever connected; `maproot_user` and ' +
     '`maproot_group` do the same for root alone. Each is null where no such ' +
     'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
     'front of the filesystem one that can DENY what the path grants, so a ' +
@@ -737,63 +737,61 @@ export const shareAccess: ReadOnlyTool = {
     '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
     'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
     'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
-    'the filesystem ACL on `path`, which ' +
-    'is what decides what each principal may do once connected: over SMB it ' +
-    'applies to whoever the share ACL above already let through, and over NFS ' +
-    'to the ids arriving from a machine the restrictions already let in, after ' +
-    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
-    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
-    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
-    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
-    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
-    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
-    'which this tool does not read, so it can say nothing about who has access ' +
-    '— or null where the system named no type, which leaves the entries below ' +
-    'readable but says nothing about which vocabulary they are in. ' +
-    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
-    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
-    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
-    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
-    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
-    'that holds no entry, and null is either the `DISABLED` path above or a ' +
-    'list the system did not report in a form this tool could read — never ' +
-    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
-    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
-    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
-    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
-    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
-    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
-    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
-    'null on a tag that is its own principal and on `MASK`: the system writes ' +
-    '-1 there, which is reported as null because no account holds it. `name` ' +
-    'is null on those tags too, since they name no separate account for the ' +
-    'system to resolve — a null on one of them is the tag\'s nature rather ' +
-    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
-    'entry `name` is the resolved account or group name and `id` is its raw ' +
-    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
-    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
-    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
-    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
-    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
-    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
-    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
-    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
-    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
-    'entry grants only what it and the `MASK` entry both name, so the two are ' +
-    'read together and an entry can appear to hold more than it does. NFS4 has ' +
-    'no mask and no such step. An empty list is an entry that names ' +
-    'permissions and holds none of them; null is one whose permissions could ' +
-    'not be read, and is not evidence that it grants nothing. ' +
-    '`children_only` true means the ' +
-    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
-    'created inside it, so its principal does not have the access it appears to ' +
-    'have; null is an entry whose inheritance could not be read. This tool ' +
-    'reads access and changes none of it. It does not report Unix mode bits, ' +
-    'the SMB service\'s own bind addresses, which users are members of a group ' +
-    'named here, or whether a dataset is locked by encryption — so a principal ' +
-    'this reports as having access can still be stopped by something outside ' +
-    'these fields, and this is an upper bound on access rather than a proof of ' +
-    'it.',
+    'the filesystem ACL on `path`, which is what decides what each principal ' +
+    'may do once connected: over SMB it applies to whoever the share ACL above ' +
+    'already let through, and over NFS to the ids arriving from a machine the ' +
+    'restrictions already let in, after any mapping. EXACTLY ONE of `acl` and ' +
+    '`acl_error` is non-null: `acl_error` says in words why the ACL could not ' +
+    'be read, and an unread ACL is never presented as an empty one. Within ' +
+    '`acl`, `type` is `NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs ' +
+    'are switched off — there `entries` is ALWAYS null, whatever list the ' +
+    'system reports beside it, because no ACL is in force: access is governed ' +
+    'by the Unix mode bits, which this tool does not read, so it can say ' +
+    'nothing about who has access — or null where the system named no type, ' +
+    'which leaves the entries below readable but says nothing about which ' +
+    'vocabulary they are in. `trivial` true means the ACL grants nothing beyond ' +
+    'the owner, the owning group and everyone else. `owner_user` and ' +
+    '`owner_group` are the names of the path\\\'s owner, with `owner_uid` and ' +
+    '`owner_gid` the raw ids, and they are who the `owner@`, `group@`, ' +
+    '`USER_OBJ` and `GROUP_OBJ` entries refer to. Each of `entries` is one ' +
+    'entry of that ACL: an empty list is an ACL that holds no entry, and null ' +
+    'is either the `DISABLED` path above or a list the system did not report in ' +
+    'a form this tool could read — never evidence that the ACL grants nothing. ' +
+    '`tag` says what kind, and the two ACL types use different words for it. On ' +
+    'an NFS4 ACL it is `USER` or `GROUP`, which name a principal, or `owner@`, ' +
+    '`group@` or `everyone@`, where the tag IS the principal. On a POSIX ACL it ' +
+    'is `USER` or `GROUP`, or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\\\'s ' +
+    'owner, its owning group, and everyone else — or `MASK`, which is NOT a ' +
+    'principal at all but a ceiling on the others, described under ' +
+    '`permissions`. `id` is ALWAYS null on a tag that is its own principal and ' +
+    'on `MASK`: the system writes -1 there, which is reported as null because ' +
+    'no account holds it. `name` is null on those tags too, since they name no ' +
+    'separate account for the system to resolve — a null on one of them is the ' +
+    'tag\\\'s nature rather than a principal that would not resolve. On a `USER` ' +
+    'or `GROUP` entry `name` is the resolved account or group name and `id` is ' +
+    'its raw numeric id; an id that resolved to no name is reported as `id` ' +
+    'beside a null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` ' +
+    'entry with neither is one whose principal could not be read. `access` is ' +
+    '`ALLOW` or `DENY` on an NFS4 ACL and null on a POSIX one, which has no ' +
+    'deny entries. `permissions` names what THE ENTRY ITSELF carries, in the ' +
+    'ACL type\\\'s own vocabulary — a single preset such as `FULL_CONTROL` or ' +
+    '`MODIFY`, or individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 ' +
+    'and `READ`, `WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A ' +
+    '`MASK` ENTRY THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or ' +
+    '`GROUP_OBJ` entry grants only what it and the `MASK` entry both name, so ' +
+    'the two are read together and an entry can appear to hold more than it ' +
+    'does. NFS4 has no mask and no such step. An empty list is an entry that ' +
+    'names permissions and holds none of them; null is one whose permissions ' +
+    'could not be read, and is not evidence that it grants nothing. ' +
+    '`children_only` true means the entry GRANTS NOTHING ON THIS PATH and ' +
+    'exists to be inherited by what is created inside it, so its principal does ' +
+    'not have the access it appears to have; null is an entry whose inheritance ' +
+    'could not be read. This tool reads access and changes none of it. It does ' +
+    'not report Unix mode bits, the SMB service\\\'s own bind addresses, which ' +
+    'users are members of a group named here, or whether a dataset is locked by ' +
+    'encryption — so a principal this reports as having access can still be ' +
+    'stopped by something outside these fields, and this is an upper bound on ' +
+    'access rather than a proof of it.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/shares.ts
+++ b/src/tools/shares.ts
@@ -684,7 +684,116 @@ export const shareAccess: ReadOnlyTool = {
     'share nobody can reach are opposite answers. A string matching MORE THAN ' +
     'one share is also an error, listing what it matched — one path can be ' +
     'shared over both protocols at once and the two grant access differently, ' +
-    'so there is no single answer to give.',
+    'so there is no single answer to give. `failures` reports a protocol whose ' +
+    'share list could not be read, as `protocol` and `error`, and is empty ' +
+    'when both were read. WHILE IT IS NOT EMPTY THIS ANSWER MAY NOT BE THE ' +
+    'ONLY ONE: the search for a second match ran over a list that was never ' +
+    'read, so a share of the protocol named there may also answer to the ' +
+    'string given, and the error this tool would otherwise raise is one it ' +
+    'could not detect. `protocol`, `id`, `name`, `path` ' +
+    'and `enabled` identify the share and mean exactly what they mean in ' +
+    '`shares_list`, including that `name` is ALWAYS null on an NFS export and ' +
+    'that a disabled share reaches nobody whatever the rest of this says. ' +
+    'ACCESS IS THE NARROWEST OF EVERYTHING BELOW, not any one field: a share ' +
+    'is reached only by a principal that every layer reporting on it allows. ' +
+    '`read_only` true CAPS EVERY WRITE PERMISSION reported anywhere below — the ' +
+    'share or export is served read-only whatever its ACLs say — and null is a ' +
+    'switch the system reported no value for, which is not the same as false. ' +
+    '`smb` is the SMB share record\'s own say in WHICH MACHINES may reach it, ' +
+    'applied by the SMB service before either ACL below is consulted, and is ' +
+    'null on an NFS export, which is not served by that service. Within it, ' +
+    '`hosts_allow` and `hosts_deny` are the share\'s host patterns — names, ' +
+    'addresses or subnets — and where both name a machine the SMB service lets ' +
+    'it in, `hosts_allow` being the one it applies first. AN EMPTY LIST MEANS ' +
+    'NO RULE OF THAT KIND, so two empty lists mean no machine is turned away ' +
+    'here. Null is not that: it means the system reported no list this tool ' +
+    'could read — the field absent, the share\'s `options` absent, or a list ' +
+    'holding something that is not a host pattern — and it is NOT evidence ' +
+    'that the share is unrestricted. `nfs` is the export record\'s own say in ' +
+    'who may reach it, and is null on ' +
+    'an SMB share, where the protocol has none of it. Within it, `hosts` and ' +
+    '`networks` are which machines may mount the export at all. AN EMPTY LIST ' +
+    'MEANS UNRESTRICTED — an empty `hosts` and an empty `networks` together ' +
+    'mean any machine that can reach this server may mount it, which is the ' +
+    'opposite of nobody. Null is neither: it means the system reported no list ' +
+    'this tool could read — the field absent, or a list holding an entry that ' +
+    'is not a host or a network, since a restriction reported in part is a ' +
+    'different restriction — and it is NOT evidence that the export is ' +
+    'unrestricted. `mapall_user` and `mapall_group`, when ' +
+    'set, REPLACE THE IDENTITY OF EVERY REQUEST arriving over the export with ' +
+    'that account before the ACL below is consulted, so the ACL then answers ' +
+    'for that one account and not for whoever connected; `maproot_user` and ' +
+    '`maproot_group` do the same for root alone. Each is null where no such ' +
+    'mapping is set. `share_acl` is the SMB SHARE-LEVEL ACL, a separate gate in ' +
+    'front of the filesystem one that can DENY what the path grants, so a ' +
+    'principal allowed below may still be refused here. It and ' +
+    '`share_acl_error` are BOTH null on an NFS export, which has no such layer; ' +
+    'on an SMB share exactly one of them is non-null. Each of its entries names ' +
+    'a principal in whichever of three ways the system had — `name` the ' +
+    'resolved account, `id` with `kind` (`USER` or `GROUP`) the local numeric ' +
+    'id, and `sid` the Windows security identifier of a domain principal — and ' +
+    'an entry that resolved to none of them is reported empty rather than ' +
+    'dropped. `access` is `ALLOWED` or `DENIED`, and `permission` is `FULL`, ' +
+    '`CHANGE`, `READ` or `CUSTOM`. AN EMPTY `share_acl` IS A SHARE-LEVEL ACL ' +
+    'THAT ALLOWS NOBODY, not a share without one — a share that carries no ' +
+    'share-level ACL reports null with a reason in `share_acl_error`. `acl` is ' +
+    'the filesystem ACL on `path`, which ' +
+    'is what decides what each principal may do once connected: over SMB it ' +
+    'applies to whoever the share ACL above already let through, and over NFS ' +
+    'to the ids arriving from a machine the restrictions already let in, after ' +
+    'any mapping. EXACTLY ONE of `acl` and `acl_error` is ' +
+    'non-null: `acl_error` says in words why the ACL could not be read, and an ' +
+    'unread ACL is never presented as an empty one. Within `acl`, `type` is ' +
+    '`NFS4`, `POSIX1E`, or `DISABLED` for a path whose ACLs are switched off — ' +
+    'there `entries` is ALWAYS null, whatever list the system reports beside ' +
+    'it, because no ACL is in force: access is governed by the Unix mode bits, ' +
+    'which this tool does not read, so it can say nothing about who has access ' +
+    '— or null where the system named no type, which leaves the entries below ' +
+    'readable but says nothing about which vocabulary they are in. ' +
+    '`trivial` true means the ACL grants nothing beyond the owner, the owning ' +
+    'group and everyone else. `owner_user` and `owner_group` are the names of ' +
+    'the path\'s owner, with `owner_uid` and `owner_gid` the raw ids, and they ' +
+    'are who the `owner@`, `group@`, `USER_OBJ` and `GROUP_OBJ` entries refer ' +
+    'to. Each of `entries` is one entry of that ACL: an empty list is an ACL ' +
+    'that holds no entry, and null is either the `DISABLED` path above or a ' +
+    'list the system did not report in a form this tool could read — never ' +
+    'evidence that the ACL grants nothing. `tag` says what kind, and ' +
+    'the two ACL types use different words for it. On an NFS4 ACL it is `USER` ' +
+    'or `GROUP`, which name a principal, or `owner@`, `group@` or `everyone@`, ' +
+    'where the tag IS the principal. On a POSIX ACL it is `USER` or `GROUP`, ' +
+    'or `USER_OBJ`, `GROUP_OBJ` and `OTHER` — the path\'s owner, its owning ' +
+    'group, and everyone else — or `MASK`, which is NOT a principal at all but ' +
+    'a ceiling on the others, described under `permissions`. `id` is ALWAYS ' +
+    'null on a tag that is its own principal and on `MASK`: the system writes ' +
+    '-1 there, which is reported as null because no account holds it. `name` ' +
+    'is null on those tags too, since they name no separate account for the ' +
+    'system to resolve — a null on one of them is the tag\'s nature rather ' +
+    'than a principal that would not resolve. On a `USER` or `GROUP` ' +
+    'entry `name` is the resolved account or group name and `id` is its raw ' +
+    'numeric id; an id that resolved to no name is reported as `id` beside a ' +
+    'null `name` and IS NEVER DROPPED, so only a `USER` or `GROUP` entry with ' +
+    'neither is one whose principal could not be read. `access` is `ALLOW` or ' +
+    '`DENY` on an NFS4 ACL and null on a POSIX one, which has no deny entries. ' +
+    '`permissions` names what THE ENTRY ITSELF carries, in the ACL type\'s own ' +
+    'vocabulary — a single preset such as `FULL_CONTROL` or `MODIFY`, or ' +
+    'individual names such as `READ_DATA` and `WRITE_ACL` on NFS4 and `READ`, ' +
+    '`WRITE` and `EXECUTE` on POSIX. ON A POSIX ACL CARRYING A `MASK` ENTRY ' +
+    'THAT IS NOT YET THE EFFECTIVE RIGHT: a `USER`, `GROUP` or `GROUP_OBJ` ' +
+    'entry grants only what it and the `MASK` entry both name, so the two are ' +
+    'read together and an entry can appear to hold more than it does. NFS4 has ' +
+    'no mask and no such step. An empty list is an entry that names ' +
+    'permissions and holds none of them; null is one whose permissions could ' +
+    'not be read, and is not evidence that it grants nothing. ' +
+    '`children_only` true means the ' +
+    'entry GRANTS NOTHING ON THIS PATH and exists to be inherited by what is ' +
+    'created inside it, so its principal does not have the access it appears to ' +
+    'have; null is an entry whose inheritance could not be read. This tool ' +
+    'reads access and changes none of it. It does not report Unix mode bits, ' +
+    'the SMB service\'s own bind addresses, which users are members of a group ' +
+    'named here, or whether a dataset is locked by encryption — so a principal ' +
+    'this reports as having access can still be stopped by something outside ' +
+    'these fields, and this is an upper bound on access rather than a proof of ' +
+    'it.',
   resultGuidance:
     '`failures` reports a protocol whose ' +
     'share list could not be read, as `protocol` and `error`, and is empty ' +


### PR DESCRIPTION
Follows the nightly failure in truenas-mcp-server#28 and @grwilliam's call on the mechanism in the project channel.

## What this is

`tools/list` is rendered into every host's context on every session, before a single tool is called, and it costs the whole catalog rather than the tools used. At 55 tools that is **215,278 bytes, 87% of it descriptions** — about 52,600 tokens.

That is more than the entire context window of a default-configured local model. ollama defaults `num_ctx` to 4096 whatever the model supports, so every goose request in the server repo's tier-3 nightly was refused outright:

```
request (32892 tokens) exceeds the available context size (4096 tokens)
```

`ToolBase.resultGuidance` carries the interpretation half of a description: delivered **with the result**, **once per tool per session**, and **never advertised**.

## Caching does not answer this, and I checked before designing around it

Tool definitions render at position 0 of the cached prefix (`tools` → `system` → `messages`) and cache reads bill at roughly **0.1×**. So on a caching host those 46k tokens of descriptions cost about 4,600 effective tokens per request, not 46,000 — an order of magnitude less than the raw figure I first quoted in the channel.

**But caching discounts input tokens without removing them from the window.** The window is the hard constraint, so this is a context-window fix and the cost argument is the weaker half. Worth stating plainly because it is the reasoning most likely to be inverted later.

## Where the line is drawn

**By when the text becomes actionable, not by length.** A caller cannot act on *"null means not read"* before it holds a null. So this is not the description summarised with detail cut — it is the half that was addressed to the wrong moment, moved to the moment it can be used. It also reads better there: the null/empty/unreadable conventions this repo is most careful about now arrive attached to the nulls they are about.

**Anything bearing on whether to call the tool at all stays in `description`.** That a report states no compliance verdict (#47), that a listing covers only data pools (#95), that a physical side effect is unestablished (#120), which ids a mutating tool takes and from where (#119, #121, #126). A caller that needed the caveat in order to choose correctly has already chosen by the time a result exists. **In doubt, it stays** — the cost of leaving it is tokens; the cost of moving it wrongly is a caller acting on an answer it would not have asked for.

## Two decisions worth arguing with

**Once per session, not once per call.** Guidance in a result is paid at full price on arrival and cached at 0.1× thereafter, so a copy per call accumulates — five calls to `fleet_compliance_report` would carry five copies where the description form had one, discounted. The delivered set lives on the `ToolExecutor` instance, which makes "per session" true **only because both deployment modes build one executor per session** — the same assumption `ConfirmationService` already makes about pending tokens. That is now stated in both places, and a deployment sharing one executor across sessions would have to re-scope both in one change.

**Attached only to a result carrying at least one `SUCCESS`.** A result with no data has nothing to read, and spending the one delivery on it leaves the caller unguided for every later call that does carry data. It falls out of that rule rather than being special-cased that a mutating plan which failed on every system — returned as `RESULTS` rather than as an approvable plan — never consumes it.

## Applied to two tools, deliberately

| tool | description before | after |
| --- | ---: | ---: |
| `fleet_compliance_report` | 10,639 | **1,241** |
| `share_access` | 8,191 | **608** |

`tools/list` goes 215,278 → 198,143 bytes: **8% from two tools of 55**. The remaining 53 follow in their own changes so the prose splits get reviewed in readable batches rather than as one 55-file diff — the splits are judgement calls per tool, which is exactly what a huge diff hides.

## The invariant, and why it is pinned

**`list()` must never carry the field.** A leak would restore exactly the cost this removes and would do it *silently* — every other test in the repository would still pass. So it is a test rather than a property of the mapping.

Verified by mutation rather than by reading: adding `resultGuidance` to `list()`'s mapping fails both the new test and the existing advertised-keys one.

```
× ToolCatalog > advertises schema and metadata only — never the callable handlers
  → expected [ 'description', 'inputSchema', …(3) ] to deeply equal [ …(2) ]
× ToolCatalog — result guidance is never advertised > omits it from the advertised tool
  → expected { name: 'guided', …(4) } to not have property "resultGuidance"
```

## Merge order — and a claim I got wrong

This originally said the field is *"carried and dropped — no behaviour change for any current consumer, which is what makes this safe to merge on its own."* **That was wrong, and the automated review was right to call it.** The text was removed from `description` too, and `description` is the field every consumer renders today. Between this merging and the server render landing, `share_access`'s *"AN EMPTY LIST MEANS UNRESTRICTED"* is in no model's context — and two empty NFS lists then read as *no access* rather than as its opposite, which is the worst direction for a caveat to go missing.

So: **this must not merge before the server render is ready.** `ExecutionOutcome`'s `RESULTS` arm gains an optional `guidance`, and `truenas-mcp-server`'s `resultsText` already takes a prefix, so that side is small — but it cannot be verified until this is on `main` and the base pin refreshed, which is the same ordering constraint the api-client pair had. The window is the interval between two merges rather than an open-ended gap, and it is a real window rather than none.

## Verification

`typecheck`, `lint`, **1,260 tests** (up 7), coverage **99.74 statements / 99.44 branches** against floors of 97/96, `build`. `smoke` needs real credentials and was not run.

Co-Authored-By: William Grzybowski <william@grzy.org>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round two — the review found real defects and they are fixed

Two HIGH findings, both mine, both reproduced before fixing:

**The first split reflowed the whole literal and silently dropped text.** The extractor matched only single-quoted literals, so the two lines built from *template* literals were omitted — `${EXPIRY_HORIZON_DAYS}` and `${MAX_LISTED}`. The guidance read *"`expiring_soon` how `expiry_unknown` how many…"* with the horizon gone, and *"are capped, at `truncated` flag"* with the cap of 10 gone. Nothing caught it: both constants are still used elsewhere so nothing goes unused, no test asserts description text, and all four CI jobs were green over it.

**The re-emitter escaped an already-escaped apostrophe**, putting five literal backslashes into the built text. `--word-diff` misses it because backslashes fall outside the word regex — worth knowing for how the rest of this series gets reviewed.

**Redone as one surgical split per file.** The line carrying the boundary becomes three; every other line is byte-identical. `--word-diff` against `main` now reports **no removals at all**, where the first attempt reported two. That is also the shape the remaining 53 should take — the reflow was going to make this same mistake 53 more times, which is the part of the finding worth carrying forward.

Rebuilt text now reads *"expiring_soon how many have 30 days or fewer left"* and *"are capped, at 10 entries each"*, with zero literal backslashes in either tool.

**The "This tool only reads" sentence is no longer moved.** It was the one deliberate removal in the first attempt and needed a second multi-line edit to carry it. `mutating: false` is advertised and already states the fact, so the move bought nothing and cost the property that makes this verifiable.

**LOW finding fixed too:** the mutating routes to a `RESULTS` outcome now have their own tests — a plan that failed on every system does not spend the delivery (the claim `results()`'s comment makes), and a confirmed execution receives it while the `PLAN` before it does not.

1,262 tests, coverage unchanged at 99.74 / 99.44.

---

## Round three — the merge window is closed rather than promised

The review restated the MEDIUM with a better answer than mine, and I took it. Instead of gating the merge on an ordering nothing in this repository enforces, `resultGuidance` now carries a **copy** and the removal from `description` moves to the follow-up that lands after the server render.

**`description` is byte-identical to `main` in both files.** `git diff --word-diff` against `main` reports no removals at all, only additions — so there is no interval in which a caveat is nowhere, and *"safe to merge on its own"* is now true rather than argued. `tools/list` does not shrink in this PR; the savings land with the removal, where they belong. The guidance being a verbatim slice of the description is a property, and it is asserted.

**Three LOW findings, all fair, all fixed:**

- **`guidance` absence has three causes, not two.** A result carrying no `SUCCESS` withholds it **and still owes it** — an adapter reading only that comment would take absence for "the caller has it". Now stated.
- **`confirmation.ts` said nothing about the shared assumption** while `CLAUDE.md` claimed it was "stated in both places" — a coupling asserted in one direction only, which is #128's own failure mode. It now carries it, plus the part that makes it matter: a shared instance fails **closed** there (an unknown token) and **open** here (a session told the guidance was already delivered when it never saw it). Only one of the two announces itself.
- **Nothing pinned the moved prose**, which is precisely how round one lost two template-literal lines with all four jobs green. Both specs now assert the verbatim-slice property, the two interpolated values that went missing, the readings that must not be lost, the caveats that must **not** move, and that neither field carries a stray backslash — the escaping defect `--word-diff` cannot see.

Verified by mutation rather than by reading: dropping the `${EXPIRY_HORIZON_DAYS}` line from the guidance copy alone fails two of the new tests.

```
× carries guidance that is a verbatim slice of the description
× states the expiry horizon and the entry cap, both interpolated
```

1,271 tests, coverage unchanged at 99.74 / 99.44.