### PR TITLE
feat(tools): add system_ntp_status, the servers the clock is disciplined against

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1258,6 +1258,50 @@ reading one middleware field differently is the expected outcome of that rule
 rather than drift; what would be drift is copying whichever sibling was read
 first.
 
+### The measured half of a question can be absent from the surface (#133)
+
+`system_ntp_status` reports which NTP servers a system is configured to
+discipline its clock against, and **nothing about whether the clock is actually
+right** — no offset, no stratum, no last step. That is not a normalization this
+tool declined to do. The pinned surface declares five methods under
+`system.ntpserver` — `create`, `delete`, `get_instance`, `query`, `update` — and
+`query` answers the stored configuration; nothing anywhere in the client's
+declarations names a stratum, an offset, or the daemon behind them. **The
+measured half is unreachable from this repository**, the same way
+`filesystem.file_tail_follow` is unreachable in #72, and closing it is an
+upstream change rather than something a tool here could compose.
+
+**Say so in the description, and say it about the CATALOG rather than about the
+tool.** A caller told only that *this* tool reports configuration will go
+looking for the tool that reports the measurement, and there is not one. This is
+#120's rule — a side effect that could not be established is stated, not settled
+— reaching a fact that could not be READ at all: the honest answer is that the
+question cannot be answered from here, and a tool whose subject is the
+configuration must not let a caller infer the measurement from it.
+
+**The empty list is the finding, and it is derived rather than reported beside
+the list.** A system with no NTP server configured is a system with nothing
+disciplining its clock, which is the one positive claim this read supports —
+`servers_configured` is `servers.length > 0` for the reason `system_reboot_info`
+derives `reboot_required` the same way: the middleware states the answer by the
+length of a list and a caller should not have to know that. Two consequences
+follow, and both are #93's direction rule:
+
+- **An entry that could not be read is KEPT, as a row of nulls, and still
+  counts.** Dropping it moves the list towards empty, and empty is the finding —
+  a server this tool cannot read is not a server that is not there.
+- **A payload that is not a list is fatal, not empty.** The client declares an
+  array and #91 says a declared type is a claim about what arrives; a system
+  answering with something else would otherwise reach `servers_configured` as a
+  `false`, which is a positive claim about the clock that nothing established.
+
+**An optional boolean the payload omits is null and never false** — `prefer`,
+`burst` and `iburst` are all optional on the declared entry, and rendering an
+absent one as `false` would report a choice nobody made. `minpoll` and `maxpoll`
+carry no unit in their names under #96's first ground: the API declares none, and
+nothing about a polling bound fixes one the way SMART fixes a drive temperature
+in Celsius.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   Read-only family:
   `system_info`, `system_update_status`, `system_reboot_info`,
   `audit_log_query`, `audit_config`, `security_config`, `system_general_config`,
+  `system_ntp_status`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
   `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `disks_list`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ export {
   auditConfig,
   securityConfig,
   systemGeneralConfig,
+  systemNtpStatus,
   poolStatus,
   poolTopology,
   scrubHistory,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-six sketch tools', () => {
+  it('registers the fifty-seven sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -12,6 +12,7 @@ describe('createDefaultCatalog', () => {
       'audit_config',
       'security_config',
       'system_general_config',
+      'system_ntp_status',
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
@@ -339,6 +340,12 @@ describe('createDefaultCatalog', () => {
   it('advertises system_general_config to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'system_general_config',
+    );
+  });
+
+  it('advertises system_ntp_status to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
+      'system_ntp_status',
     );
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,7 @@ import {
   rebootInfo,
   systemGeneralConfig,
   systemInfo,
+  systemNtpStatus,
   updateStatus,
 } from '@/tools/system';
 import {
@@ -43,7 +44,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: fifty read-only tools plus six mutating tools. */
+/** The sketch's catalog: fifty-one read-only tools plus six mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -53,6 +54,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(auditConfig);
   catalog.register(securityConfig);
   catalog.register(systemGeneralConfig);
+  catalog.register(systemNtpStatus);
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
@@ -156,6 +158,7 @@ export {
   systemGeneralConfig,
   systemHealthReport,
   systemInfo,
+  systemNtpStatus,
   tasksRecentRuns,
   updateStatus,
   usersList,

--- a/src/tools/system.spec.ts
+++ b/src/tools/system.spec.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Role } from '@/interfaces';
 import { fakeSystem, failingSystem } from '@/testing/fake-systems';
 import {
   auditConfig,
   auditLogQuery,
   rebootInfo,
   systemGeneralConfig,
+  systemNtpStatus,
   updateStatus,
 } from '@/tools/index';
 
@@ -1170,5 +1172,177 @@ describe('system_general_config', () => {
     await systemGeneralConfig.handler(ctx, {});
     expect(call.mock.calls.map((args) => args[0])).toEqual(['system.general.config']);
     expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('system_ntp_status', () => {
+  /** An NTP server row as `system.ntpserver.query` reports one. */
+  const server = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    address: '0.debian.pool.ntp.org',
+    burst: false,
+    iburst: true,
+    prefer: false,
+    minpoll: 6,
+    maxpoll: 10,
+    ...over,
+  });
+
+  const reported = async (rows: unknown): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['system.ntpserver.query']: rows });
+    return (await systemNtpStatus.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  /** The `servers` list of a read, whatever the rows were. */
+  const listed = async (rows: unknown[]): Promise<Record<string, unknown>[]> =>
+    (await reported(rows))['servers'] as Record<string, unknown>[];
+
+  /** One server, differing only in the fields the case is about. */
+  const one = async (over: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    (await listed([server(over)]))[0];
+
+  it('maps a server to its address and its polling settings', async () => {
+    expect(await reported([server()])).toEqual({
+      servers_configured: true,
+      servers: [
+        {
+          address: '0.debian.pool.ntp.org',
+          prefer: false,
+          burst: false,
+          iburst: true,
+          minpoll: 6,
+          maxpoll: 10,
+        },
+      ],
+    });
+  });
+
+  it('carries no field the tool does not name, including one a later release adds', async () => {
+    const rows = await listed([server({ force: true })]);
+    expect(Object.keys(rows[0])).toEqual([
+      'address',
+      'prefer',
+      'burst',
+      'iburst',
+      'minpoll',
+      'maxpoll',
+    ]);
+  });
+
+  it('does not report the middleware row id', async () => {
+    // Nothing in this catalog takes one: adding, changing and removing a server
+    // are all mutating and none of them is registered here.
+    const rows = await listed([server({ id: 7 })]);
+    expect(rows[0]).not.toHaveProperty('id');
+    expect(JSON.stringify(rows)).not.toContain('7');
+  });
+
+  it('reads an unreported option as null and never as false', async () => {
+    // The acceptance criterion this tool turns on: `prefer` absent is not
+    // `prefer` switched off, and rendering it as false would report a choice
+    // nobody made.
+    for (const option of ['prefer', 'burst', 'iburst'] as const) {
+      expect(await one({ [option]: true })).toMatchObject({ [option]: true });
+      expect(await one({ [option]: false })).toMatchObject({ [option]: false });
+      for (const unreadable of [undefined, null, 'true', 1, {}]) {
+        expect(await one({ [option]: unreadable })).toMatchObject({ [option]: null });
+      }
+    }
+  });
+
+  it('reports the polling bounds as the bare numbers they arrive as, keeping a zero', async () => {
+    // No unit is carried in either name, per #96: the API declares none, and a
+    // suffix is a claim a caller converts on.
+    expect(await one({ minpoll: 0, maxpoll: 17 })).toMatchObject({ minpoll: 0, maxpoll: 17 });
+    for (const unreadable of [undefined, null, '6', Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(await one({ minpoll: unreadable })).toMatchObject({ minpoll: null });
+      expect(await one({ maxpoll: unreadable })).toMatchObject({ maxpoll: null });
+    }
+  });
+
+  it('nulls an address it could not read, so the entry names no server', async () => {
+    for (const unreadable of [undefined, null, '', 7]) {
+      expect(await one({ address: unreadable })).toMatchObject({ address: null });
+    }
+  });
+
+  it('reads a system with no NTP servers as the finding rather than an empty list', async () => {
+    // The whole reason `servers_configured` is derived here: an empty array is
+    // what "nothing is configured to discipline this clock" looks like, and a
+    // caller should not have to know that.
+    expect(await reported([])).toEqual({ servers_configured: false, servers: [] });
+  });
+
+  it('keeps an entry it could not read, as a row of nulls that still counts', async () => {
+    // The #93 direction rule. Dropping it would move the list towards EMPTY,
+    // and empty is this tool's one positive finding — so a server this tool
+    // cannot read must not read as a server that is not there.
+    const nulls = {
+      address: null,
+      prefer: null,
+      burst: null,
+      iburst: null,
+      minpoll: null,
+      maxpoll: null,
+    };
+    for (const unreadable of [null, undefined, 7, 'ntp', []]) {
+      expect(await reported([unreadable])).toEqual({
+        servers_configured: true,
+        servers: [nulls],
+      });
+    }
+  });
+
+  it('lists the servers in the order the system listed them', async () => {
+    // The system ordered this list; re-ordering it would be this tool's own
+    // opinion about a sequence the middleware chose.
+    const rows = await listed([
+      server({ id: 1, address: 'tick.example.invalid' }),
+      server({ id: 2, address: 'aaa.example.invalid' }),
+      server({ id: 3, address: 'tock.example.invalid' }),
+    ]);
+    expect(rows.map((row) => row['address'])).toEqual([
+      'tick.example.invalid',
+      'aaa.example.invalid',
+      'tock.example.invalid',
+    ]);
+  });
+
+  it('fails rather than reporting no servers when the payload is not a list', async () => {
+    // The costly mistake: a payload this tool cannot read reaching
+    // `servers_configured` as a false, which is a positive finding about the
+    // clock that nothing established.
+    for (const answer of [null, undefined, 'servers', 7, {}]) {
+      await expect(reported(answer)).rejects.toThrow(
+        'system.ntpserver.query did not answer with a list of NTP servers',
+      );
+    }
+  });
+
+  it('fails rather than reporting no servers when the read could not be made', async () => {
+    const { ctx } = failingSystem({}, { ['system.ntpserver.query']: new Error('connection reset') });
+    await expect(systemNtpStatus.handler(ctx, {})).rejects.toThrow('connection reset');
+  });
+
+  it('states that it reports configuration rather than synchronisation', async () => {
+    // The tool's central limitation lives in prose, and prose is one edit away
+    // from being undone — so the claim is pinned here (#128).
+    expect(systemNtpStatus.description).toContain('REPORTS INTENT, NOT SYNCHRONISATION');
+    expect(systemNtpStatus.description).toContain(
+      'NO TOOL IN THIS CATALOG REPORTS THE MEASURED STATE',
+    );
+    // No field of the result offers one either, so a caller cannot read a
+    // stratum or an offset out of it and believe it was measured.
+    const result = await reported([server()]);
+    expect(Object.keys(result)).toEqual(['servers_configured', 'servers']);
+  });
+
+  it('asks for the servers, and never mutates', async () => {
+    const { ctx, call, query } = fakeSystem({ ['system.ntpserver.query']: [] });
+    await systemNtpStatus.handler(ctx, {});
+    expect(query).toHaveBeenCalledWith('system.ntpserver.query');
+    expect(call).not.toHaveBeenCalled();
+    expect(systemNtpStatus.mutating).toBe(false);
+    expect(systemNtpStatus.requiredRole).toBe(Role.ReadOnly);
   });
 });

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1129,3 +1129,188 @@ export const systemGeneralConfig: ReadOnlyTool = {
     };
   },
 };
+
+/** One configured NTP server, as this tool reports it. */
+interface NtpServer {
+  address: string | null;
+  prefer: boolean | null;
+  burst: boolean | null;
+  iburst: boolean | null;
+  minpoll: number | null;
+  maxpoll: number | null;
+}
+
+/**
+ * The servers the system listed, one entry each, in the order it listed them.
+ *
+ * Not sorted, unlike {@link configuredServices}: that one reads a keyed object,
+ * whose key order means nothing and would otherwise make two reads of the same
+ * unchanged configuration differ. This reads a list the system itself ordered,
+ * and re-ordering it would be this tool's own opinion about a sequence the
+ * middleware chose.
+ *
+ * AN ENTRY THAT COULD NOT BE READ IS KEPT, as a row of nulls, which is the #93
+ * direction rule rather than leniency. Dropping it would move the list towards
+ * EMPTY — and empty is this tool's one positive finding, "nothing is configured
+ * to discipline the clock". A server this tool cannot read is not a server that
+ * is not there, so it stays and it still makes `servers_configured` true. Same
+ * answer {@link rebootReasons} arrives at about a reason, and the opposite of
+ * the all-or-nothing reading `strictTextList` takes of an audit scope.
+ *
+ * A row that is not a record at all is read as an empty one, so every field
+ * lands on the same null the guards already give an absent field, and the entry
+ * is still counted.
+ *
+ * Every field is read through a guard even where the client declares it, which
+ * is the #91 decision: a declared type is a claim about what the middleware
+ * sends and not the value received. The three booleans are optional on that
+ * declaration, so null here covers a field the system did not report as well as
+ * one it reported unreadably — and neither is `false`, which is the one reading
+ * the ticket names as unacceptable.
+ */
+function ntpServers(rows: readonly unknown[]): NtpServer[] {
+  return rows.map((row) => {
+    const held: Record<string, unknown> = recordOrNull(row) ?? {};
+    return {
+      address: textOrNull(held['address']),
+      prefer: booleanOrNull(held['prefer']),
+      burst: booleanOrNull(held['burst']),
+      iburst: booleanOrNull(held['iburst']),
+      minpoll: numberOrNull(held['minpoll']),
+      maxpoll: numberOrNull(held['maxpoll']),
+      // `id` is a middleware row id, dropped by being absent from this
+      // allowlist as `services_status` drops a service's. Nothing in this
+      // catalog takes one: `system.ntpserver.update` and `.delete` are the
+      // methods that would, and both are mutating and not registered here.
+      // Growing this tool the field is what #119 describes doing deliberately,
+      // on the ticket that needs it.
+    };
+  });
+}
+
+/**
+ * Which servers the clock is configured to be disciplined against — and,
+ * emphatically, not whether it is.
+ *
+ * Nothing else in the catalog reports time synchronisation at all, and it sits
+ * underneath data most of the rest of it returns: every timestamp reported by
+ * `audit_log_query`, `snapshots_list`, `tasks_recent_runs` and
+ * `storage_scrub_history` is only as trustworthy as the clock that wrote it,
+ * and `system_general_config` reports the ZONE those times are expressed in
+ * without reporting whether the instant behind them is right.
+ *
+ * THE CENTRAL LIMITATION IS THE WHOLE DESIGN OF THIS TOOL.
+ * `system.ntpserver.query` answers with the configured server list and nothing
+ * else: not whether any of them answered, not the offset, not the stratum, not
+ * when the clock last stepped. A description implying the clock is correct
+ * because servers are listed would be exactly the overpromise this repository's
+ * first convention names, so the tool is named and described for what is
+ * measured — which servers are configured.
+ *
+ * **No method on the pinned surface reports the live state**, which is an A2.4
+ * finding rather than a gap worked around here. `DefaultApiDirectory` declares
+ * `system.ntpserver.create`, `.delete`, `.get_instance`, `.query` and `.update`
+ * and nothing else under that namespace, and no method anywhere in the client's
+ * declarations names a stratum, an offset or the daemon behind them. So the
+ * measured half of "is this system's clock right" is unreachable from this
+ * repository, and closing it is an upstream change rather than a normalization
+ * this tool could have done. The description says so rather than leaving a
+ * caller to infer it from the fields that are missing.
+ *
+ * `servers_configured` is derived from the list rather than reported beside it,
+ * the same move `system_reboot_info` makes: the middleware states the answer by
+ * the LENGTH of a list, an empty one is the finding, and a caller should not
+ * have to know that an empty array is what "nothing disciplines this clock"
+ * looks like.
+ *
+ * WHAT THIS TOOL DELIBERATELY DOES NOT DO:
+ *
+ * - **It does not add, change or remove an NTP server.** `system.ntpserver.create`,
+ *   `.update` and `.delete` exist and are mutating; no tool here is.
+ * - **It does not set or step the clock**, and it does not read the time.
+ * - **It does not report the timezone.** That is `system_general_config`, and a
+ *   zone is not what keeps a clock correct.
+ */
+export const systemNtpStatus: ReadOnlyTool = {
+  name: 'system_ntp_status',
+  description:
+    'The NTP servers a TrueNAS system is CONFIGURED to synchronise its clock ' +
+    'against. THIS TOOL REPORTS INTENT, NOT SYNCHRONISATION, and that is its ' +
+    'central limitation: it does NOT establish that the clock is correct, that ' +
+    'any listed server ever answered, what the current offset or stratum is, ' +
+    'or when the clock last stepped. A system with servers listed here can ' +
+    'still have a badly wrong clock. NO TOOL IN THIS CATALOG REPORTS THE ' +
+    'MEASURED STATE — the TrueNAS API surface this catalog is written against ' +
+    'exposes the configuration and nothing else — so if the question is ' +
+    'whether the clock is actually right, say that it cannot be answered from ' +
+    'here rather than answering it from this result. ' +
+    '`servers_configured` is true when the system listed at least one NTP ' +
+    'server and false when it listed none. FALSE IS THE FINDING THIS TOOL ' +
+    'EXISTS TO SURFACE: nothing is configured to discipline the clock, so ' +
+    'every timestamp this catalog reports for that system comes from a clock ' +
+    'nothing is correcting, and time-sensitive services degrade quietly — ' +
+    'Kerberos rejects tickets outside a small clock skew, so an Active ' +
+    'Directory join reported as failing by `directory_services_status` with no ' +
+    'stated cause is worth checking against this. TRUE IS NOT THE OPPOSITE ' +
+    'FINDING: it says servers are configured, never that the clock is in sync. ' +
+    '`servers` is one entry per configured server, IN THE ORDER THE SYSTEM ' +
+    'LISTED THEM and not re-ordered here. `address` is the server as the ' +
+    'system spelled it — a hostname such as `0.debian.pool.ntp.org` or an IP ' +
+    'address — passed through exactly and NOT resolved, contacted or checked. ' +
+    '`prefer` is the server\'s own `prefer` setting as the system recorded it, ' +
+    '`burst` and `iburst` its two burst settings. Each of the three is ' +
+    'THREE-VALUED: true, false, or NULL WHERE THE SYSTEM REPORTED NO VALUE ' +
+    'THIS TOOL COULD READ — which covers a setting the system did not report ' +
+    'at all as well as one it reported in a form this tool cannot read. A NULL ' +
+    'IS NOT A FALSE and must never be reported as the setting being off: ' +
+    'nothing has been established about it. `minpoll` and `maxpoll` are the ' +
+    'polling bounds the system recorded for that server, reported as the bare ' +
+    'numbers they arrive as. THE API STATES NO UNIT FOR EITHER, so neither ' +
+    'carries one in its name and NEITHER IS TO BE CONVERTED OR PRESENTED AS ' +
+    'SECONDS, MINUTES OR ANY OTHER UNIT — report the number as itself and say ' +
+    'the unit is unstated. Each is null where the system reported no number ' +
+    'this tool could read. AN ENTRY WHOSE FIELDS ARE ALL NULL IS STILL A ' +
+    'SERVER THE SYSTEM HAS CONFIGURED: it is returned rather than dropped, and ' +
+    'it still makes `servers_configured` true, because a server this tool ' +
+    'could not read is not a server that is not there. AN EMPTY `servers` IS ' +
+    'THE SYSTEM HAVING BEEN READ AND HAVING LISTED NO SERVERS — it is never a ' +
+    'failed read, because a configuration that could not be read at all is an ' +
+    'error naming what the system said rather than an empty list. The ' +
+    'middleware row id of each server is NOT reported: nothing in this catalog ' +
+    'takes one, since adding, changing and removing a server are all mutating ' +
+    'and none of them is here. NO field beyond those named above is returned, ' +
+    'whatever a later TrueNAS release adds to an NTP server record. THIS TOOL ' +
+    'ONLY READS. It does not add, change or remove an NTP server, and it does ' +
+    'not set, step or read the clock. The system\'s TIMEZONE is a different ' +
+    'question and is `system_general_config` — a zone is the frame a time is ' +
+    'expressed in, not anything that keeps the time correct.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // No filters and no options, as `services_status` asks for none: a system
+    // holds a handful of NTP servers, every field reported is part of the row
+    // as it stands, and the question this answers is about all of them.
+    const answer = await firstValueFrom(system.client.api.query('system.ntpserver.query'));
+    // Guarded rather than mapped straight, and on this tool that is not
+    // defensiveness for its own sake. The client DECLARES a list, and #91's
+    // rule is that a declared type is a claim about what the middleware sends
+    // rather than the value received — so a system answering with something
+    // that is not a list would reach `servers_configured` as a false, which is
+    // this tool's one positive finding and the most costly thing it could get
+    // wrong. Fatal instead, and named for the read rather than for a property.
+    if (!Array.isArray(answer)) {
+      throw new Error('system.ntpserver.query did not answer with a list of NTP servers');
+    }
+    const servers = ntpServers(answer);
+    return {
+      // Derived rather than read, as `system_reboot_info` derives
+      // `reboot_required` from its own list: the middleware states the answer
+      // by the length of a list and a caller should not have to know that.
+      // Never null — a list that could not be read stopped the call above, so
+      // there is no third case here to report.
+      servers_configured: servers.length > 0,
+      servers,
+    };
+  },
+};

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1256,7 +1256,10 @@ export const systemNtpStatus: ReadOnlyTool = {
     '`servers` is one entry per configured server, IN THE ORDER THE SYSTEM ' +
     'LISTED THEM and not re-ordered here. `address` is the server as the ' +
     'system spelled it — a hostname such as `0.debian.pool.ntp.org` or an IP ' +
-    'address — passed through exactly and NOT resolved, contacted or checked. ' +
+    'address — passed through exactly as spelled and NOT resolved, contacted ' +
+    'or checked. It is NULL WHERE THE SYSTEM REPORTED NO ADDRESS THIS TOOL ' +
+    'COULD READ, which covers an address reported as empty text, and such an ' +
+    'entry names no server that could be looked up or matched. ' +
     '`prefer` is the server\'s own `prefer` setting as the system recorded it, ' +
     '`burst` and `iburst` its two burst settings. Each of the three is ' +
     'THREE-VALUED: true, false, or NULL WHERE THE SYSTEM REPORTED NO VALUE ' +


### PR DESCRIPTION
Closes #133.

## What this adds

`system_ntp_status` (`src/tools/system.ts`), over `system.ntpserver.query`:
which NTP servers a system is configured to discipline its clock against.
`mutating: false`, `requiredRole: Role.ReadOnly`, registered after
`system_general_config` and exported on the barrel in that same position.

```
{
  "servers_configured": true,
  "servers": [
    { "address": "0.debian.pool.ntp.org",
      "prefer": false, "burst": false, "iburst": true,
      "minpoll": 6, "maxpoll": 10 }
  ]
}
```

## The decisions worth reading

**It reports intent, not synchronisation, and that is stated first.** The
description opens on the limitation: the tool does not establish that the clock
is correct, that any listed server answered, what the offset or stratum is, or
when the clock last stepped. A list of servers is not evidence of a working
clock, and this repository's first convention is exactly about not letting a
description imply otherwise.

**The A2.4 question the ticket left open is answered: nothing on the pinned
surface reports the live state.** `DefaultApiDirectory` declares five methods
under `system.ntpserver` — `create`, `delete`, `get_instance`, `query`,
`update` — and `query` answers stored configuration. No method anywhere in the
client's declarations names a stratum, an offset, or the daemon behind them
(checked against `dist/index.d.ts` for `stratum`, `chrony`, `ntpq`, `timesync`
and `clock_offset`: zero hits). So the measured half of "is this clock right" is
unreachable from this repository, the way `filesystem.file_tail_follow` is in
#72. The description says the **catalog** cannot answer it, not merely this
tool — a caller told only that this tool reports configuration would otherwise
go looking for the tool that reports the measurement, and there is not one.
Recorded as an A2.4 finding on the ticket and as a `## Decisions` entry.

**An empty server list is the finding, derived rather than reported beside the
list.** `servers_configured` is `servers.length > 0`, the same move
`system_reboot_info` makes with `reboot_required`: the middleware states the
answer by the length of a list and a caller should not have to know that. False
is the positive claim this read supports — nothing is configured to discipline
the clock.

Two consequences, both #93's direction rule, since dropping towards empty here
is dropping towards a claim:

- **An entry that could not be read is kept, as a row of nulls, and still
  counts.** A server this tool cannot read is not a server that is not there.
- **A payload that is not a list is fatal, not empty.** The client declares an
  array; #91 says a declared type is a claim about what arrives rather than the
  value received. A system answering with something else would otherwise reach
  `servers_configured` as a `false` — a positive claim about the clock that
  nothing established. The error names the read rather than a property.

**An absent optional boolean is null and never false.** `prefer`, `burst` and
`iburst` are all optional on the declared entry; rendering an absent one as
`false` would report a choice nobody made. Null covers both "not reported" and
"reported unreadably", which the description states.

**`minpoll` and `maxpoll` carry no unit in their names** (#96, first ground):
the API declares none, and nothing about a polling bound fixes one the way SMART
fixes a drive temperature in Celsius. The description says the unit is unstated
and that the numbers are not to be converted.

**The middleware row id is not reported.** Nothing in this catalog takes one —
`system.ntpserver.update` and `.delete` are the methods that would, and both are
mutating and not registered. Growing the field is #119's deliberate act, on the
ticket that needs it. The omission is named in the description.

## Tests

In `system.spec.ts` under #87's default. **The 1,500-line split trigger was
measured, not felt** (#97): the merged file is 1,348 lines, so the exception is
not met and was not taken.

`yarn lint`, `yarn typecheck`, `yarn test` and `yarn test:coverage` all run
clean locally — 1,289 tests, coverage 99.74 statements / 99.45 branches against
floors of 97 / 96, and no floor was changed. Nothing in CI was skipped.

## Local review

`local-review.py` ran the project's own reviewer (exit 0, `$2.35`) and returned
**one finding, at LOW**, which is fixed here rather than deferred: the
description named no null case for `address`, while the field is `string | null`
and `textOrNull` also nulls empty text — a guarantee the normalization does not
deliver, on the one field a caller would use to look a server up. Prose only, in
its own commit; no executable code changed after the clean round.

## What I did not change

Nothing else was outstanding. Two things deliberately left out of scope, both
per the ticket:

- Adding, editing or removing an NTP server — mutating, not filed.
- The measured offset, stratum or last step — unreachable from the pinned
  surface, per the A2.4 finding above, and closing it is an upstream change
  rather than something a tool here could compose.
