### PR TITLE
feat(tools): add replication_topology, the peer on the far end of each task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1213,6 +1213,51 @@ guarantee this check cannot make) would have passed every test. **A redefinition
 that lives only in prose is one edit away from being undone** — where the rule
 is enforced by a message rather than by a type, pin the message.
 
+### A credential is named by an allowlist, and that is what makes it readable (#132)
+
+`replication_topology` reports the peer on the far end of each replication task,
+which means reading a stored SSH credential — the thing `automated_tasks_list`
+deliberately reads by `id` and `name` and no further, because its `attributes`
+hold an SSH private key (#97). The ticket asked whether the host can be reached
+without the key coming with it. It can, and the reason is the allowlist rather
+than anything about this particular payload.
+
+**The declared type is `SSHKeyPair | SSHCredentials`, and it is UNTAGGED.**
+Nothing in the union says which arm a row is, and one of the two is
+`{ private_key?: string, public_key?: string }`. What settles it is that the arm
+a replication task actually uses declares `private_key` as a **number** — the id
+of the separate `SSH_KEY_PAIR` credential that holds the key — so `host` and
+`port` are ordinary fields on a record whose secret is a reference. Naming those
+two BY NAME is what keeps that true whichever arm arrives, and what keeps the key
+out if a release ever moves it. #97's account is unchanged: forwarding
+`attributes`, or trimming the known secrets out of it, would still put a private
+key in a tool result. **"This payload holds a secret" is a reason to name fields,
+not a reason to refuse the read** — and the two are only the same answer for a
+tool that had no use for the record.
+
+**The join the ticket named is a FALLBACK, and it is made lazily.** A
+`replication.query` row's `ssh_credentials` is declared a whole
+`KeychainCredentialEntry`, so the common case carries the host inside the task
+row and there is nothing to look up; the middleware also sends the id-only form,
+which `tasks.ts` already reads for a cloud sync task's `credentials`. So both
+shapes are read (#102's rule about a payload arriving more than one way), and
+`keychaincredential.query` is called only where at least one task named its
+credential by id alone. **A supporting read that was never made reports no reason
+for not having been** — `credentials_unavailable` is null both where the listing
+was read and where nothing needed it, and a section-style `unavailable` that
+fired on a call this tool chose not to make would report a failure that did not
+happen.
+
+**One field, two tools, two readings — and #93 is what decides, not
+consistency.** `source_datasets` is `textList`-shaped in `replication_status`,
+which drops an entry it cannot read, and `strictTextList`-shaped here, which
+nulls the whole list. This tool is asked which datasets go to a named peer, so a
+list one name short says that dataset is not replicated there — a claim — while
+in the status listing the same shortening understates a description. Two tools
+reading one middleware field differently is the expected outcome of that rule
+rather than drift; what would be drift is copying whichever sibling was read
+first.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `disks_temperature`, `apps_list`,
   `app_engine_status`, `apps_update_summary`,
   `vms_list`, `vm_logs`, `vm_devices`, `alerts_list`, `snapshots_list`,
-  `replication_status`,
+  `replication_status`, `replication_topology`,
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `automated_tasks_list`,
   `tasks_recent_runs`,
   `shares_list`, `share_access`, `nfs_clients`, `iscsi_list`, `nvmeof_list`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export {
   alertSettings,
   snapshotsList,
   replicationStatus,
+  replicationTopology,
   snapshotTasksList,
   cloudsyncTasksList,
   automatedTasksList,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-five sketch tools', () => {
+  it('registers the fifty-six sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -29,6 +29,7 @@ describe('createDefaultCatalog', () => {
       'alerts_list',
       'snapshots_list',
       'replication_status',
+      'replication_topology',
       'snapshot_tasks_list',
       'cloudsync_tasks_list',
       'automated_tasks_list',
@@ -236,6 +237,12 @@ describe('createDefaultCatalog', () => {
   it('advertises replication_status to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'replication_status',
+    );
+  });
+
+  it('advertises replication_topology to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'replication_topology',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,7 +11,7 @@ import { fleetComplianceReport, fleetHealthRollup, haStatus } from '@/tools/flee
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { nfsClients } from '@/tools/nfs';
 import { poolTopology, scrubHistory } from '@/tools/pools';
-import { replicationStatus } from '@/tools/replication';
+import { replicationStatus, replicationTopology } from '@/tools/replication';
 import {
   reportingAppVmUsage,
   reportingDiskIo,
@@ -43,7 +43,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: forty-nine read-only tools plus six mutating tools. */
+/** The sketch's catalog: fifty read-only tools plus six mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -70,6 +70,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(alertsList);
   catalog.register(snapshotsList);
   catalog.register(replicationStatus);
+  catalog.register(replicationTopology);
   catalog.register(snapshotTasksList);
   catalog.register(cloudsyncTasksList);
   catalog.register(automatedTasksList);
@@ -139,6 +140,7 @@ export {
   quotaReport,
   rebootInfo,
   replicationStatus,
+  replicationTopology,
   reportingAppVmUsage,
   reportingDiskIo,
   reportingSpaceTrends,

--- a/src/tools/replication.spec.ts
+++ b/src/tools/replication.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { fakeSystem } from '@/testing/fake-systems';
-import { replicationStatus } from '@/tools/index';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { replicationStatus, replicationTopology } from '@/tools/index';
 
 describe('replication_status', () => {
   /**
@@ -183,5 +183,397 @@ describe('replication_status', () => {
     expect(await sources(['tank/media', 7, null])).toEqual(['tank/media']);
     expect(await sources(undefined)).toEqual([]);
     expect(await sources('tank/media')).toEqual([]);
+  });
+});
+
+describe('replication_topology', () => {
+  /** The SSH private key a stored credential can hold, in the arm that holds one. */
+  const PRIVATE_KEY = '-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE\n';
+
+  /**
+   * A stored SSH credential as `keychaincredential.query` reports one, and as a
+   * replication task embeds one.
+   *
+   * `private_key` is a NUMBER on this arm — the id of the separate
+   * `SSH_KEY_PAIR` credential that holds the key — and `remote_host_key`,
+   * `username` and `connect_timeout` are here to be dropped: they are fields of
+   * the real payload this tool does not name.
+   */
+  const credential = (over: Record<string, unknown> = {}) => ({
+    id: 7,
+    name: 'backup-node',
+    type: 'SSH_CREDENTIALS',
+    attributes: {
+      host: 'backup.example.net',
+      port: 2222,
+      username: 'root',
+      private_key: 3,
+      remote_host_key: 'ssh-ed25519 AAAAC3Nza',
+      connect_timeout: 10,
+    },
+    ...over,
+  });
+
+  /**
+   * A replication task as `replication.query` reports one, carrying its
+   * credential in full — the shape the pinned client declares.
+   */
+  const task = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'nightly-to-backup',
+    direction: 'PUSH',
+    transport: 'SSH',
+    ssh_credentials: credential(),
+    source_datasets: ['tank/media'],
+    target_dataset: 'backup/media',
+    recursive: true,
+    auto: true,
+    retention_policy: 'SOURCE',
+    periodic_snapshot_tasks: [],
+    has_encrypted_dataset_keys: false,
+    state: { state: 'FINISHED', datetime: { $date: 1756346400000 } },
+    job: null,
+    ...over,
+  });
+
+  const answer = async (
+    tasks: unknown[],
+    credentials?: unknown,
+  ): Promise<{ result: Record<string, unknown>; query: ReturnType<typeof fakeSystem>['query'] }> => {
+    const { ctx, query } = fakeSystem({
+      ['replication.query']: tasks,
+      ['keychaincredential.query']: credentials,
+    });
+    const result = (await replicationTopology.handler(ctx, {})) as Record<string, unknown>;
+    return { result, query };
+  };
+
+  const rows = async (tasks: unknown[], credentials?: unknown): Promise<Record<string, unknown>[]> =>
+    (await answer(tasks, credentials)).result['tasks'] as Record<string, unknown>[];
+
+  /** One task, differing only in what it says about its SSH credential. */
+  const forCredential = async (
+    ssh_credentials: unknown,
+    credentials?: unknown,
+  ): Promise<Record<string, unknown>> => (await rows([task({ ssh_credentials })], credentials))[0];
+
+  it('names the peer from the credential the task carries', async () => {
+    const { result, query } = await answer([task()]);
+    expect(result).toEqual({
+      credentials_unavailable: null,
+      tasks: [
+        {
+          id: 1,
+          name: 'nightly-to-backup',
+          direction: 'PUSH',
+          transport: 'SSH',
+          source_datasets: ['tank/media'],
+          target_dataset: 'backup/media',
+          peer_status: 'NAMED',
+          peer_host: 'backup.example.net',
+          peer_port: 2222,
+          credential_id: 7,
+          credential_name: 'backup-node',
+        },
+      ],
+    });
+    // One call: the task row carried the whole credential, so there was
+    // nothing to look up.
+    expect(query).toHaveBeenCalledWith('replication.query');
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const reported = await rows([
+      task({
+        future_field: 'added by a later TrueNAS release',
+        ssh_credentials: credential({ future_field: 'added to a credential' }),
+      }),
+    ]);
+    expect(Object.keys(reported[0])).toEqual([
+      'id',
+      'name',
+      'direction',
+      'transport',
+      'source_datasets',
+      'target_dataset',
+      'peer_status',
+      'peer_host',
+      'peer_port',
+      'credential_id',
+      'credential_name',
+    ]);
+  });
+
+  it('returns a clean empty answer for a system with no replication tasks', async () => {
+    const { result, query } = await answer([]);
+    expect(result).toEqual({ credentials_unavailable: null, tasks: [] });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a local task as local rather than as a failed peer lookup', async () => {
+    const { result, query } = await answer([
+      task({ transport: 'LOCAL', ssh_credentials: null, target_dataset: 'tank/copy' }),
+    ]);
+    const [local] = result['tasks'] as Record<string, unknown>[];
+    expect(local['peer_status']).toBe('LOCAL');
+    expect(local['peer_host']).toBeNull();
+    expect(local['peer_port']).toBeNull();
+    expect(local['credential_id']).toBeNull();
+    expect(local['credential_name']).toBeNull();
+    expect(result['credentials_unavailable']).toBeNull();
+    // A local task needs no credential, so none is looked up for it.
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read a transport it could not read as local', async () => {
+    // Defaulting an unreadable transport to LOCAL would claim the task has no
+    // peer, from a field that said nothing — and `local` is not `LOCAL`.
+    for (const notLocal of [undefined, null, '', 42, 'local', 'SSH+NETCAT']) {
+      const [row] = await rows([task({ transport: notLocal, ssh_credentials: null })]);
+      expect(row['peer_status']).toBe('CREDENTIAL_NOT_REPORTED');
+    }
+    // The peer of a task that travels over netcat is still its SSH credential.
+    const [netcat] = await rows([task({ transport: 'SSH+NETCAT' })]);
+    expect(netcat['peer_status']).toBe('NAMED');
+    expect(netcat['peer_host']).toBe('backup.example.net');
+  });
+
+  it('reports a task that names no credential it could read, rather than dropping it', async () => {
+    for (const none of [undefined, null, 'backup-node', [], Number.NaN]) {
+      const row = await forCredential(none);
+      expect(row['peer_status']).toBe('CREDENTIAL_NOT_REPORTED');
+      expect(row['peer_host']).toBeNull();
+      expect(row['credential_id']).toBeNull();
+      expect(row['credential_name']).toBeNull();
+      // The task itself is still fully reported.
+      expect(row['id']).toBe(1);
+    }
+  });
+
+  it('looks the peer up where the task names its credential by id alone', async () => {
+    const { result, query } = await answer([task({ ssh_credentials: 7 })], [credential()]);
+    expect(result['tasks']).toEqual([
+      expect.objectContaining({
+        peer_status: 'NAMED',
+        peer_host: 'backup.example.net',
+        peer_port: 2222,
+        credential_id: 7,
+        credential_name: 'backup-node',
+      }),
+    ]);
+    expect(result['credentials_unavailable']).toBeNull();
+    expect(query).toHaveBeenCalledWith('keychaincredential.query');
+  });
+
+  it('reports a deleted credential as missing, keeping the task and the id', async () => {
+    const row = await forCredential(7, [credential({ id: 9 })]);
+    expect(row['peer_status']).toBe('CREDENTIAL_MISSING');
+    expect(row['credential_id']).toBe(7);
+    expect(row['credential_name']).toBeNull();
+    expect(row['peer_host']).toBeNull();
+    expect(row['peer_port']).toBeNull();
+  });
+
+  it('keeps a credential listing that failed separate from a credential that is gone', async () => {
+    const { ctx } = failingSystem(
+      { ['replication.query']: [task({ ssh_credentials: 7 })] },
+      { ['keychaincredential.query']: new Error('connection reset') },
+    );
+    const result = (await replicationTopology.handler(ctx, {})) as Record<string, unknown>;
+    expect(result['credentials_unavailable']).toBe('connection reset');
+    const [row] = result['tasks'] as Record<string, unknown>[];
+    expect(row['peer_status']).toBe('CREDENTIAL_UNREADABLE');
+    expect(row['credential_id']).toBe(7);
+    expect(row['credential_name']).toBeNull();
+  });
+
+  it('reads a credential listing that is not a list as unreadable', async () => {
+    const { result } = await answer([task({ ssh_credentials: 7 })], { id: 7 });
+    expect(result['credentials_unavailable']).toBe(
+      'the system did not answer with a list of credentials',
+    );
+    const [row] = result['tasks'] as Record<string, unknown>[];
+    expect(row['peer_status']).toBe('CREDENTIAL_UNREADABLE');
+  });
+
+  it('reports no reason where nothing needed looking up, and one where something did', async () => {
+    // A read that never happened has no failure to report — the reason field
+    // must not read as "the credentials could not be read" on a system whose
+    // tasks all carried theirs.
+    const { result } = await answer([task()], undefined);
+    expect(result['credentials_unavailable']).toBeNull();
+    const { result: looked } = await answer([task({ ssh_credentials: 7 })], undefined);
+    expect(looked['credentials_unavailable']).toBe(
+      'the system did not answer with a list of credentials',
+    );
+  });
+
+  it('reports a credential that records no host it could read as host-not-reported', async () => {
+    // The other arm of the credential's attributes union: a key pair carries a
+    // key and no host at all.
+    const keyPair = credential({
+      name: 'replication-key',
+      type: 'SSH_KEY_PAIR',
+      attributes: { private_key: PRIVATE_KEY, public_key: 'ssh-ed25519 AAAAC3Nza' },
+    });
+    const row = await forCredential(keyPair);
+    expect(row['peer_status']).toBe('HOST_NOT_REPORTED');
+    expect(row['peer_host']).toBeNull();
+    expect(row['peer_port']).toBeNull();
+    // The credential was reached, so it is still identified.
+    expect(row['credential_id']).toBe(7);
+    expect(row['credential_name']).toBe('replication-key');
+  });
+
+  it('reports attributes it cannot read at all as host-not-reported', async () => {
+    for (const attributes of [undefined, null, 'backup.example.net', ['backup.example.net']]) {
+      const row = await forCredential(credential({ attributes }));
+      expect(row['peer_status']).toBe('HOST_NOT_REPORTED');
+      expect(row['peer_host']).toBeNull();
+      expect(row['peer_port']).toBeNull();
+    }
+    // A record naming no host, or one this tool cannot read as a host.
+    for (const host of [undefined, null, '', 42]) {
+      const row = await forCredential(credential({ attributes: { host, port: 2222 } }));
+      expect(row['peer_status']).toBe('HOST_NOT_REPORTED');
+      expect(row['peer_host']).toBeNull();
+      // The port is a fact the credential recorded; it is reported either way.
+      expect(row['peer_port']).toBe(2222);
+    }
+  });
+
+  it('reports a port only where the credential records one, and asserts no default', async () => {
+    const ports = async (port: unknown): Promise<unknown> =>
+      (await forCredential(credential({ attributes: { host: 'backup.example.net', port } })))[
+        'peer_port'
+      ];
+    expect(await ports(2222)).toBe(2222);
+    expect(await ports(22)).toBe(22);
+    // Null is "the credential records no port", never "the port is 22".
+    expect(await ports(undefined)).toBeNull();
+    expect(await ports(null)).toBeNull();
+    expect(await ports('2222')).toBeNull();
+    expect(await ports(Number.NaN)).toBeNull();
+  });
+
+  it('identifies a credential whose own id it cannot read, without inventing one', async () => {
+    const row = await forCredential(credential({ id: undefined }));
+    expect(row['peer_status']).toBe('NAMED');
+    expect(row['peer_host']).toBe('backup.example.net');
+    expect(row['credential_id']).toBeNull();
+    expect(row['credential_name']).toBe('backup-node');
+  });
+
+  it('never matches a task to a credential row whose id it could not read', async () => {
+    // Such a row can never be the answer to a lookup by id, and keeping it
+    // under a substitute key would name the wrong peer.
+    const row = await forCredential(7, [
+      'not a credential row',
+      credential({ id: undefined }),
+      credential({ id: '7' }),
+    ]);
+    expect(row['peer_status']).toBe('CREDENTIAL_MISSING');
+    expect(row['peer_host']).toBeNull();
+  });
+
+  it('returns no key material under any input', async () => {
+    // Both arms of the credential's attributes union, both reached: one
+    // embedded in the task and one joined by id, each carrying a private key.
+    const { result } = await answer(
+      [
+        task({
+          id: 1,
+          ssh_credentials: credential({
+            attributes: {
+              host: 'backup.example.net',
+              port: 2222,
+              private_key: PRIVATE_KEY,
+              public_key: 'ssh-ed25519 AAAAC3Nza',
+              remote_host_key: 'ssh-ed25519 AAAAC3NzaRemote',
+              password: 'hunter2',
+            },
+          }),
+        }),
+        task({ id: 2, ssh_credentials: 9 }),
+      ],
+      [
+        credential({
+          id: 9,
+          attributes: { host: 'offsite.example.net', private_key: PRIVATE_KEY },
+        }),
+      ],
+    );
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('BEGIN OPENSSH PRIVATE KEY');
+    expect(serialized).not.toContain('private_key');
+    expect(serialized).not.toContain('public_key');
+    expect(serialized).not.toContain('remote_host_key');
+    expect(serialized).not.toContain('hunter2');
+    // Reached, in both shapes: the hosts are reported and only the hosts.
+    const reported = result['tasks'] as Record<string, unknown>[];
+    expect(reported.map((row) => row['peer_host'])).toEqual([
+      'backup.example.net',
+      'offsite.example.net',
+    ]);
+  });
+
+  it('refuses a source dataset list it could not read in full, rather than shortening it', async () => {
+    const sources = async (value: unknown): Promise<unknown> =>
+      (await rows([task({ source_datasets: value })]))[0]['source_datasets'];
+    expect(await sources(['tank/media', 'tank/docs'])).toEqual(['tank/media', 'tank/docs']);
+    // A list one name short would say that dataset is not replicated to this
+    // peer, which is the claim this tool is asked to answer.
+    expect(await sources(['tank/media', 7])).toBeNull();
+    expect(await sources(['tank/media', ''])).toBeNull();
+    expect(await sources(undefined)).toBeNull();
+    expect(await sources('tank/media')).toBeNull();
+    // An empty list is a different answer and is returned as itself.
+    expect(await sources([])).toEqual([]);
+  });
+
+  it('reports a task field it could not read as null rather than omitting it', async () => {
+    const [row] = await rows([
+      task({ id: undefined, name: '', direction: null, target_dataset: 42, transport: undefined }),
+    ]);
+    expect(row).toEqual(
+      expect.objectContaining({
+        id: null,
+        name: null,
+        direction: null,
+        transport: null,
+        target_dataset: null,
+      }),
+    );
+  });
+
+  it('names the peer of a pull task the same way it names a push task', async () => {
+    const [pull] = await rows([
+      task({ direction: 'PULL', source_datasets: ['remote/media'], target_dataset: 'tank/media' }),
+    ]);
+    expect(pull['direction']).toBe('PULL');
+    expect(pull['peer_host']).toBe('backup.example.net');
+    expect(pull['source_datasets']).toEqual(['remote/media']);
+  });
+
+  it('resolves each task independently across the shapes and failures in one listing', async () => {
+    const { result } = await answer(
+      [
+        task({ id: 1 }),
+        task({ id: 2, ssh_credentials: 9 }),
+        task({ id: 3, ssh_credentials: 99 }),
+        task({ id: 4, transport: 'LOCAL', ssh_credentials: null }),
+        task({ id: 5, ssh_credentials: null }),
+      ],
+      [credential({ id: 9, name: 'offsite', attributes: { host: 'offsite.example.net' } })],
+    );
+    const reported = result['tasks'] as Record<string, unknown>[];
+    expect(reported.map((row) => [row['id'], row['peer_status'], row['peer_host']])).toEqual([
+      [1, 'NAMED', 'backup.example.net'],
+      [2, 'NAMED', 'offsite.example.net'],
+      [3, 'CREDENTIAL_MISSING', null],
+      [4, 'LOCAL', null],
+      [5, 'CREDENTIAL_NOT_REPORTED', null],
+    ]);
   });
 });

--- a/src/tools/replication.ts
+++ b/src/tools/replication.ts
@@ -470,8 +470,12 @@ export const replicationTopology: ReadOnlyTool = {
     'port of 22 and a reported port is not necessarily a non-default one. A ' +
     'port beside a null host is a credential that recorded one and no ' +
     'readable host. `credential_id` and `credential_name` identify the stored ' +
-    'SSH credential the peer was read from, and `credential_name` is null ' +
-    'wherever the credential was not reached. NO KEY MATERIAL APPEARS IN THIS ' +
+    'SSH credential the peer was read from. Either is null where the ' +
+    'credential was not reached AND where it was reached and recorded no ' +
+    'value this tool could read, so both can be null beside a `NAMED` peer ' +
+    'whose host was read perfectly well; the two causes are not separable ' +
+    'from these fields, and `peer_status` is what says whether a credential ' +
+    'was reached at all. NO KEY MATERIAL APPEARS IN THIS ' +
     'RESULT UNDER ANY INPUT. The stored credential holds an SSH private key ' +
     'or a reference to one, and this tool reads four fields off it — id, ' +
     'name, host and port — by name; nothing else of the credential, and no ' +

--- a/src/tools/replication.ts
+++ b/src/tools/replication.ts
@@ -1,11 +1,19 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
-import { MAX_TIME_MS, MiddlewareDate } from '@/tools/common';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import {
+  MAX_TIME_MS,
+  MiddlewareDate,
+  errorText as failureText,
+  numberOrNull,
+  recordOrNull,
+  strictTextList,
+  textOrNull,
+} from '@/tools/common';
 
 /**
- * Replication family: the replication tasks that exist and how their last run
- * went.
+ * Replication family: the replication tasks that exist, how their last run went,
+ * and which peer each of them replicates with.
  *
  * `snapshots_list` shows the snapshots a system holds, which is what a task
  * replicates and not whether it did. Replication is the difference between a
@@ -13,6 +21,12 @@ import { MAX_TIME_MS, MiddlewareDate } from '@/tools/common';
  * looks, from the source system alone, exactly like one that is working — the
  * snapshots are all there either way. The task's own state record is the only
  * place that difference is visible.
+ *
+ * `replication_topology` answers the other half: WHO the other end is. A task's
+ * state says a replication is working and never says what it is working
+ * towards, so "is anything still replicating to the decommissioned box" and
+ * "which node holds the offsite copy" are questions neither this system's
+ * snapshots nor its task states can answer.
  */
 
 /**
@@ -210,5 +224,304 @@ export const replicationStatus: ReadOnlyTool = {
         error: errorText(state),
       };
     });
+  },
+};
+
+/**
+ * The one transport that has no peer: the task replicates within this system,
+ * so there is no remote end to name and no credential to look one up with.
+ *
+ * Matched against what the system actually spelled, never defaulted to. A task
+ * whose transport could not be read is NOT reported as local — that would be
+ * the claim "this task has no peer", made from a field that said nothing.
+ */
+const LOCAL_TRANSPORT = 'LOCAL';
+
+/** What a system answering `keychaincredential.query` with something else is reported as. */
+const NOT_A_CREDENTIAL_LIST = 'the system did not answer with a list of credentials';
+
+/**
+ * Why a task's peer is named, or which of the ways it could not be.
+ *
+ * These are five separate causes rather than one absence, and the caller acts
+ * differently on each: a task replicating locally has no peer to find, a task
+ * whose credential was deleted has one nobody can name any more, and a task
+ * this tool could not look up has one that is probably fine. Collapsing them
+ * into a null `peer_host` would make "there is no remote end" and "this tool
+ * did not manage to say" the same answer.
+ */
+type PeerStatus =
+  /** `transport` is `LOCAL`: the task replicates within this system. */
+  | 'LOCAL'
+  /** A host was read off the task's SSH credential. */
+  | 'NAMED'
+  /** The task is not local and named no SSH credential this tool could read. */
+  | 'CREDENTIAL_NOT_REPORTED'
+  /** The task named a credential by id and the system lists no credential with it. */
+  | 'CREDENTIAL_MISSING'
+  /** The task named a credential by id and the credential listing could not be read. */
+  | 'CREDENTIAL_UNREADABLE'
+  /** A credential was reached and it records no host this tool could read. */
+  | 'HOST_NOT_REPORTED';
+
+/**
+ * A stored SSH credential reduced to the peer it names, AND NOTHING ELSE.
+ *
+ * THIS IS THE CREDENTIAL BOUNDARY, and it is an allowlist for a sharper reason
+ * than most in this repository. The client types a keychain credential's
+ * `attributes` as `SSHKeyPair | SSHCredentials` — an UNTAGGED union, so the
+ * compiler cannot tell which arm a row is, and one of the two arms is
+ * `{ private_key?: string, public_key?: string }`. On the arm a replication
+ * task actually uses, `private_key` is a NUMBER: the id of the separate
+ * `SSH_KEY_PAIR` credential holding the key, so naming `host` and `port` never
+ * brings key material with it. Reading the two fields BY NAME is what makes
+ * that true whichever arm arrives, and what keeps the key out if a release ever
+ * moves it. Tool results are recorded verbatim in the audit trail (S3.3);
+ * forwarding `attributes`, or trimming known secrets out of it, would put an
+ * SSH private key in one. `username`, `connect_timeout` and `remote_host_key`
+ * are not read either — they are not the peer, and the description says so.
+ */
+interface Peer {
+  name: string | null;
+  host: string | null;
+  port: number | null;
+}
+
+/** The peer half of a reported task: the status and the four fields under it. */
+interface PeerReading {
+  peer_status: PeerStatus;
+  peer_host: string | null;
+  peer_port: number | null;
+  credential_id: number | null;
+  credential_name: string | null;
+}
+
+/** A stored credential row, reduced to the peer it names the moment it is read. */
+function peerOf(record: Record<string, unknown>): Peer {
+  const attributes = recordOrNull(record['attributes']);
+  return {
+    name: textOrNull(record['name']),
+    host: attributes === null ? null : textOrNull(attributes['host']),
+    // Reported as the credential records it, with no comparison against 22.
+    // The pinned surface declares `port?: number` and states no default, so
+    // "the port differs from the default" is not a fact this tool has read —
+    // asserting one would be a unit-suffix on a number nobody named (#96),
+    // one field over.
+    port: attributes === null ? null : numberOrNull(attributes['port']),
+  };
+}
+
+/** A peer that could not be named, under the status saying which way. */
+function unnamed(status: PeerStatus, credentialId: number | null = null): PeerReading {
+  return {
+    peer_status: status,
+    peer_host: null,
+    peer_port: null,
+    credential_id: credentialId,
+    credential_name: null,
+  };
+}
+
+/**
+ * A credential that was reached, read as the task's peer.
+ *
+ * `NAMED` is the narrow claim that a host was read — a credential reached with
+ * no readable host is `HOST_NOT_REPORTED` and not a peer named as nothing.
+ * `peer_port` is reported either way, because the port is a fact the credential
+ * recorded and dropping it would not make the missing host any clearer.
+ */
+function named(peer: Peer, credentialId: number | null): PeerReading {
+  return {
+    peer_status: peer.host === null ? 'HOST_NOT_REPORTED' : 'NAMED',
+    peer_host: peer.host,
+    peer_port: peer.port,
+    credential_id: credentialId,
+    credential_name: peer.name,
+  };
+}
+
+/**
+ * What a task's own row already says about its peer, or the id a second read
+ * has to resolve.
+ *
+ * `ssh_credentials` arrives in two shapes and the difference decides whether a
+ * second call is needed at all. The pinned client declares it as a whole
+ * `KeychainCredentialEntry` — so the common case carries the host inside the
+ * task row and NOTHING needs looking up — while the middleware also sends the
+ * id-only form, which `tasks.ts` reads for a cloud sync task's `credentials`
+ * and an rsync task's `ssh_credentials` for the same reason. Reading both is
+ * the move `system_general_config` makes for `ui_certificate` (#102): where a
+ * payload can arrive in more than one shape, a reading both shapes satisfy is
+ * worth more than a guard written to the pinned one.
+ */
+type PeerSource = { kind: 'read'; reading: PeerReading } | { kind: 'lookup'; id: number };
+
+function peerSource(transport: string | null, credentials: unknown): PeerSource {
+  if (transport === LOCAL_TRANSPORT) return { kind: 'read', reading: unnamed('LOCAL') };
+  const embedded = recordOrNull(credentials);
+  if (embedded !== null) {
+    return { kind: 'read', reading: named(peerOf(embedded), numberOrNull(embedded['id'])) };
+  }
+  const id = numberOrNull(credentials);
+  if (id === null) return { kind: 'read', reading: unnamed('CREDENTIAL_NOT_REPORTED') };
+  return { kind: 'lookup', id };
+}
+
+/** The credential listing, by id — or the reason it could not be read. */
+interface CredentialLookup {
+  peers: Map<number, Peer> | null;
+  error: string | null;
+}
+
+/**
+ * Every stored credential, reduced to a peer and keyed by id, with a failure
+ * named rather than thrown.
+ *
+ * Caught because this is the SECOND read: the tasks were listed successfully,
+ * and a credential listing that fails must leave every task still reported —
+ * including the ones whose peer the task row already named. That is the section
+ * seam `boot.ts` and `automated_tasks_list` use, with one supporting read
+ * rather than several independent ones, so the reason is reported once beside
+ * the list instead of repeated on every row.
+ *
+ * A row whose id cannot be read is dropped: it can never be the answer to a
+ * lookup by id, and keeping it under some substitute key would make a task
+ * match a credential that is not its own.
+ */
+async function readCredentials(system: SystemHandle): Promise<CredentialLookup> {
+  try {
+    // No filters: a system holds a handful of stored credentials, and a filter
+    // is bandwidth rather than a control — an unrecognised query parameter is
+    // dropped rather than refused, so a filter that did not apply comes back as
+    // the whole table and is indistinguishable from one that matched
+    // everything (#121). The match by id below is what decides either way.
+    const answer = await firstValueFrom(system.client.api.query('keychaincredential.query'));
+    if (!Array.isArray(answer)) return { peers: null, error: NOT_A_CREDENTIAL_LIST };
+    const peers = new Map<number, Peer>();
+    for (const row of answer) {
+      const record = recordOrNull(row);
+      if (record === null) continue;
+      const id = numberOrNull(record['id']);
+      if (id !== null) peers.set(id, peerOf(record));
+    }
+    return { peers, error: null };
+  } catch (reason) {
+    return { peers: null, error: failureText(reason) };
+  }
+}
+
+/** One task's peer, once the lookup (where one was needed) has been made. */
+function resolvePeer(source: PeerSource, lookup: CredentialLookup): PeerReading {
+  if (source.kind === 'read') return source.reading;
+  if (lookup.peers === null) return unnamed('CREDENTIAL_UNREADABLE', source.id);
+  const found = lookup.peers.get(source.id);
+  // Absent from a listing that WAS read is the deleted credential: the task
+  // still references an id, and nothing on the system answers to it. That is a
+  // different answer from the listing being unreadable, and the task is
+  // reported under either rather than dropped.
+  return found === undefined ? unnamed('CREDENTIAL_MISSING', source.id) : named(found, source.id);
+}
+
+export const replicationTopology: ReadOnlyTool = {
+  name: 'replication_topology',
+  description:
+    'Which peer each replication task on this system replicates with — the ' +
+    'remote host on the far end — beside the direction and datasets ' +
+    '`replication_status` reports. THIS REPORTS ONE NODE\'S EDGES AND ONLY ' +
+    'ITS OWN. It reads the replication tasks configured on the system it is ' +
+    'called against; it does not connect to any peer and cannot see a task ' +
+    'configured on one. A fleet-wide replication topology is assembled BY THE ' +
+    'CALLER, by calling this tool on each node and joining the results — a ' +
+    'peer named here is a host this system points at, not evidence that the ' +
+    'host exists, is reachable, or holds what the task says it sends. ' +
+    '`tasks` lists every replication task, local ones included. `id` is the ' +
+    "task's numeric identity and `name` its own name. `direction` is `PUSH`, " +
+    'replicating from this system outwards, or `PULL`, replicating onto it, ' +
+    'and it says which end the peer is: on a `PUSH` the peer holds ' +
+    '`target_dataset` and `source_datasets` are local, and on a `PULL` the ' +
+    'peer holds `source_datasets` and `target_dataset` is local. `transport` ' +
+    'is how the data travels — `SSH`, `SSH+NETCAT` or `LOCAL`. ' +
+    '`source_datasets` is the datasets replicated from and `target_dataset` ' +
+    'the one replicated to. `source_datasets` is null, rather than a shorter ' +
+    'list, where any entry could not be read as a dataset name: a list one ' +
+    'name short would say that dataset is not replicated to this peer, which ' +
+    'is the claim this tool exists to answer and must not make by accident. ' +
+    'An empty list is a different answer and is returned as itself. ' +
+    '`peer_status` says whether the peer is named and, where it is not, why: ' +
+    '`NAMED`, a host was read and is in `peer_host`; `LOCAL`, the task ' +
+    'replicates within this system and has no remote end at all; ' +
+    '`CREDENTIAL_NOT_REPORTED`, the task is not local and named no SSH ' +
+    'credential this tool could read; `CREDENTIAL_MISSING`, the task names a ' +
+    'credential by id and the system lists no credential with that id, which ' +
+    'is what a deleted credential looks like — the task is still reported, ' +
+    'with `credential_id` naming the id nothing answers to; ' +
+    '`CREDENTIAL_UNREADABLE`, the task names a credential by id and the ' +
+    'credential listing could not be read, so this is a limit of this call ' +
+    'rather than anything about the task, and `credentials_unavailable` ' +
+    'carries the reason; and `HOST_NOT_REPORTED`, a credential was reached ' +
+    'and records no host this tool could read. `LOCAL` is reported only where ' +
+    'the system spelled the transport `LOCAL`: a task whose transport could ' +
+    'not be read is never presented as having no peer. `peer_host` is the ' +
+    'host as the credential records it — a hostname or an address, whichever ' +
+    'was configured — and is null under every status but `NAMED`. `peer_port` ' +
+    'is the port the credential records, and is null where it records none, ' +
+    "which means SSH's own default applies; this tool does not assert what " +
+    'that default is and does not compare against it, so a null port is not a ' +
+    'port of 22 and a reported port is not necessarily a non-default one. A ' +
+    'port beside a null host is a credential that recorded one and no ' +
+    'readable host. `credential_id` and `credential_name` identify the stored ' +
+    'SSH credential the peer was read from, and `credential_name` is null ' +
+    'wherever the credential was not reached. NO KEY MATERIAL APPEARS IN THIS ' +
+    'RESULT UNDER ANY INPUT. The stored credential holds an SSH private key ' +
+    'or a reference to one, and this tool reads four fields off it — id, ' +
+    'name, host and port — by name; nothing else of the credential, and no ' +
+    'field a later TrueNAS release adds to one, can reach a caller without a ' +
+    'change to this file. The username, connect timeout and remote host key it ' +
+    'also records are not reported. `credentials_unavailable` is why the ' +
+    'credential listing could not be read, and is null both where it was read ' +
+    'and where no task needed it — the listing is read only when at least one ' +
+    'task names its credential by id alone, and a system whose tasks all ' +
+    'carry their credential in full never calls it. This tool reports nothing ' +
+    'about how replication is GOING: `replication_status` is where a task\'s ' +
+    'state, last run, error and enabled switch are, for the same tasks under ' +
+    'the same `id`. The netcat listen and connect addresses an `SSH+NETCAT` ' +
+    "task also carries are not reported; the peer above is the SSH credential's " +
+    'host either way.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options, as `replication_status` reads the same method:
+    // a system holds tens of replication tasks at most, and every field read
+    // here is part of a task row as it stands.
+    const tasks = await firstValueFrom(system.client.api.query('replication.query'));
+    const sources = tasks.map((task) => {
+      // Read once and passed to `peerSource`, so that the transport reported
+      // and the decision that a task is local cannot be two different readings
+      // of the same field.
+      const transport = textOrNull(task.transport);
+      return {
+        task: {
+          id: numberOrNull(task.id),
+          name: textOrNull(task.name),
+          direction: textOrNull(task.direction),
+          transport,
+          source_datasets: strictTextList(task.source_datasets),
+          target_dataset: textOrNull(task.target_dataset),
+        },
+        peer: peerSource(transport, task.ssh_credentials),
+      };
+    });
+    // The second read is made only where a task actually needs it. The pinned
+    // client embeds the whole credential in the task row, so on most systems
+    // there is nothing to look up and this tool is one call — and a listing
+    // that was never read reports no reason for not having been.
+    const lookup: CredentialLookup = sources.some((source) => source.peer.kind === 'lookup')
+      ? await readCredentials(system)
+      : { peers: new Map(), error: null };
+    return {
+      credentials_unavailable: lookup.error,
+      tasks: sources.map(({ task, peer }) => ({ ...task, ...resolvePeer(peer, lookup) })),
+    };
   },
 };


### PR DESCRIPTION
Adds `replication_topology`, the read-only tool that names the peer on the far
end of each replication task, beside the direction and datasets
`replication_status` already reports.

Fixes #132

## Both unconfirmed questions resolve in favour of building it

The ticket asked for these to be settled before any code, and to stop if either
went the other way. Both were read off the pinned client
(`@truenas/api-client` 4.0.1, `dist/index.d.ts`) rather than assumed.

**1. `ssh_credentials` is an embedded record, not an id and not a list.** On
`DefaultApiDirectory` — the surface these tools are written against —
`replication.query`'s entity declares
`ssh_credentials?: KeychainCredentialEntry | null` (`index.d.ts:7074`), so the
common case carries the whole credential inside the task row and **the join the
ticket scoped is a fallback rather than the primary route**. The id-only form
the middleware also sends is read too — `tasks.ts` already reads it for a cloud
sync task's `credentials` and an rsync task's `ssh_credentials` — and
`keychaincredential.query` is called **only where at least one task named its
credential by id alone**. On a system whose tasks all carry theirs, this tool is
one call.

**2. The host is readable without key material coming with it.** A credential's
`attributes` is the union `SSHKeyPair | SSHCredentials` (`index.d.ts:5170`), and
it is **untagged** — nothing in the type says which arm a row is, and
`SSHKeyPair` is `{ private_key?: string, public_key?: string }`. What settles it
is that the arm a replication task uses declares `private_key` as a **number**
(`index.d.ts:5145`): the id of the separate `SSH_KEY_PAIR` credential that holds
the key. So `host` and `port` are ordinary fields on a record whose secret is a
reference, and naming those two **by name** is what keeps that true whichever
arm arrives, and what keeps the key out if a release ever moves it. Four fields
of the credential are read — `id`, `name`, `host`, `port` — and nothing else,
and no field a later TrueNAS release adds to a credential, can reach a caller
without a change to `replication.ts`. `username`, `connect_timeout` and
`remote_host_key` are not reported, and the description says so.

`#97`'s account is unchanged rather than contradicted: forwarding `attributes`,
or trimming the known secrets out of it, would still put a private key in a tool
result. "This payload holds a secret" is a reason to name fields, not a reason
to refuse the read.

## What it reports

`{ credentials_unavailable, tasks }`. Each task carries `id`, `name`,
`direction`, `transport`, `source_datasets`, `target_dataset`, then
`peer_status`, `peer_host`, `peer_port`, `credential_id`, `credential_name`.

`peer_status` keeps five ways of not naming a peer apart, because a caller acts
differently on each:

| value | means |
|---|---|
| `NAMED` | a host was read, and it is in `peer_host` |
| `LOCAL` | `transport` is `LOCAL`: the task replicates within this system and has no remote end |
| `CREDENTIAL_NOT_REPORTED` | not local, and the task named no credential this tool could read |
| `CREDENTIAL_MISSING` | the task names a credential by id and the system lists none with it — the deleted credential |
| `CREDENTIAL_UNREADABLE` | the task names a credential by id and the listing could not be read |
| `HOST_NOT_REPORTED` | a credential was reached and records no host this tool could read |

`LOCAL` is reported **only** where the system spelled the transport `LOCAL`. A
transport that could not be read is never presented as a task with no peer —
that would be a claim made from a field that said nothing.

`credentials_unavailable` is null both where the listing was read and **where no
task needed it**. A section-style `unavailable` that fired on a call this tool
chose not to make would report a failure that did not happen.

`source_datasets` is `strictTextList` here where `replication_status` uses the
dropping form. That is `#93`'s direction rule rather than drift: this tool is
asked which datasets go to a named peer, so a list one name short would say a
dataset is **not** replicated there — the claim the tool exists to answer. The
divergence is stated in the description and recorded as a decision in
`CLAUDE.md`.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (1275 passing, 35 of them new) and
`yarn build` all run clean locally. `yarn test:coverage` passes its floors with
`src/tools/replication.ts` at **100% statements, branches, functions and lines**;
global is 99.74 / 99.45 against floors of 97 / 96. Nothing was skipped and every
gating job in `.github/workflows/ci.yml` was runnable here.

The acceptance criterion about key material is
`returns no key material under any input`: it reaches both arms of the
attributes union — one credential embedded in the task, one joined by id, each
carrying a `-----BEGIN OPENSSH PRIVATE KEY-----` string — and asserts the
serialized result contains no key, no `private_key`/`public_key`/
`remote_host_key` key name, and no password, while both hosts are still
reported.

## Local review

`./scripts/local-review.py 132` ran the project's own reviewer in a separate
process and **returned nothing at or above MEDIUM** — four LOW findings, listed
below. That is the check's own rubric, threshold and parser, so it is a strong
prediction that the required check passes.

### What I changed after it, and what I did not

One prose correction was applied: the description said `credential_name` is null
"wherever the credential was not reached", which reads as a guarantee that it is
non-null wherever one was. It is not — a credential reached with an empty or
unreadable `name` is `NAMED` with a null name. Both causes are now stated and
`peer_status` is named as what separates them. Description text only; no change
to what the tool reads or returns.

The other three are recorded rather than fixed, per the rule that a clean review
round ends the work:

- **`replication.ts:437` — the description does not enumerate every field that
  can be null.** `id`, `name`, `direction`, `transport` and `target_dataset` are
  all guarded and all can come back null. True, and worth a follow-up; the
  guards are `common.ts`'s and behave as every sibling listing's do.
- **`replication.ts:335` — any record at `ssh_credentials` is treated as a
  credential that was reached.** An empty object reports `HOST_NOT_REPORTED`,
  which claims a credential was reached. The alternative — requiring a readable
  `id` or `name` before calling it reached — is a real design question rather
  than a typo, and it would change what the tool says.
- **`replication.ts:505` — this tool guards `id` and `target_dataset` where
  `replication_status` passes them raw**, so the two could in principle report
  different values for one row despite the cross-reference between them. The
  guarded reading is the one `CLAUDE.md`'s `#91` decision asks for ("a declared
  type is a claim about what the middleware sends, not the value received"), so
  the fix belongs in `replication_status` and is not this ticket's.

None of the three can break the build, and the required check reads the same
diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
