### PR TITLE
feat(tools): add fc_list, the Fibre Channel hosts and ports the catalog missed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1382,15 +1382,25 @@ correct and is not. This is `attribute`'s reason in `nvmeof_list` one level up:
 there the unconfirmed part is whether an id answers to a listed subsystem, here
 it is whether the key exists at all.
 
-**What that costs is a second cause for one null, and the description owes
-both.** A port's `status` is null where the status read failed AND where the
-port carries no name to be joined on — the first is in `failures` and the second
-leaves it empty, so `port` and `failures` together are what separate them. The
-same doubling reaches the list: everything landing in `unattributed_status` at
-once is a broken join where `ports` is populated and simply a failed port read
-where `ports` is null. **A join whose key is a guess adds a cause to every null
-downstream of it**, and enumerating one of them is this repository's most common
-finding wearing the join's hat.
+**What that costs is a cause added to every null downstream, and the description
+owes all of them.** A port's `status` is null where the status read failed AND
+where the port carries no name to be joined on — the first is in `failures` and
+the second leaves it empty, so `port` and `failures` together separate them.
+**A join whose key is a guess adds a cause to every null downstream of it**, and
+naming one of them is this repository's most common finding wearing the join's
+hat.
+
+**Where the added causes stop being separable, say so instead of enumerating
+them.** A full `unattributed_status` was first described as two readings split
+by `ports` — a failed port read where `ports` is null, a join that does not hold
+where `ports` is populated. It is three: an appliance that listed its ports and
+has none mapped reads both lists cleanly and still attributes nothing, which is
+neither. So the description now says what a full list RULES OUT (ports with
+nothing to report; every row in it was read) and names what it cannot tell
+apart, which is #122's rule about `ended: false` reaching a list. **Two review
+rounds went on one sentence here and on the same sentence in `cloudsync_run` —
+when a field's causes come from a guess, assume you have not enumerated them
+all.**
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1348,7 +1348,7 @@ and returning it would be returning a shape with nowhere to put anything. An FC
 host adapter, an FC port and a port's link state are three facts about a
 protocol rather than three parts of one entity: a system whose `fcport.query`
 failed still has adapters worth reporting, and its status rows are still worth
-reporting under `unmatched_status`. So no read there is entitled to fail the
+reporting under `unattributed_status`. So no read there is entitled to fail the
 tool, and the acceptance criterion that a system without the hardware answers
 cleanly falls out of that rather than needing a check of its own.
 
@@ -1373,14 +1373,24 @@ the rows are ATTRIBUTED on: `port` is the only field the status rows and
 `fcport.query` plausibly share, and if that is wrong nothing joins.
 
 **Make a wrong join visible in the shape rather than in the field.** Every
-status row that names no listed port goes to `unmatched_status` rather than
+status row that names no listed port goes to `unattributed_status` rather than
 being dropped, so a join key that does not hold produces empty per-port `status`
-lists beside a full `unmatched_status` — which reads as "this tool could not
+lists beside a full `unattributed_status` — which reads as "this tool could not
 place these" and not as "these ports report nothing about their links". Dropping
 them, or filing them under a port anyway, both produce an answer that looks
 correct and is not. This is `attribute`'s reason in `nvmeof_list` one level up:
 there the unconfirmed part is whether an id answers to a listed subsystem, here
 it is whether the key exists at all.
+
+**What that costs is a second cause for one null, and the description owes
+both.** A port's `status` is null where the status read failed AND where the
+port carries no name to be joined on — the first is in `failures` and the second
+leaves it empty, so `port` and `failures` together are what separate them. The
+same doubling reaches the list: everything landing in `unattributed_status` at
+once is a broken join where `ports` is populated and simply a failed port read
+where `ports` is null. **A join whose key is a guess adds a cause to every null
+downstream of it**, and enumerating one of them is this repository's most common
+finding wearing the join's hat.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1334,6 +1334,54 @@ forwarded, so the fact replaces it; here the raw field is safe to report and is
 the evidence for the companion's reading. Add the reading, keep the field, and
 say in the description which combination means what.
 
+### A read fails the tool only where the others describe its subject (#135)
+
+`iscsi_list` and `nvmeof_list` each let ONE read fail the whole tool —
+`iscsi.target.query` and `nvmet.subsys.query` — and catch the rest into a
+`failures` list. `fc_list` catches all three of its reads and has no primary one.
+That is not the new tool being more careful; it is the same test answered
+differently by the subject.
+
+**Ask what the other reads are ABOUT.** An extent and a session are both facts
+about a target, so a listing with no targets has nothing for either to describe
+and returning it would be returning a shape with nowhere to put anything. An FC
+host adapter, an FC port and a port's link state are three facts about a
+protocol rather than three parts of one entity: a system whose `fcport.query`
+failed still has adapters worth reporting, and its status rows are still worth
+reporting under `unmatched_status`. So no read there is entitled to fail the
+tool, and the acceptance criterion that a system without the hardware answers
+cleanly falls out of that rather than needing a check of its own.
+
+**A `supported` field is a claim, and this tool does not make one.**
+`nvmeof_list` reports `supported: false` off an absent-method rejection, which
+is the strongest thing available to it. `fc.capable` — declared on the pinned
+surface, `params: []`, `response: boolean` — would be a stronger and simpler
+answer for FC, and it is NOT read here: #135's scope names three methods and a
+fourth read is a decision a ticket should make deliberately. What the tool does
+instead is refuse to imply one: its description says outright that the catalog
+cannot say whether a system has FC hardware and that empty `hosts` and `ports`
+do not distinguish absent hardware from unconfigured hardware. **Where a
+question the API can answer is out of scope, say the catalog cannot answer it —
+never let an empty list imply the answer.**
+
+### An unconfirmed allowlist can reach the JOIN, not just the field names (#135)
+
+`fcport.status` answers `unknown[]` — no declared row shape at all — so its four
+reported fields are #98's considered guess, with `unreported_fields` built from
+the keys that produced a value. What is new is that the guess extends to the key
+the rows are ATTRIBUTED on: `port` is the only field the status rows and
+`fcport.query` plausibly share, and if that is wrong nothing joins.
+
+**Make a wrong join visible in the shape rather than in the field.** Every
+status row that names no listed port goes to `unmatched_status` rather than
+being dropped, so a join key that does not hold produces empty per-port `status`
+lists beside a full `unmatched_status` — which reads as "this tool could not
+place these" and not as "these ports report nothing about their links". Dropping
+them, or filing them under a port anyway, both produce an answer that looks
+correct and is not. This is `attribute`'s reason in `nvmeof_list` one level up:
+there the unconfirmed part is whether an id answers to a listed subsystem, here
+it is whether the key exists at all.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `snapshot_tasks_list`, `cloudsync_tasks_list`, `automated_tasks_list`,
   `tasks_recent_runs`,
   `shares_list`, `share_access`, `nfs_clients`, `iscsi_list`, `nvmeof_list`,
+  `fc_list`,
   `users_list`,
   `directory_services_status`, `privileges_list`, `network_interfaces`,
   `network_config`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ export {
   nfsClients,
   iscsiList,
   nvmeofList,
+  fcList,
   usersList,
   directoryServicesStatus,
   privilegesList,

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { failingSystem } from '@/testing/fake-systems';
-import { iscsiList, nvmeofList } from '@/tools/index';
+import { fcList, iscsiList, nvmeofList } from '@/tools/index';
 
 describe('iscsi_list', () => {
   /**
@@ -1043,5 +1043,410 @@ describe('nvmeof_list', () => {
       'nvmet.host_subsys.query',
     ]);
     await listing;
+  });
+});
+
+/**
+ * Here rather than in a spec of its own, under #87's default: the split
+ * exception is checked and was not met. `block.spec.ts` was 1,047 lines and this
+ * block is around 400, so the merged file is about 1,446 — short of the
+ * 1,500-line trigger, which is #97's case rather than #121's.
+ */
+describe('fc_list', () => {
+  /**
+   * A host adapter as `fc.fc_host.query` reports one. `npiv` is optional on the
+   * declared entity and is present here; the cases about it absent build a row
+   * without it rather than overriding it to undefined, since the tool reads
+   * whether the KEY is there.
+   */
+  const host = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    alias: 'fc0',
+    wwpn: '0x21000024ff0a1b2c',
+    wwpn_b: '0x21000024ff0a1b2d',
+    npiv: 2,
+    ...over,
+  });
+
+  /**
+   * A port as `fcport.query` reports one. `target` is an open record on the
+   * declared entity and carries more than the id this tool reduces it to, which
+   * is what the reduction has to drop.
+   */
+  const port = (over: Record<string, unknown> = {}) => ({
+    id: 3,
+    port: 'fc0',
+    wwpn: '0x21000024ff0a1b2c',
+    wwpn_b: '0x21000024ff0a1b2d',
+    target: { id: 11, name: 'tgt0', alias: 'VMware datastore', mode: 'FC' },
+    ...over,
+  });
+
+  /**
+   * A status row as `fcport.status` might report one. Every key here is a guess
+   * — the payload is an open record the middleware declares nothing about — so
+   * `extra` stands for the keys a real system carries that the allowlist does
+   * not name, which is what `unreported_fields` is for.
+   */
+  const status = (over: Record<string, unknown> = {}) => ({
+    port: 'fc0',
+    port_type: 'NPort (fabric via point-to-point)',
+    port_state: 'Online',
+    speed: '16 Gbit',
+    ...over,
+  });
+
+  type Listing = {
+    hosts: Record<string, unknown>[] | null;
+    ports: Record<string, unknown>[] | null;
+    failures: Record<string, unknown>[];
+    unmatched_status: Record<string, unknown>[];
+  };
+
+  const listed = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Listing> => {
+    const { ctx } = failingSystem(
+      {
+        ['fc.fc_host.query']: [host()],
+        ['fcport.query']: [port()],
+        ['fcport.status']: [status()],
+        ...rows,
+      },
+      failures,
+    );
+    return (await fcList.handler(ctx, {})) as Listing;
+  };
+
+  /** The single host of a listing, for the cases about one adapter's fields. */
+  const onlyHost = async (over: Record<string, unknown> = {}) => {
+    const listing = await listed({ ['fc.fc_host.query']: [host(over)] });
+    return (listing.hosts ?? [])[0];
+  };
+
+  /** The single port of a listing, for the cases about one port's fields. */
+  const onlyPort = async (
+    over: Record<string, unknown> = {},
+    rows: Partial<Record<string, unknown>> = {},
+  ) => {
+    const listing = await listed({ ['fcport.query']: [port(over)], ...rows });
+    return (listing.ports ?? [])[0];
+  };
+
+  /** The single status row attributed to the single port. */
+  const onlyStatus = async (over: Record<string, unknown> = {}) => {
+    const listing = await listed({ ['fcport.status']: [status(over)] });
+    return ((listing.ports ?? [])[0]['status'] as Record<string, unknown>[])[0];
+  };
+
+  it('is advertised as read-only and non-mutating', () => {
+    expect(fcList.mutating).toBe(false);
+    expect(fcList.name).toBe('fc_list');
+  });
+
+  it('reads the three FC methods and nothing else', async () => {
+    const { ctx, query, call } = failingSystem({
+      ['fc.fc_host.query']: [host()],
+      ['fcport.query']: [port()],
+      ['fcport.status']: [status()],
+    });
+    await fcList.handler(ctx, {});
+    expect(query.mock.calls.map(([method]) => method)).toEqual([
+      'fc.fc_host.query',
+      'fcport.query',
+    ]);
+    expect(call.mock.calls.map(([method]) => method)).toEqual(['fcport.status']);
+  });
+
+  describe('host adapters', () => {
+    it('reports the adapter and both controllers’ WWPNs', async () => {
+      expect(await onlyHost()).toEqual({
+        id: 1,
+        alias: 'fc0',
+        wwpn: '0x21000024ff0a1b2c',
+        wwpn_b: '0x21000024ff0a1b2d',
+        npiv: 2,
+        npiv_reported: true,
+      });
+    });
+
+    it('reports a single-controller appliance’s absent peer WWPN as null', async () => {
+      expect((await onlyHost({ wwpn_b: null }))['wwpn_b']).toBeNull();
+    });
+
+    it('reports an empty alias as no value rather than as a name', async () => {
+      expect((await onlyHost({ alias: '' }))['alias']).toBeNull();
+    });
+
+    it('reports an id that did not read as a number as null', async () => {
+      expect((await onlyHost({ id: 'first' }))['id']).toBeNull();
+    });
+
+    // The companion field #134 established over the same `field?: T` signature:
+    // one null, two causes, and only this separates them.
+    it('reports npiv_reported false where the system omitted the field', async () => {
+      const { ctx } = failingSystem({
+        ['fc.fc_host.query']: [{ id: 1, alias: 'fc0', wwpn: null, wwpn_b: null }],
+        ['fcport.query']: [],
+        ['fcport.status']: [],
+      });
+      const listing = (await fcList.handler(ctx, {})) as Listing;
+      expect((listing.hosts ?? [])[0]).toMatchObject({ npiv: null, npiv_reported: false });
+    });
+
+    it('reports npiv_reported true beside a null npiv where the value did not read', async () => {
+      expect(await onlyHost({ npiv: 'two' })).toMatchObject({
+        npiv: null,
+        npiv_reported: true,
+      });
+    });
+
+    it('reports a zero npiv as a count rather than as an absence', async () => {
+      expect(await onlyHost({ npiv: 0 })).toMatchObject({ npiv: 0, npiv_reported: true });
+    });
+
+    // `Object.hasOwn` rather than `in`, which walks the prototype (#101). Only
+    // the flag is asserted: reading `host.npiv` walks the chain like any
+    // property access, so an inherited key still produces a value — what must
+    // not happen is that value being ADVERTISED as one the system reported.
+    it('does not read an inherited key as a reported field', async () => {
+      const inherited = Object.create({ npiv: 4 }) as Record<string, unknown>;
+      Object.assign(inherited, { id: 1, alias: 'fc0', wwpn: null, wwpn_b: null });
+      const { ctx } = failingSystem({
+        ['fc.fc_host.query']: [inherited],
+        ['fcport.query']: [],
+        ['fcport.status']: [],
+      });
+      const listing = (await fcList.handler(ctx, {})) as Listing;
+      expect((listing.hosts ?? [])[0]['npiv_reported']).toBe(false);
+    });
+  });
+
+  describe('ports and the target they are mapped to', () => {
+    it('reduces the target record to its id and drops the rest of it', async () => {
+      expect(await onlyPort()).toEqual({
+        id: 3,
+        port: 'fc0',
+        wwpn: '0x21000024ff0a1b2c',
+        wwpn_b: '0x21000024ff0a1b2d',
+        target_mapped: true,
+        target_id: 11,
+        status: [
+          {
+            port: 'fc0',
+            port_type: 'NPort (fabric via point-to-point)',
+            port_state: 'Online',
+            speed: '16 Gbit',
+            unreported_fields: [],
+          },
+        ],
+      });
+    });
+
+    it('reports a port mapped to no target as target_mapped false', async () => {
+      expect(await onlyPort({ target: null })).toMatchObject({
+        target_mapped: false,
+        target_id: null,
+      });
+    });
+
+    it('separates an unreadable target record from a port mapped to nothing', async () => {
+      expect(await onlyPort({ target: 'tgt0' })).toMatchObject({
+        target_mapped: null,
+        target_id: null,
+      });
+    });
+
+    it('does not read a list as a target record', async () => {
+      expect(await onlyPort({ target: [{ id: 11 }] })).toMatchObject({
+        target_mapped: null,
+        target_id: null,
+      });
+    });
+
+    it('reports a mapping whose target carried no readable id as mapped anyway', async () => {
+      expect(await onlyPort({ target: { name: 'tgt0' } })).toMatchObject({
+        target_mapped: true,
+        target_id: null,
+      });
+    });
+
+    it('reports a port name the system did not send as null', async () => {
+      expect((await onlyPort({ port: '' }))['port']).toBeNull();
+    });
+  });
+
+  describe('the unconfirmed status allowlist', () => {
+    it('names every key a row carried whose value it does not report', async () => {
+      expect((await onlyStatus({ physical_port_state: 'Online', node_name: '0x2000' }))[
+        'unreported_fields'
+      ]).toEqual(['node_name', 'physical_port_state']);
+    });
+
+    // The likelier failure of an unconfirmed allowlist is a right key over an
+    // unexpected value type, and a list built from the ALLOWLIST would hide it:
+    // it would answer "every key is reported" beside a null field.
+    it('names a key whose value the guard rejected, not only one nobody looked for', async () => {
+      const row = await onlyStatus({ speed: 16 });
+      expect(row['speed']).toBeNull();
+      expect(row['unreported_fields']).toEqual(['speed']);
+    });
+
+    it('reports an empty unreported_fields where every key it carried is reported', async () => {
+      expect((await onlyStatus())['unreported_fields']).toEqual([]);
+    });
+
+    it('sorts the names so two systems reporting the same keys answer alike', async () => {
+      expect((await onlyStatus({ zeta: 1, alpha: 2 }))['unreported_fields']).toEqual([
+        'alpha',
+        'zeta',
+      ]);
+    });
+
+    it('keeps an entry that was not a record at all, as a row of nulls', async () => {
+      const listing = await listed({ ['fcport.status']: ['Online'] });
+      expect(listing.unmatched_status).toEqual([
+        {
+          port: null,
+          port_type: null,
+          port_state: null,
+          speed: null,
+          unreported_fields: null,
+        },
+      ]);
+    });
+
+    it('tells a non-record entry from a record that named no port', async () => {
+      const listing = await listed({ ['fcport.status']: [{ port_state: 'Online' }] });
+      expect(listing.unmatched_status).toEqual([
+        {
+          port: null,
+          port_type: null,
+          port_state: 'Online',
+          speed: null,
+          unreported_fields: [],
+        },
+      ]);
+    });
+  });
+
+  describe('attributing a status row to a port', () => {
+    it('files every row naming one port under it', async () => {
+      const listing = await listed({
+        ['fcport.status']: [status(), status({ port_state: 'Linkdown' })],
+      });
+      const rows = (listing.ports ?? [])[0]['status'] as Record<string, unknown>[];
+      expect(rows.map((row) => row['port_state'])).toEqual(['Online', 'Linkdown']);
+      expect(listing.unmatched_status).toEqual([]);
+    });
+
+    it('sets aside a row naming a port no listed port answers to', async () => {
+      const listing = await listed({ ['fcport.status']: [status({ port: 'fc9' })] });
+      expect((listing.ports ?? [])[0]['status']).toEqual([]);
+      expect(listing.unmatched_status).toHaveLength(1);
+      expect(listing.unmatched_status[0]['port']).toBe('fc9');
+    });
+
+    it('reports an empty status where the read succeeded and named no port here', async () => {
+      const listing = await listed({ ['fcport.status']: [] });
+      expect((listing.ports ?? [])[0]['status']).toEqual([]);
+      expect(listing.failures).toEqual([]);
+    });
+
+    it('reports a null status for a port the system did not name', async () => {
+      expect((await onlyPort({ port: '' }))['status']).toBeNull();
+    });
+
+    it('sets aside every row where the port read failed', async () => {
+      const listing = await listed({}, { ['fcport.query']: new Error('down') });
+      expect(listing.ports).toBeNull();
+      expect(listing.unmatched_status).toHaveLength(1);
+    });
+  });
+
+  describe('a read that failed', () => {
+    it('names the host read and still answers the other two', async () => {
+      const listing = await listed({}, { ['fc.fc_host.query']: new Error('no such method') });
+      expect(listing.hosts).toBeNull();
+      expect(listing.ports).toHaveLength(1);
+      expect(listing.failures).toEqual([{ source: 'hosts', error: 'no such method' }]);
+    });
+
+    it('names the port read and still answers the other two', async () => {
+      const listing = await listed({}, { ['fcport.query']: { reason: 'denied' } });
+      expect(listing.ports).toBeNull();
+      expect(listing.hosts).toHaveLength(1);
+      expect(listing.failures).toEqual([{ source: 'ports', error: 'denied' }]);
+    });
+
+    // Null rather than empty: an empty `status` says the read placed nothing on
+    // this port, which is a claim about the link a failed read never made.
+    it('names the status read and reports a null status rather than an empty one', async () => {
+      const listing = await listed({}, { ['fcport.status']: new Error('timed out') });
+      expect((listing.ports ?? [])[0]['status']).toBeNull();
+      expect(listing.unmatched_status).toEqual([]);
+      expect(listing.failures).toEqual([{ source: 'port_status', error: 'timed out' }]);
+    });
+
+    it('names all three in read order where none of them answered', async () => {
+      const listing = await listed(
+        {},
+        {
+          ['fc.fc_host.query']: new Error('a'),
+          ['fcport.query']: new Error('b'),
+          ['fcport.status']: new Error('c'),
+        },
+      );
+      expect(listing).toEqual({
+        hosts: null,
+        ports: null,
+        failures: [
+          { source: 'hosts', error: 'a' },
+          { source: 'ports', error: 'b' },
+          { source: 'port_status', error: 'c' },
+        ],
+        unmatched_status: [],
+      });
+    });
+  });
+
+  // The common case the ticket names: an appliance with no FC hardware. It must
+  // answer rather than throw, and an empty answer is not a failure.
+  it('answers cleanly on a system with no Fibre Channel hardware', async () => {
+    const listing = await listed({
+      ['fc.fc_host.query']: [],
+      ['fcport.query']: [],
+      ['fcport.status']: [],
+    });
+    expect(listing).toEqual({ hosts: [], ports: [], failures: [], unmatched_status: [] });
+  });
+
+  describe('its description', () => {
+    // The load-bearing readings, pinned so a later edit cannot quietly drop
+    // them: each is a claim the normalization actually delivers and a caller
+    // acts on differently for having read it.
+    it('says which WWPN is which controller and what a null second one means', () => {
+      expect(fcList.description).toContain('THE TWO CONTROLLERS OF AN HA PAIR');
+      expect(fcList.description).toContain('`ha_status`');
+    });
+
+    it('says the status field names are unconfirmed', () => {
+      expect(fcList.description).toContain('THE FIELD NAMES IN A STATUS ROW ARE UNCONFIRMED');
+    });
+
+    it('says an empty status and a null one are different answers', () => {
+      expect(fcList.description).toContain(
+        'AN EMPTY `status` AND A NULL ONE ARE DIFFERENT ANSWERS',
+      );
+    });
+
+    it('refuses to answer whether the system has FC at all', () => {
+      expect(fcList.description).toContain('THERE IS NO `supported` FIELD');
+    });
+
+    it('says it reports no sessions', () => {
+      expect(fcList.description).toContain('CONFIGURATION AND LINK STATE AND NOT SESSIONS');
+    });
   });
 });

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -1048,9 +1048,11 @@ describe('nvmeof_list', () => {
 
 /**
  * Here rather than in a spec of its own, under #87's default: the split
- * exception is checked and was not met. `block.spec.ts` was 1,047 lines and this
- * block is around 400, so the merged file is about 1,446 — short of the
- * 1,500-line trigger, which is #97's case rather than #121's.
+ * exception is checked and was not met. This file was 1,047 lines and this
+ * block is around 450, so the merged file is 1,497 — under the 1,500-line
+ * trigger, which is #97's case rather than #121's. THE MARGIN IS THREE LINES:
+ * the next tool added to this family meets the exception on arrival, and takes
+ * its own spec named for it rather than growing this one.
  */
 describe('fc_list', () => {
   /**

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -1368,9 +1368,18 @@ describe('fc_list', () => {
       const listing = await listed({}, { ['fcport.query']: new Error('down') });
       expect(listing.ports).toBeNull();
       expect(listing.unattributed_status).toHaveLength(1);
-      // The other reading of a full `unattributed_status`, and `ports` is what
-      // separates it from a port-name join that does not hold.
       expect(listing.failures).toEqual([{ source: 'ports', error: 'down' }]);
+    });
+
+    // The third shape a full `unattributed_status` takes, and the reason the
+    // description refuses to partition it: an adapter with no port mapped reads
+    // both lists successfully and still attributes nothing. It is neither a
+    // failed read nor a join key that does not hold.
+    it('sets aside every row where the ports read succeeded and listed none', async () => {
+      const listing = await listed({ ['fcport.query']: [] });
+      expect(listing.ports).toEqual([]);
+      expect(listing.failures).toEqual([]);
+      expect(listing.unattributed_status).toHaveLength(1);
     });
   });
 
@@ -1461,6 +1470,18 @@ describe('fc_list', () => {
       expect(fcList.description).toContain(
         'NULL HAS TWO CAUSES AND ONLY ONE OF THEM IS A FAILED READ',
       );
+    });
+
+    // A not-established list is not a status enum: say what it rules out and
+    // name what cannot be told apart, rather than offering a partition the
+    // shapes do not support.
+    it('does not partition a full unattributed_status', () => {
+      expect(fcList.description).toContain('IT IS NOT A PARTITION BEYOND THAT');
+      expect(fcList.description).toContain('NOTHING HERE SEPARATES THOSE TWO');
+    });
+
+    it('refuses to relate an adapter to a port', () => {
+      expect(fcList.description).toContain('THIS TOOL DOES NOT RELATE AN ADAPTER TO A PORT');
     });
 
     it('refuses to answer whether the system has FC at all', () => {

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -1100,7 +1100,7 @@ describe('fc_list', () => {
     hosts: Record<string, unknown>[] | null;
     ports: Record<string, unknown>[] | null;
     failures: Record<string, unknown>[];
-    unmatched_status: Record<string, unknown>[];
+    unattributed_status: Record<string, unknown>[];
   };
 
   const listed = async (
@@ -1306,7 +1306,7 @@ describe('fc_list', () => {
 
     it('keeps an entry that was not a record at all, as a row of nulls', async () => {
       const listing = await listed({ ['fcport.status']: ['Online'] });
-      expect(listing.unmatched_status).toEqual([
+      expect(listing.unattributed_status).toEqual([
         {
           port: null,
           port_type: null,
@@ -1319,7 +1319,7 @@ describe('fc_list', () => {
 
     it('tells a non-record entry from a record that named no port', async () => {
       const listing = await listed({ ['fcport.status']: [{ port_state: 'Online' }] });
-      expect(listing.unmatched_status).toEqual([
+      expect(listing.unattributed_status).toEqual([
         {
           port: null,
           port_type: null,
@@ -1338,14 +1338,14 @@ describe('fc_list', () => {
       });
       const rows = (listing.ports ?? [])[0]['status'] as Record<string, unknown>[];
       expect(rows.map((row) => row['port_state'])).toEqual(['Online', 'Linkdown']);
-      expect(listing.unmatched_status).toEqual([]);
+      expect(listing.unattributed_status).toEqual([]);
     });
 
     it('sets aside a row naming a port no listed port answers to', async () => {
       const listing = await listed({ ['fcport.status']: [status({ port: 'fc9' })] });
       expect((listing.ports ?? [])[0]['status']).toEqual([]);
-      expect(listing.unmatched_status).toHaveLength(1);
-      expect(listing.unmatched_status[0]['port']).toBe('fc9');
+      expect(listing.unattributed_status).toHaveLength(1);
+      expect(listing.unattributed_status[0]['port']).toBe('fc9');
     });
 
     it('reports an empty status where the read succeeded and named no port here', async () => {
@@ -1354,14 +1354,23 @@ describe('fc_list', () => {
       expect(listing.failures).toEqual([]);
     });
 
-    it('reports a null status for a port the system did not name', async () => {
-      expect((await onlyPort({ port: '' }))['status']).toBeNull();
+    // The second cause of a null `status`, and the one `failures` cannot show:
+    // a port with no name has nothing for a status row to be joined on, and the
+    // read that would have filled it succeeded.
+    it('reports a null status for a port the system did not name, with no failure', async () => {
+      const listing = await listed({ ['fcport.query']: [port({ port: '' })] });
+      expect((listing.ports ?? [])[0]).toMatchObject({ port: null, status: null });
+      expect(listing.failures).toEqual([]);
+      expect(listing.unattributed_status).toHaveLength(1);
     });
 
     it('sets aside every row where the port read failed', async () => {
       const listing = await listed({}, { ['fcport.query']: new Error('down') });
       expect(listing.ports).toBeNull();
-      expect(listing.unmatched_status).toHaveLength(1);
+      expect(listing.unattributed_status).toHaveLength(1);
+      // The other reading of a full `unattributed_status`, and `ports` is what
+      // separates it from a port-name join that does not hold.
+      expect(listing.failures).toEqual([{ source: 'ports', error: 'down' }]);
     });
   });
 
@@ -1385,7 +1394,7 @@ describe('fc_list', () => {
     it('names the status read and reports a null status rather than an empty one', async () => {
       const listing = await listed({}, { ['fcport.status']: new Error('timed out') });
       expect((listing.ports ?? [])[0]['status']).toBeNull();
-      expect(listing.unmatched_status).toEqual([]);
+      expect(listing.unattributed_status).toEqual([]);
       expect(listing.failures).toEqual([{ source: 'port_status', error: 'timed out' }]);
     });
 
@@ -1406,7 +1415,7 @@ describe('fc_list', () => {
           { source: 'ports', error: 'b' },
           { source: 'port_status', error: 'c' },
         ],
-        unmatched_status: [],
+        unattributed_status: [],
       });
     });
   });
@@ -1419,7 +1428,7 @@ describe('fc_list', () => {
       ['fcport.query']: [],
       ['fcport.status']: [],
     });
-    expect(listing).toEqual({ hosts: [], ports: [], failures: [], unmatched_status: [] });
+    expect(listing).toEqual({ hosts: [], ports: [], failures: [], unattributed_status: [] });
   });
 
   describe('its description', () => {
@@ -1427,8 +1436,14 @@ describe('fc_list', () => {
     // them: each is a claim the normalization actually delivers and a caller
     // acts on differently for having read it.
     it('says which WWPN is which controller and what a null second one means', () => {
-      expect(fcList.description).toContain('THE TWO CONTROLLERS OF AN HA PAIR');
+      expect(fcList.description).toContain('UNDERSTOOD TO BE THE TWO ');
       expect(fcList.description).toContain('`ha_status`');
+    });
+
+    // The reading is the ticket's and not the API's, and saying so is what
+    // keeps it from being a description promising more than the read delivers.
+    it('says the HA reading of the _b fields is not stated by the API', () => {
+      expect(fcList.description).toContain('THAT READING IS NOT STATED BY THE API');
     });
 
     it('says the status field names are unconfirmed', () => {
@@ -1438,6 +1453,13 @@ describe('fc_list', () => {
     it('says an empty status and a null one are different answers', () => {
       expect(fcList.description).toContain(
         'AN EMPTY `status` AND A NULL ONE ARE DIFFERENT ANSWERS',
+      );
+    });
+
+    // One null, two causes, and only one of them is in `failures`.
+    it('enumerates both causes of a null status rather than only the failed read', () => {
+      expect(fcList.description).toContain(
+        'NULL HAS TWO CAUSES AND ONLY ONE OF THEM IS A FAILED READ',
       );
     });
 

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -921,14 +921,21 @@ export const fcList: ReadOnlyTool = {
   description:
     'Every Fibre Channel host adapter the system has, every FC port and the ' +
     'iSCSI target it is mapped to, and each port\'s link status. `hosts` are ' +
-    'the adapters: `id` is the numeric identity, `alias` the name the port is ' +
-    'known by, and `npiv` the number of virtual ports configured on it. `npiv` ' +
+    'the adapters: `id` is the numeric identity, `alias` the label the adapter ' +
+    'records for itself, and `npiv` the number of virtual ports configured on ' +
+    'it. `npiv` ' +
     'IS OPTIONAL ON THIS PAYLOAD, so `npiv_reported` says whether the system ' +
     'reported the field at all — false means this TrueNAS does not report NPIV, ' +
     'while true beside a null `npiv` means it reported something that could not ' +
     'be read as a count. A reported `0` is a real count of none and is not ' +
     'either of those. `ports` are the FC ports: `id` is the numeric identity ' +
     'and `port` the port name, which is also what a `status` row names. ' +
+    'THIS TOOL DOES NOT RELATE AN ADAPTER TO A PORT and offers no field that ' +
+    'does: `hosts[].alias` and `ports[].port` are separate names the payloads ' +
+    'report separately, nothing in the API says they are drawn from one ' +
+    'namespace, and an adapter carrying NPIV virtual ports is precisely the ' +
+    'case where they need not coincide. Matching them by text is a guess, and ' +
+    'not one this tool makes on a caller\'s behalf. ' +
     '`wwpn` AND `wwpn_b` ON BOTH LISTS ARE UNDERSTOOD TO BE THE TWO ' +
     'CONTROLLERS OF AN HA PAIR rather than two ports of one adapter: `wwpn` is ' +
     'this controller\'s World Wide Port Name and `wwpn_b` its peer\'s. THAT ' +
@@ -974,11 +981,15 @@ export const fcList: ReadOnlyTool = {
     'answers to carries that name, one that named no readable port carries a ' +
     'null `port` beside a non-null `unreported_fields`, and one that was not a ' +
     'record at all carries null for both. WHILE IT IS NOT EMPTY THE PER-PORT ' +
-    '`status` LISTS ARE INCOMPLETE. Every row landing there at once has two ' +
-    'readings and `ports` is what separates them: with `ports` null the port ' +
-    'read simply failed and there was nothing to attribute against, while with ' +
-    '`ports` populated it is the shape of a port-name join that does not hold ' +
-    'on this system — in neither case is it ports with nothing to report. ' +
+    '`status` LISTS ARE INCOMPLETE. WHAT A FULL ONE RULES OUT IS PORTS WITH ' +
+    'NOTHING TO REPORT — every row in it was read, and none was dropped. IT IS ' +
+    'NOT A PARTITION BEYOND THAT and this tool does not offer one: a null ' +
+    '`ports` says the port read failed and there was nothing to attribute ' +
+    'against, but where `ports` was read the same shape covers a system whose ' +
+    'status rows name ports it has not mapped, and a port-name join that does ' +
+    'not hold on this system at all — and NOTHING HERE SEPARATES THOSE TWO. ' +
+    'Comparing the `port` names in this list against `ports[].port` is what ' +
+    'tells them apart, and it is the caller\'s to do. ' +
     '`failures` names each read that failed, as ' +
     '`source` — `hosts`, `ports` or `port_status` — and `error`, and is empty ' +
     'when all three were read. NONE OF THE THREE FAILS THE TOOL, so a system ' +

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -804,7 +804,7 @@ function readPortStatus(entry: unknown): FcPortStatus {
 /** Status rows filed under the port each named, and the ones that could not be. */
 interface StatusAttribution {
   byPort: Map<string, FcPortStatus[]>;
-  unmatched: FcPortStatus[];
+  unattributed: FcPortStatus[];
 }
 
 /**
@@ -819,22 +819,22 @@ interface StatusAttribution {
  * The join is on the port NAME because that is the only field the two reads
  * plausibly share — and it is part of the same unconfirmed guess as the
  * allowlist above. Getting it wrong empties every `status` list and fills
- * `unmatched_status`, which is the one shape that says so rather than reading
- * as ports with nothing to report.
+ * `unattributed_status`, which is the one shape that says so rather than
+ * reading as ports with nothing to report.
  */
 function attributeStatus(rows: FcPortStatus[], listed: Set<string>): StatusAttribution {
   const byPort = new Map<string, FcPortStatus[]>();
-  const unmatched: FcPortStatus[] = [];
+  const unattributed: FcPortStatus[] = [];
   for (const row of rows) {
     if (row.port === null || !listed.has(row.port)) {
-      unmatched.push(row);
+      unattributed.push(row);
       continue;
     }
     const filed = byPort.get(row.port);
     if (filed === undefined) byPort.set(row.port, [row]);
     else filed.push(row);
   }
-  return { byPort, unmatched };
+  return { byPort, unattributed };
 }
 
 /**
@@ -845,17 +845,27 @@ function attributeStatus(rows: FcPortStatus[], listed: Set<string>): StatusAttri
  * tool could not read as a count. `npiv_reported` separates the first from the
  * second, which is #134's companion-field shape over the same `field?: T`
  * signature — `Object.hasOwn` and not `in`, which walks the prototype (#101).
+ *
+ * BOTH FIELDS READ THE ROW'S OWN KEY, and that pairing is the point rather than
+ * a flourish. Plain property access walks the prototype too, so reading the
+ * value that way beside a membership test that does not would let a non-null
+ * `npiv` sit beside `npiv_reported: false` — a value presented as one the
+ * system did not report. No JSON payload carries such a chain, which is exactly
+ * why the two would be trusted to agree and never checked.
  */
 async function readFcHosts(system: SystemHandle): Promise<FcHost[]> {
   const hosts = await firstValueFrom(system.client.api.query('fc.fc_host.query'));
-  return hosts.map((host) => ({
-    id: numberOrNull(host.id),
-    alias: textOrNull(host.alias),
-    wwpn: textOrNull(host.wwpn),
-    wwpn_b: textOrNull(host.wwpn_b),
-    npiv: numberOrNull(host.npiv),
-    npiv_reported: Object.hasOwn(host, 'npiv'),
-  }));
+  return hosts.map((host) => {
+    const reported = Object.hasOwn(host, 'npiv');
+    return {
+      id: numberOrNull(host.id),
+      alias: textOrNull(host.alias),
+      wwpn: textOrNull(host.wwpn),
+      wwpn_b: textOrNull(host.wwpn_b),
+      npiv: reported ? numberOrNull(host.npiv) : null,
+      npiv_reported: reported,
+    };
+  });
 }
 
 /**
@@ -919,14 +929,18 @@ export const fcList: ReadOnlyTool = {
     'be read as a count. A reported `0` is a real count of none and is not ' +
     'either of those. `ports` are the FC ports: `id` is the numeric identity ' +
     'and `port` the port name, which is also what a `status` row names. ' +
-    '`wwpn` AND `wwpn_b` ON BOTH LISTS ARE THE TWO CONTROLLERS OF AN HA PAIR, ' +
-    'not two ports of one adapter: `wwpn` is this controller\'s World Wide Port ' +
-    'Name and `wwpn_b` is its peer\'s. A single-controller appliance has no ' +
-    'peer, so a null `wwpn_b` there is the expected answer and NOT a ' +
-    'misconfiguration — it is also what a system that reported no value sends, ' +
-    'and nothing here tells those two apart. `ha_status` is the tool that says ' +
-    'whether this system is an HA pair, and it is what settles which reading a ' +
-    'null `wwpn_b` has. `target_id` is the iSCSI target the port is mapped to, ' +
+    '`wwpn` AND `wwpn_b` ON BOTH LISTS ARE UNDERSTOOD TO BE THE TWO ' +
+    'CONTROLLERS OF AN HA PAIR rather than two ports of one adapter: `wwpn` is ' +
+    'this controller\'s World Wide Port Name and `wwpn_b` its peer\'s. THAT ' +
+    'READING IS NOT STATED BY THE API — both are plain nullable strings on the ' +
+    'payload, which says nothing about what the `_b` names — so it is reported ' +
+    'here as the reading it is. Under it, a single-controller appliance has no ' +
+    'peer and a null `wwpn_b` there is the expected answer rather than a ' +
+    'misconfiguration; but that is also what a system reporting no value sends, ' +
+    'and nothing in this tool tells those two apart. `ha_status` is what says ' +
+    'whether this system is an HA pair at all, and it is what a caller needs ' +
+    'before reading anything into a null `wwpn_b`. ' +
+    '`target_id` is the iSCSI target the port is mapped to, ' +
     'reduced to that target\'s identity and joinable against `iscsi_list`\'s ' +
     '`targets[].id`; the target\'s name and its extents are reported there and ' +
     'not here. `target_mapped` is whether the port named a target at all: false ' +
@@ -949,16 +963,23 @@ export const fcList: ReadOnlyTool = {
     'reported ONLY AS TEXT, so a system sending a numeric `speed` reports null ' +
     'there and names `speed` in `unreported_fields`. AN EMPTY `status` AND A ' +
     'NULL ONE ARE DIFFERENT ANSWERS: empty means the status read succeeded and ' +
-    'no row named this port; null means it could not be read at all, and says ' +
-    'nothing about the link. `hosts` and `ports` are null in the same way and ' +
-    'for the same reason. `unmatched_status` holds status rows that could not ' +
+    'no row named this port. NULL HAS TWO CAUSES AND ONLY ONE OF THEM IS A ' +
+    'FAILED READ — either the status read failed, which `failures` names, or ' +
+    'this port carries a null `port` and so has no name for a status row to be ' +
+    'joined on, which leaves `failures` empty. Read `port` and `failures` ' +
+    'together to tell them apart. Neither says anything about the link. ' +
+    '`hosts` and `ports` are null only in the first way. ' +
+    '`unattributed_status` holds status rows that could not ' +
     'be placed on any port listed here — one naming a `port` no listed port ' +
     'answers to carries that name, one that named no readable port carries a ' +
     'null `port` beside a non-null `unreported_fields`, and one that was not a ' +
     'record at all carries null for both. WHILE IT IS NOT EMPTY THE PER-PORT ' +
-    '`status` LISTS ARE INCOMPLETE; every row landing there at once is the ' +
-    'shape of a port-name join that does not hold on this system rather than of ' +
-    'ports with nothing to report. `failures` names each read that failed, as ' +
+    '`status` LISTS ARE INCOMPLETE. Every row landing there at once has two ' +
+    'readings and `ports` is what separates them: with `ports` null the port ' +
+    'read simply failed and there was nothing to attribute against, while with ' +
+    '`ports` populated it is the shape of a port-name join that does not hold ' +
+    'on this system — in neither case is it ports with nothing to report. ' +
+    '`failures` names each read that failed, as ' +
     '`source` — `hosts`, `ports` or `port_status` — and `error`, and is empty ' +
     'when all three were read. NONE OF THE THREE FAILS THE TOOL, so a system ' +
     'with no Fibre Channel hardware answers cleanly: it reports empty lists ' +
@@ -994,7 +1015,7 @@ export const fcList: ReadOnlyTool = {
 
     // What a status row has to name to be filed under a port. Built from the
     // ports that were read: where the port read itself failed there is nothing
-    // to file against, and every status row is reported unmatched instead.
+    // to file against, and every status row is reported unattributed instead.
     const listed = new Set(
       (ports.value ?? []).flatMap((port) => (port.port === null ? [] : [port.port])),
     );
@@ -1016,7 +1037,9 @@ export const fcList: ReadOnlyTool = {
                   : (attributed.byPort.get(port.port) ?? []),
             })),
       failures,
-      unmatched_status: attributed?.unmatched ?? [],
+      // Named for the concept the two tools above already use: an entity that
+      // was read and could not be placed under the thing it named.
+      unattributed_status: attributed?.unattributed ?? [],
     };
   },
 };

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -2,19 +2,27 @@ import type { QueryEntity } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, ReadOnlyTool, SystemHandle } from '@/catalog/tool';
-import { booleanOrNull, errorText, numberOrNull, textOrNull } from '@/tools/common';
+import {
+  booleanOrNull,
+  errorText,
+  numberOrNull,
+  recordOrNull,
+  textOrNull,
+  unreportedKeys,
+} from '@/tools/common';
 
 /**
  * Block-storage family: what the system serves as block devices rather than as
- * filesystem paths, over each of the two protocols that do it.
+ * filesystem paths, over each of the three protocols that do it.
  *
- * `shares_list` deliberately excludes both, and says so: a target or a
- * subsystem exports a block device rather than a filesystem path, and its
- * vocabulary answers a different question. That question is asked here, once
- * per protocol — `iscsi_list` for iSCSI, `nvmeof_list` for NVMe-oF. They are
- * two tools rather than one because they share no vocabulary: targets, extents
- * and initiators on one side, subsystems, namespaces and hosts on the other,
- * with no field meaning the same thing in both.
+ * `shares_list` deliberately excludes all of them, and says so: a target, a
+ * subsystem or an FC port exports a block device rather than a filesystem path,
+ * and its vocabulary answers a different question. That question is asked here,
+ * once per protocol — `iscsi_list` for iSCSI, `nvmeof_list` for NVMe-oF,
+ * `fc_list` for Fibre Channel. They are three tools rather than one because
+ * they share no vocabulary: targets, extents and initiators on the first side,
+ * subsystems, namespaces and hosts on the second, host adapters, ports and
+ * WWPNs on the third, with no field meaning the same thing in any two.
  *
  * iSCSI takes four middleware namespaces to answer, and none of them nests
  * inside another. `iscsi.target.query` names the targets; `iscsi.extent.query`
@@ -31,6 +39,15 @@ import { booleanOrNull, errorText, numberOrNull, textOrNull } from '@/tools/comm
  * sides whole. None of them is live state — the middleware exposes no
  * equivalent of `iscsi.global.sessions` for NVMe-oF in this client, so
  * `nvmeof_list` answers what is configured and cannot say what is attached.
+ *
+ * Fibre Channel takes three that do not nest at all, and unlike the other two
+ * families one of them is untyped: `fc.fc_host.query` and `fcport.query` are
+ * declared entities, while `fcport.status` takes and answers open records and
+ * is the one read that says whether a link is up. So the FC tool is the only one
+ * here carrying an unconfirmed allowlist and the `unreported_fields` list that
+ * makes it checkable (#98), and the only one whose three reads are ALL caught:
+ * no one of them names the others' subjects, so none is entitled to fail the
+ * tool.
  */
 
 /** Which of the two secondary iSCSI reads failed. */
@@ -251,7 +268,9 @@ export const iscsiList: ReadOnlyTool = {
     '`initiators` AS AN IDLE TARGET: an `FC` target is not served over iSCSI ' +
     'at all, so it holds no iSCSI session by definition and an empty list ' +
     'there says nothing about whether it is in use. Fibre Channel sessions are ' +
-    'not visible to this tool. `extents` are the backing ' +
+    'not visible to this tool, and are not visible to `fc_list` either — the ' +
+    'middleware exposes no FC equivalent of the iSCSI session list, so nothing ' +
+    'in this catalog reports who is attached over FC. `extents` are the backing ' +
     'stores mapped onto the target: `lun` is the logical unit number the ' +
     'initiator addresses it by, `id` the extent\'s numeric identity, `name` its ' +
     'name, and `type` `DISK` or `FILE` — a zvol or a file on a dataset. `disk` ' +
@@ -288,8 +307,10 @@ export const iscsiList: ReadOnlyTool = {
     'visible, and is grouped by initiator in the same way. WHILE IT IS NOT EMPTY THE ' +
     'PER-TARGET `initiators` LISTS ARE INCOMPLETE, and a target reporting an ' +
     'empty list may in fact be in use. This tool reads only iSCSI: NVMe-oF ' +
-    'subsystems and Fibre Channel ports are served separately and are not ' +
-    'listed here, and neither are SMB or NFS shares, which are `shares_list`.',
+    'subsystems are `nvmeof_list` and Fibre Channel host adapters and ports are ' +
+    '`fc_list`, and neither is listed here; nor are SMB or NFS shares, which ' +
+    'are `shares_list`. A target whose `mode` is `FC` or `BOTH` is served over ' +
+    'Fibre Channel, and `fc_list` is what reports the ports carrying it.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
@@ -607,7 +628,8 @@ export const nvmeofList: ReadOnlyTool = {
     'and the other list is unaffected — `failures` names which read that was, ' +
     'and is also what tells a list that could not be read from one that could ' +
     'not be attributed. This tool reads only ' +
-    'NVMe-oF: iSCSI targets are `iscsi_list`, and SMB or NFS shares are ' +
+    'NVMe-oF: iSCSI targets are `iscsi_list`, Fibre Channel host adapters and ' +
+    'ports are `fc_list`, and SMB or NFS shares are ' +
     '`shares_list`. It does not report which ports a subsystem is published ' +
     'on, so a subsystem listed here is not necessarily reachable over the ' +
     'network.',
@@ -693,6 +715,308 @@ export const nvmeofList: ReadOnlyTool = {
         subsystem_id: row.subsystem_id,
         subsystem: row.subsystem,
       })),
+    };
+  },
+};
+
+/** Which of the three Fibre Channel reads failed. */
+type FcSource = 'hosts' | 'ports' | 'port_status';
+
+/**
+ * One Fibre Channel host adapter.
+ *
+ * `wwpn` and `wwpn_b` are the two CONTROLLERS' port names on an HA appliance,
+ * not two ports of one adapter: `wwpn` is this controller's and `wwpn_b` the
+ * peer's, and a single-controller system carries none for a peer it does not
+ * have. That is why both are reported and why the description says which is
+ * which — an operator shown one null would otherwise read a correctly
+ * configured adapter as half-configured.
+ */
+interface FcHost {
+  id: number | null;
+  alias: string | null;
+  wwpn: string | null;
+  wwpn_b: string | null;
+  npiv: number | null;
+  npiv_reported: boolean;
+}
+
+/**
+ * The keys of an `fcport.status` row whose values this tool reports.
+ *
+ * **(unconfirmed) in its entirety.** `fcport.status` takes and answers open
+ * records — `QueryFilters<Record<string, unknown>>` in, `unknown[]` out — so
+ * unlike every other read in this file there is no declared shape to name
+ * fields off, and no live system with FC hardware was available to read the real
+ * keys from. These four are taken from what a Linux FC host publishes per port
+ * (`/sys/class/fc_host/<host>/`), plus the port name the other two reads are
+ * spelled with, and they are a considered guess rather than a reading.
+ *
+ * #98 is what makes the guess checkable instead of hidden: every key a row
+ * actually carried whose value is not reported lands in `unreported_fields`,
+ * built from the keys that PRODUCED A VALUE and never from this list. A wrong
+ * key name and a right key over an unexpected value type then look different
+ * from the outside, and the second is the likelier failure here — a status
+ * record assembled from a sysfs tree sends numbers as text about as readily as
+ * it sends them as numbers.
+ */
+const PORT_STATUS_KEYS = ['port', 'port_type', 'port_state', 'speed'] as const;
+
+/** One row of `fcport.status`, read through the allowlist above. */
+interface FcPortStatus {
+  port: string | null;
+  port_type: string | null;
+  port_state: string | null;
+  speed: string | null;
+  unreported_fields: string[] | null;
+}
+
+/**
+ * One status row, or a row of nulls for an entry that was not a record.
+ *
+ * An unreadable entry is KEPT rather than dropped, per #93's direction rule: the
+ * per-port `status` lists are what a caller reads to find a link that is down,
+ * so a list one entry shorter says a port reported nothing about its link when
+ * what is true is that this tool could not read what it reported. It carries no
+ * `port`, so it is reported beside the listing rather than under a port, and its
+ * null `unreported_fields` is what tells it from a record that named no port.
+ */
+function readPortStatus(entry: unknown): FcPortStatus {
+  const record = recordOrNull(entry);
+  if (record === null) {
+    return { port: null, port_type: null, port_state: null, speed: null, unreported_fields: null };
+  }
+  const read = {
+    port: textOrNull(record['port']),
+    port_type: textOrNull(record['port_type']),
+    port_state: textOrNull(record['port_state']),
+    speed: textOrNull(record['speed']),
+  };
+  return {
+    ...read,
+    unreported_fields: unreportedKeys(
+      record,
+      PORT_STATUS_KEYS.filter((key) => read[key] !== null),
+    ),
+  };
+}
+
+/** Status rows filed under the port each named, and the ones that could not be. */
+interface StatusAttribution {
+  byPort: Map<string, FcPortStatus[]>;
+  unmatched: FcPortStatus[];
+}
+
+/**
+ * The status rows filed under the port each named, where that names a port this
+ * listing actually reports, and set aside where it does not.
+ *
+ * Set aside rather than dropped, for `attribute`'s reason one family over: a
+ * dropped row leaves an empty `status` behind that says the port reported no
+ * link state, which is a claim this read did not make. A row is set aside where
+ * it named no readable `port` and where it named one no listed port answers to.
+ *
+ * The join is on the port NAME because that is the only field the two reads
+ * plausibly share — and it is part of the same unconfirmed guess as the
+ * allowlist above. Getting it wrong empties every `status` list and fills
+ * `unmatched_status`, which is the one shape that says so rather than reading
+ * as ports with nothing to report.
+ */
+function attributeStatus(rows: FcPortStatus[], listed: Set<string>): StatusAttribution {
+  const byPort = new Map<string, FcPortStatus[]>();
+  const unmatched: FcPortStatus[] = [];
+  for (const row of rows) {
+    if (row.port === null || !listed.has(row.port)) {
+      unmatched.push(row);
+      continue;
+    }
+    const filed = byPort.get(row.port);
+    if (filed === undefined) byPort.set(row.port, [row]);
+    else filed.push(row);
+  }
+  return { byPort, unmatched };
+}
+
+/**
+ * Every host adapter the system reported.
+ *
+ * `npiv` is optional on the declared entity, so its null covers a release that
+ * does not report the field at all as well as one that reported something this
+ * tool could not read as a count. `npiv_reported` separates the first from the
+ * second, which is #134's companion-field shape over the same `field?: T`
+ * signature — `Object.hasOwn` and not `in`, which walks the prototype (#101).
+ */
+async function readFcHosts(system: SystemHandle): Promise<FcHost[]> {
+  const hosts = await firstValueFrom(system.client.api.query('fc.fc_host.query'));
+  return hosts.map((host) => ({
+    id: numberOrNull(host.id),
+    alias: textOrNull(host.alias),
+    wwpn: textOrNull(host.wwpn),
+    wwpn_b: textOrNull(host.wwpn_b),
+    npiv: numberOrNull(host.npiv),
+    npiv_reported: Object.hasOwn(host, 'npiv'),
+  }));
+}
+
+/**
+ * One Fibre Channel port, and the iSCSI target it is mapped to reduced to that
+ * target's id.
+ *
+ * `target` is an open record on the declared entity, so it is REDUCED rather
+ * than forwarded (#102): a caller gets the one fact reading it establishes and
+ * nothing a later release adds to that record reaches a tool result.
+ * `target_mapped` is the companion that splits the reduction's null — a port
+ * mapped to no target at all is a different answer from one whose target record
+ * could not be read, and only the first says the port serves nothing.
+ */
+interface FcPort {
+  id: number | null;
+  port: string | null;
+  wwpn: string | null;
+  wwpn_b: string | null;
+  target_mapped: boolean | null;
+  target_id: number | null;
+  status: FcPortStatus[] | null;
+}
+
+/** Every port the system reported, before any status row has been attributed. */
+async function readFcPorts(system: SystemHandle): Promise<Omit<FcPort, 'status'>[]> {
+  const ports = await firstValueFrom(system.client.api.query('fcport.query'));
+  return ports.map((port) => {
+    const target = port.target;
+    const record = recordOrNull(target);
+    return {
+      id: numberOrNull(port.id),
+      port: textOrNull(port.port),
+      wwpn: textOrNull(port.wwpn),
+      wwpn_b: textOrNull(port.wwpn_b),
+      // Three answers rather than two: a record is a mapping, an explicit null
+      // is the system saying there is none, and anything else established
+      // neither — `recordOrNull` alone answers null for the last two alike,
+      // which is the reading this field exists to separate (#102).
+      target_mapped: record !== null ? true : target === null ? false : null,
+      target_id: record === null ? null : numberOrNull(record['id']),
+    };
+  });
+}
+
+/** Every `fcport.status` row the system reported, each read through #98's allowlist. */
+async function readPortStatuses(system: SystemHandle): Promise<FcPortStatus[]> {
+  const rows = await firstValueFrom(system.client.api.call('fcport.status'));
+  return rows.map(readPortStatus);
+}
+
+export const fcList: ReadOnlyTool = {
+  name: 'fc_list',
+  description:
+    'Every Fibre Channel host adapter the system has, every FC port and the ' +
+    'iSCSI target it is mapped to, and each port\'s link status. `hosts` are ' +
+    'the adapters: `id` is the numeric identity, `alias` the name the port is ' +
+    'known by, and `npiv` the number of virtual ports configured on it. `npiv` ' +
+    'IS OPTIONAL ON THIS PAYLOAD, so `npiv_reported` says whether the system ' +
+    'reported the field at all — false means this TrueNAS does not report NPIV, ' +
+    'while true beside a null `npiv` means it reported something that could not ' +
+    'be read as a count. A reported `0` is a real count of none and is not ' +
+    'either of those. `ports` are the FC ports: `id` is the numeric identity ' +
+    'and `port` the port name, which is also what a `status` row names. ' +
+    '`wwpn` AND `wwpn_b` ON BOTH LISTS ARE THE TWO CONTROLLERS OF AN HA PAIR, ' +
+    'not two ports of one adapter: `wwpn` is this controller\'s World Wide Port ' +
+    'Name and `wwpn_b` is its peer\'s. A single-controller appliance has no ' +
+    'peer, so a null `wwpn_b` there is the expected answer and NOT a ' +
+    'misconfiguration — it is also what a system that reported no value sends, ' +
+    'and nothing here tells those two apart. `ha_status` is the tool that says ' +
+    'whether this system is an HA pair, and it is what settles which reading a ' +
+    'null `wwpn_b` has. `target_id` is the iSCSI target the port is mapped to, ' +
+    'reduced to that target\'s identity and joinable against `iscsi_list`\'s ' +
+    '`targets[].id`; the target\'s name and its extents are reported there and ' +
+    'not here. `target_mapped` is whether the port named a target at all: false ' +
+    'is a port mapped to nothing, which serves no data; true beside a null ' +
+    '`target_id` is a mapping whose target this tool could not identify; and ' +
+    'null is a field that was neither. `status` is what `fcport.status` said ' +
+    'about that port, and it is THE ONLY READ HERE THAT SAYS WHETHER A LINK IS ' +
+    'ACTUALLY UP — `port_state` is the system\'s own word for the link state, ' +
+    '`port_type` the topology it negotiated, and `speed` the negotiated speed. ' +
+    'THE FIELD NAMES IN A STATUS ROW ARE UNCONFIRMED: this read answers an open ' +
+    'record the middleware declares nothing about, so the four names above are ' +
+    'taken from what a Linux FC host publishes and have not been checked ' +
+    'against a live system. `unreported_fields` names every key a row actually ' +
+    'carried whose value is not reported here, so an allowlist that does not ' +
+    'fit this system is visible rather than silent: the four fields all null ' +
+    'beside a full `unreported_fields` is a wrong allowlist, and all null ' +
+    'beside an EMPTY one is a row that genuinely carried nothing under those ' +
+    'names. `unreported_fields` is null for an entry that was not a record at ' +
+    'all, whose other fields are then all null for that reason. Values are ' +
+    'reported ONLY AS TEXT, so a system sending a numeric `speed` reports null ' +
+    'there and names `speed` in `unreported_fields`. AN EMPTY `status` AND A ' +
+    'NULL ONE ARE DIFFERENT ANSWERS: empty means the status read succeeded and ' +
+    'no row named this port; null means it could not be read at all, and says ' +
+    'nothing about the link. `hosts` and `ports` are null in the same way and ' +
+    'for the same reason. `unmatched_status` holds status rows that could not ' +
+    'be placed on any port listed here — one naming a `port` no listed port ' +
+    'answers to carries that name, one that named no readable port carries a ' +
+    'null `port` beside a non-null `unreported_fields`, and one that was not a ' +
+    'record at all carries null for both. WHILE IT IS NOT EMPTY THE PER-PORT ' +
+    '`status` LISTS ARE INCOMPLETE; every row landing there at once is the ' +
+    'shape of a port-name join that does not hold on this system rather than of ' +
+    'ports with nothing to report. `failures` names each read that failed, as ' +
+    '`source` — `hosts`, `ports` or `port_status` — and `error`, and is empty ' +
+    'when all three were read. NONE OF THE THREE FAILS THE TOOL, so a system ' +
+    'with no Fibre Channel hardware answers cleanly: it reports empty lists ' +
+    'where the reads succeed and names them in `failures` where they do not. ' +
+    'THERE IS NO `supported` FIELD AND NO CATALOG ANSWER TO "does this system ' +
+    'have FC at all" — empty `hosts` and empty `ports` are the closest thing to ' +
+    'one, and they do not distinguish an appliance with no FC hardware from one ' +
+    'whose hardware is present and unconfigured. This tool reports ' +
+    'CONFIGURATION AND LINK STATE AND NOT SESSIONS: the middleware exposes no ' +
+    'FC equivalent of the iSCSI session list, so nothing here says which hosts ' +
+    'are attached, and a port whose link is up may have nothing talking to it. ' +
+    'It reads only Fibre Channel: iSCSI targets are `iscsi_list`, NVMe-oF ' +
+    'subsystems are `nvmeof_list`, and SMB or NFS shares are `shares_list`.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    // Every read is issued before any is awaited, so none waits on another —
+    // and unlike the two tools above, ALL THREE are caught. There is no primary
+    // read here: an adapter, a port and a link state are three separate facts
+    // about a protocol rather than three parts of one entity, so no one of them
+    // failing leaves the others with nothing to describe.
+    const [hosts, ports, status] = await Promise.all([
+      attempt('hosts', () => readFcHosts(system)),
+      attempt('ports', () => readFcPorts(system)),
+      attempt('port_status', () => readPortStatuses(system)),
+    ]);
+
+    const failures: Failure<FcSource>[] = [];
+    if (hosts.failure !== null) failures.push(hosts.failure);
+    if (ports.failure !== null) failures.push(ports.failure);
+    if (status.failure !== null) failures.push(status.failure);
+
+    // What a status row has to name to be filed under a port. Built from the
+    // ports that were read: where the port read itself failed there is nothing
+    // to file against, and every status row is reported unmatched instead.
+    const listed = new Set(
+      (ports.value ?? []).flatMap((port) => (port.port === null ? [] : [port.port])),
+    );
+    const attributed = status.value === null ? null : attributeStatus(status.value, listed);
+
+    return {
+      hosts: hosts.value,
+      ports:
+        ports.value === null
+          ? null
+          : ports.value.map((port) => ({
+              ...port,
+              // Null for a read that failed and for a port the system did not
+              // name, which is what a status row is joined on; an empty list
+              // for a read that succeeded and placed nothing here.
+              status:
+                attributed === null || port.port === null
+                  ? null
+                  : (attributed.byPort.get(port.port) ?? []),
+            })),
+      failures,
+      unmatched_status: attributed?.unmatched ?? [],
     };
   },
 };

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the fifty-eight sketch tools', () => {
+  it('registers the fifty-nine sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -40,6 +40,7 @@ describe('createDefaultCatalog', () => {
       'nfs_clients',
       'iscsi_list',
       'nvmeof_list',
+      'fc_list',
       'users_list',
       'directory_services_status',
       'privileges_list',
@@ -354,5 +355,9 @@ describe('createDefaultCatalog', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain(
       'privileges_list',
     );
+  });
+
+  it('advertises fc_list to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).toContain('fc_list');
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,7 +2,7 @@ import { ToolCatalog } from '@/catalog/catalog';
 import { directoryServicesStatus, privilegesList, usersList } from '@/tools/accounts';
 import { alertsDismiss, alertSettings, alertsList, alertsRestore } from '@/tools/alerts';
 import { appEngineStatus, appsList, appsUpdateSummary } from '@/tools/apps';
-import { iscsiList, nvmeofList } from '@/tools/block';
+import { fcList, iscsiList, nvmeofList } from '@/tools/block';
 import { bootPoolStatus } from '@/tools/boot';
 import { certificatesList } from '@/tools/certificates';
 import { cloudCredentialsList } from '@/tools/credentials';
@@ -44,7 +44,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: fifty-two read-only tools plus six mutating tools. */
+/** The sketch's catalog: fifty-three read-only tools plus six mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -82,6 +82,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(nfsClients);
   catalog.register(iscsiList);
   catalog.register(nvmeofList);
+  catalog.register(fcList);
   catalog.register(usersList);
   catalog.register(directoryServicesStatus);
   catalog.register(privilegesList);
@@ -129,6 +130,7 @@ export {
   directoryServicesStatus,
   disksList,
   disksTemperature,
+  fcList,
   fleetComplianceReport,
   fleetHealthRollup,
   haStatus,


### PR DESCRIPTION
## What this does

The catalog served two of the three block protocols. `iscsi_list` covers iSCSI
and `nvmeof_list` covers NVMe-oF; Fibre Channel had no tool at all, so on an
appliance presenting storage over FC the catalog reported a pool, a dataset, and
nothing about how any of it reaches a host.

`fc_list` (`src/tools/block.ts`, over `fc.fc_host.query`, `fcport.query` and
`fcport.status`) reports the host adapters, the ports and the iSCSI target each
is mapped to, and each port's link status. Read-only, `requiredRole:
Role.ReadOnly`, `mutating: false`. Both typed reads are named off the call
through the client's own entity rather than by importing the generated interface
(#91), and every field is still read through a `common.ts` guard, because a
declared type is a claim about what the middleware sends and not the value
received.

## The four readings that are the substance of it

**All three reads are caught and none is primary, which is where this differs
from its two siblings.** `iscsi_list` lets `iscsi.target.query` fail the tool and
`nvmeof_list` lets `nvmet.subsys.query` do it, because an extent and a session
are facts *about* a target — with no targets there is nothing for either to
describe. An FC adapter, an FC port and a port's link state are three facts about
a protocol rather than three parts of one entity: a system whose `fcport.query`
failed still has adapters worth reporting. So no read is entitled to fail the
tool, and the acceptance criterion that a system with no FC hardware answers
cleanly falls out of that rather than needing a check of its own.

**`fcport.status` is unconfirmed in its entirety, so it gets #98's treatment.**
It takes and answers open records — `QueryFilters<Record<string, unknown>>` in,
`unknown[]` out — and no live system with FC hardware was available here, so the
four reported names (`port`, `port_type`, `port_state`, `speed`) are taken from
what a Linux FC host publishes and are a considered guess. `unreported_fields`
names every key a row actually carried whose value is not reported, **built from
the keys that produced a value and never from the allowlist**, so a wrong key
name and a right key over an unexpected value type look different from outside —
and the second is the likelier here, since a status record assembled from a sysfs
tree sends numbers as text about as readily as it sends them as numbers. Values
are read as text only, so a numeric `speed` reports null and names itself in the
list rather than passing through under a shape nothing declared.

**The guess reaches the JOIN, not only the field names, and that is what the
last two review rounds were about.** `port` is the only field the status rows and
`fcport.query` plausibly share, so it is what a status row is attributed on. A
row that names no listed port goes to `unattributed_status` rather than being
dropped (#93: dropping moves the per-port list towards empty, and empty is a
claim about the link). The description then does **not** partition a full
`unattributed_status`: it says what such a list rules out — ports with nothing to
report, since every row in it was read — names the null-`ports` case, and says
outright that where `ports` was read nothing separates "status rows naming ports
this system has not mapped" from "the port-name join does not hold here".

**`FCPortEntry.target` is an open record, so it is reduced rather than
forwarded** (#102). `target_id` is the one fact reading it establishes, joinable
against `iscsi_list`'s `targets[].id`; `target_mapped` is the companion that
splits the reduction's null three ways — a record is a mapping, an explicit null
is a port mapped to nothing, and anything else established neither. `recordOrNull`
alone answers null for the last two alike.

`npiv` is optional on the declared entity, so `npiv_reported` separates a TrueNAS
that does not report the field from one whose value would not read — #134's
companion-field shape over the same `field?: T` signature, and both fields read
the row's own key so they cannot disagree.

## What it deliberately does not do

- **It does not read `fc.capable`**, which is declared on the pinned surface
  (`params: []`, `response: boolean`) and would be a cleaner answer to "does this
  system have FC hardware" than anything here. #135's scope names three methods
  and a fourth read is a decision a ticket should make deliberately. What the
  tool does instead is refuse to imply the answer: its description says the
  catalog cannot say, and that empty `hosts` and `ports` do not distinguish
  absent hardware from present-but-unconfigured hardware. Worth its own ticket.
- **It reports no sessions.** The middleware exposes no FC equivalent of
  `iscsi.global.sessions`, so a port whose link is up may have nothing talking to
  it. Stated in the description, and `iscsi_list`'s claim that FC sessions are
  not visible *to it* is corrected to say they are not visible to the catalog.
- **It relates no adapter to a port.** `hosts[].alias` and `ports[].port` are
  separate names the payloads report separately; nothing in the API says they
  share a namespace, and an adapter carrying NPIV virtual ports is exactly the
  case where they need not coincide.
- **The HA reading of `wwpn` / `wwpn_b` is reported as a reading.** The ticket's
  account — `_b` is the second controller — is not stated by the pinned surface,
  which declares two plain nullable strings. The description carries it and says
  it is not the API's claim, and points at `ha_status` for what a null `wwpn_b`
  actually means on a given system.

## What adding this tool did to two descriptions it does not own

A tool description is the string `ToolCatalog.list()` advertises and the only
thing a model routes on, so a new tool can make an existing description
incomplete without touching the file it lives in. Both are in the same file here:

- **`iscsi_list`** said Fibre Channel ports "are served separately and are not
  listed here" without saying where they *are*, and said FC sessions are not
  visible to this tool in a way that now reads as pointing at somewhere else. It
  names `fc_list`, says FC sessions are visible to nothing in the catalog, and
  points a caller holding an `FC` or `BOTH` target at the tool that reports the
  ports carrying it.
- **`nvmeof_list`** enumerated where the other protocols live — iSCSI here,
  shares there — and that enumeration was complete when written and is not now.
  It names `fc_list` too. Under #101 the pointer is owed in both directions.

The file's own header comment said "each of the two protocols that do it"; it now
covers three and says what makes the third's shape different.

## Acceptance criteria

- [x] `fc_list` registered, `mutating: false`, `requiredRole: Role.ReadOnly`
- [x] Nothing from `fcport.status` is forwarded as an open record; every field is
      named explicitly, with `unreported_fields` naming what was not
- [x] `FCPortEntry.target` is not forwarded; it is reduced to `target_id` beside
      `target_mapped`
- [x] Both controllers' WWPNs are reported, the description says which is which
      and what a null second one means — and that the reading is not the API's
- [x] A system with no FC hardware returns a clean answer rather than throwing
- [x] A failure of one read does not prevent the others answering, and is named
      in `failures` as `source` + `error`
- [x] `src/tools/index.spec.ts`'s exact list updated in registration order, with
      its count wording ("fifty-eight" → "fifty-nine") and the same count in
      `createDefaultCatalog`'s doc comment ("fifty-two read-only" → "fifty-three")
- [x] `README.md` tool listing names it
- [x] `yarn test:coverage` meets the floors

## Checks run locally

Every gating step of `.github/workflows/ci.yml` was run here on the final commit:
`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass.
`block.ts` is at 100% statements, branches, functions and lines; the global
figures are 99.75 / 99.46 against floors of 97 / 96, so no floor moved.

## Where the tests live

In `block.spec.ts`, under #87's default rather than in a spec of its own. The
1,500-line exception was checked and is not met: the file was 1,047 lines and
this block is around 450, so the merged file is 1,497. That is #97's case rather
than #121's — but the margin is three lines, and the comment above the block says
so, and says the next tool added to this family takes its own spec on arrival.

## Review rounds, and what is left unchanged

**Round 1 (local).** `local-review.py` ran the project's own reviewer — the same
rubric, threshold and parser the required check uses — and returned one MEDIUM
and four LOWs. The MEDIUM: a port's `status` is null both where the status read
failed and where the port carries no name to join on, and only the first is in
`failures`, so a caller meeting a null `status` beside an empty `failures` was
reading a shape the description said could not occur. All five were fixed in one
commit, because the MEDIUM's fix was a rewrite of the claims the LOWs were about:
the over-broad `unattributed_status` reading, `npiv` read through the prototype
while `npiv_reported` used `Object.hasOwn`, the HA reading asserted as fact, and
`unmatched_status` renamed `unattributed_status` to match what this file already
calls the concept.

**Round 2 (local).** One MEDIUM: round 1's fix was wrong in the same way the
original had been. It said a full `unattributed_status` has two readings split by
`ports` — and there are three, since an appliance that listed its ports and has
none mapped reads both lists cleanly and still attributes nothing. The
description now refuses to partition it at all, per #122's rule that a
not-established field is not a status enum. The round's LOW, on the
`alias`/`port` join, was fixed in the same commit for the same reason as round 1.

**Round 3 (local).** Nothing at or above MEDIUM. One LOW: the split-rule comment
stated a stale line count (1,446, against a real 1,497). That is prose stating
something false about the code it sits above, so it was fixed and pushed without
another round — the exception, not the loop.

Nothing is left unchanged from a finding. `fc.capable` above is the one thing a
reviewer might expect and will not find, and it is an out-of-scope read rather
than a finding anyone raised.

Fixes #135
