### PR TITLE
feat(tools): report iSCSI portals and NVMe-oF ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,8 +305,11 @@ Two things that rule does not decide on its own:
   and the other two stayed. What decides which block moves is that it is one the
   ticket already has open and that moving it brings the file back under 1,500:
   moving a block the ticket did not touch is the re-homing #121 rules out, and
-  moving every block is a rewrite where a move was owed. **Move the largest block
-  the ticket touched, and stop when the file is under the number.**
+  moving every block is a rewrite where a move was owed. **Move a block the
+  ticket touched, and stop as soon as the file is under the number** — which
+  block, where more than one qualifies and either would do it, is not a decision
+  this rule makes. It is not the largest: the block moved here is the smaller of
+  the two, and the file is under the trigger either way.
 - **The catalog-wide test is not any tool's.** The exact-list assertion over
   `createDefaultCatalog()` is about `src/tools/index.ts`, so it lives in
   `index.spec.ts` under the same rule as everything else. Registering a tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ Two things that rule does not decide on its own:
   **The trigger can also be met by GROWING tools rather than by adding one, and
   then there is no new tool whose block is the one to move.** #138 grew two of `block.ts`'s three
   tools past the three-line margin `block.spec.ts` had recorded for itself, so
-  `iscsi_list` — the largest block the ticket touched — took `iscsi-list.spec.ts`
+  `iscsi_list` — one of the two blocks it had open — took `iscsi-list.spec.ts`
   and the other two stayed. What decides which block moves is that it is one the
   ticket already has open and that moving it brings the file back under 1,500:
   moving a block the ticket did not touch is the re-homing #121 rules out, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,16 @@ Two things that rule does not decide on its own:
   not touch is a separate change. So a module can be part-split, and that is not
   a half-finished state to tidy — the next tool over the line takes its own spec
   the same way.
+
+  **The trigger can also be met by GROWING tools rather than by adding one, and
+  then there is no new tool whose block is the one to move.** #138 grew two of `block.ts`'s three
+  tools past the three-line margin `block.spec.ts` had recorded for itself, so
+  `iscsi_list` — the largest block the ticket touched — took `iscsi-list.spec.ts`
+  and the other two stayed. What decides which block moves is that it is one the
+  ticket already has open and that moving it brings the file back under 1,500:
+  moving a block the ticket did not touch is the re-homing #121 rules out, and
+  moving every block is a rewrite where a move was owed. **Move the largest block
+  the ticket touched, and stop when the file is under the number.**
 - **The catalog-wide test is not any tool's.** The exact-list assertion over
   `createDefaultCatalog()` is about `src/tools/index.ts`, so it lives in
   `index.spec.ts` under the same rule as everything else. Registering a tool
@@ -1401,6 +1411,48 @@ apart, which is #122's rule about `ended: false` reaching a list. **Two review
 rounds went on one sentence here and on the same sentence in `cloudsync_run` —
 when a field's causes come from a guess, assume you have not enumerated them
 all.**
+
+### Where a service listens is reported beside what it serves, not under it (#138)
+
+`iscsi_list` reports `portals` and `nvmeof_list` reports `ports`, each a
+top-level list rather than a field on a target or a subsystem. Both are read
+through `attempt`, so neither can fail its tool — which is #135's test answered
+the way `fc_list` answers it: a listener is a fact about the PROTOCOL rather
+than a part of the entity, so a system whose portals did not read still has
+targets and sessions worth reporting.
+
+**Only one of the two families can be joined, and the tool that cannot says so.**
+`nvmet.port_subsys.query` embeds the port and the subsystem whole, so each port
+carries the subsystems published through it — reduced to `subsystem_id` and
+`subsystem` (#100), never forwarded, and the NQN deliberately not repeated
+because it is reported once on the subsystem itself. iSCSI has the same
+relationship in a target's own `groups[].portal` and **this catalog does not
+read it**: `portal` sits beside `initiator` and `auth`, which are the initiator
+allowlist and the CHAP credential, and reading the group was out of #138's
+scope. So `iscsi_list` reports the portals and states outright that it does not
+say which portal serves which target. **A tool reporting two lists a caller
+would expect to be joined has to say it did not join them** — side by side is
+what an implied join looks like from the outside.
+
+**Closing a gap a description NAMES means editing that sentence, not appending
+to it.** `nvmeof_list` said in its own description that it did not report which
+ports a subsystem was published on; that sentence is now the opposite of the
+tool, and it is replaced rather than qualified — with the direction the answer
+is read in (`ports[].subsystems`, since the subsystem row still carries no port
+field) and with what the absence of a subsystem there does NOT establish when
+either read failed or a publication could not be placed.
+
+**A wildcard listen address is the trap, and it is the description's to state.**
+An iSCSI portal on `0.0.0.0` is bound to EVERY address, and `::` is the same
+answer for IPv6 — the opposite of what a reader who sees a placeholder assumes.
+The string is passed through as the system spelled it and the description says
+what it means, which is the same division `addr_trsvcid` gets one tool over:
+declared `number | string | null`, reported as whichever arrived, and never
+converted, because fixing one spelling would assert a meaning the surface
+refuses to (#96). A port's `address` is null both where the field could not be
+read and where the system sent the empty address the middleware accepts on a
+TCP port — stated, since **this catalog does not establish what an empty
+address means** (#120), and a null there is not evidence a port listens nowhere.
 
 ## Conventions
 

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -734,6 +734,19 @@ describe('nvmeof_list', () => {
       ]);
     });
 
+    it('reports a publication naming a subsystem this listing does not report', async () => {
+      // The two are separate round trips, so a subsystem deleted between them
+      // leaves a publication naming it. It is kept under its port — dropping it
+      // would say the port publishes less than it does — and the description
+      // says outright that these fields are the publication's claim rather
+      // than a lookup, so a caller joining them can find nothing.
+      const only = await onlyPort({
+        ['nvmet.port_subsys.query']: [portJoin({ subsys: subsystem({ id: 9, name: 'gone' }) })],
+      });
+      expect(only['subsystems']).toEqual([{ subsystem_id: 9, subsystem: 'gone' }]);
+      expect(nvmeofList.description).toContain('RATHER THAN A LOOKUP');
+    });
+
     it('sets aside a publication naming a port this listing does not report', async () => {
       const listing = await listed({
         ['nvmet.port_subsys.query']: [
@@ -820,8 +833,8 @@ describe('nvmeof_list', () => {
  * exception is checked each time this file grows, and the margin it recorded —
  * three lines — is what #138 spent. That ticket grew `iscsi_list` and
  * `nvmeof_list`, so `iscsi_list` took the spec named for it and this block did
- * not move: the trigger is a file size, and moving the largest block a ticket
- * touched brought this one back under it. A tool added to this family now
+ * not move: the trigger is a file size, and moving either of the two blocks
+ * that ticket had open brought this one back under it. A tool added to this family now
  * measures again against what is left rather than against the old number.
  */
 describe('fc_list', () => {

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -705,6 +705,18 @@ describe('nvmeof_list', () => {
       });
     });
 
+    it('reports a transport this catalog does not recognise as null', async () => {
+      // The three values are read off the OLDEST supported directory (#101), so
+      // a later TrueNAS can send a fourth. Passing it through would put a word
+      // in a field whose type holds three, and a caller switching on it would
+      // fall through every arm.
+      expect(
+        await onlyPort({
+          ['nvmet.port.query']: [port({ addr_trtype: 'ROCE', addr_adrfam: 'IB' })],
+        }),
+      ).toMatchObject({ transport: null, address_family: null });
+    });
+
     it('reports an FC port as a transport rather than as FC hardware', async () => {
       expect(
         await onlyPort({

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -1,541 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { failingSystem } from '@/testing/fake-systems';
-import { fcList, iscsiList, nvmeofList } from '@/tools/index';
+import { fcList, nvmeofList } from '@/tools/index';
 
-describe('iscsi_list', () => {
-  /**
-   * A target as `iscsi.target.query` reports one. `rel_tgt_id`, `mode`,
-   * `groups` and `auth_networks` are real fields of the payload the tool does
-   * not name, and are here to be dropped.
-   */
-  const target = (over: Record<string, unknown> = {}) => ({
-    id: 1,
-    name: 'tgt0',
-    alias: 'VMware datastore',
-    rel_tgt_id: 1,
-    mode: 'ISCSI',
-    groups: [{ portal: 1, initiator: 1 }],
-    auth_networks: [],
-    ...over,
-  });
-
-  /**
-   * An extent as `iscsi.extent.query` reports one. A `DISK` extent carries
-   * BOTH `disk` and `path` — the system reports the device node in `path` too,
-   * so `path` is not evidence that an extent is file-backed.
-   */
-  const extent = (over: Record<string, unknown> = {}) => ({
-    id: 7,
-    name: 'vmstore',
-    type: 'DISK',
-    disk: 'zvol/tank/vmstore',
-    path: '/dev/zvol/tank/vmstore',
-    enabled: true,
-    locked: false,
-    naa: '0x6589cfc000000',
-    vendor: 'TrueNAS',
-    serial: 'abc123',
-    ...over,
-  });
-
-  /** A row of the join table mapping an extent onto a target at a LUN. */
-  const mapping = (over: Record<string, unknown> = {}) => ({
-    id: 4,
-    target: 1,
-    extent: 7,
-    lunid: 0,
-    ...over,
-  });
-
-  /** A live session as `iscsi.global.sessions` reports one. */
-  const session = (over: Record<string, unknown> = {}) => ({
-    initiator: 'iqn.1998-01.com.vmware:esx1',
-    initiator_addr: '10.0.0.20',
-    initiator_alias: 'esx1',
-    target: 'tgt0',
-    target_alias: 'VMware datastore',
-    header_digest: null,
-    data_digest: null,
-    immediate_data: true,
-    iser: false,
-    offload: false,
-    ...over,
-  });
-
-  type Listing = {
-    targets: Record<string, unknown>[];
-    failures: Record<string, unknown>[];
-    unattributed_initiators: Record<string, unknown>[];
-  };
-
-  const listed = async (
-    rows: Partial<Record<string, unknown>> = {},
-    failures: Partial<Record<string, unknown>> = {},
-  ): Promise<Listing> => {
-    const { ctx } = failingSystem(
-      {
-        ['iscsi.target.query']: [target()],
-        ['iscsi.extent.query']: [extent()],
-        ['iscsi.targetextent.query']: [mapping()],
-        ['iscsi.global.sessions']: [session()],
-        ...rows,
-      },
-      failures,
-    );
-    return (await iscsiList.handler(ctx, {})) as Listing;
-  };
-
-  /** The single target of a listing, for the cases about one target's fields. */
-  const onlyTarget = async (
-    rows: Partial<Record<string, unknown>> = {},
-    failures: Partial<Record<string, unknown>> = {},
-  ): Promise<Record<string, unknown>> => (await listed(rows, failures)).targets[0];
-
-  it('reports each target with its extents and connected initiators', async () => {
-    expect(await listed()).toEqual({
-      targets: [
-        {
-          id: 1,
-          name: 'tgt0',
-          alias: 'VMware datastore',
-          mode: 'ISCSI',
-          extents: [
-            {
-              id: 7,
-              lun: 0,
-              name: 'vmstore',
-              type: 'DISK',
-              path: '/dev/zvol/tank/vmstore',
-              disk: 'zvol/tank/vmstore',
-              enabled: true,
-              locked: false,
-            },
-          ],
-          initiators: [
-            {
-              initiator: 'iqn.1998-01.com.vmware:esx1',
-              addresses: ['10.0.0.20'],
-              alias: 'esx1',
-            },
-          ],
-        },
-      ],
-      failures: [],
-      unattributed_initiators: [],
-    });
-  });
-
-  it('surfaces no field a later release adds', async () => {
-    const listing = await listed({
-      ['iscsi.target.query']: [target({ future_field: 'added by a later release' })],
-      ['iscsi.extent.query']: [extent({ future_field: 'added by a later release' })],
-      ['iscsi.targetextent.query']: [mapping({ future_field: 'added by a later release' })],
-      ['iscsi.global.sessions']: [session({ future_field: 'added by a later release' })],
-    });
-    expect(Object.keys(listing.targets[0])).toEqual([
-      'id',
-      'name',
-      'alias',
-      'mode',
-      'extents',
-      'initiators',
-    ]);
-    expect(Object.keys((listing.targets[0]['extents'] as Record<string, unknown>[])[0])).toEqual([
-      'id',
-      'lun',
-      'name',
-      'type',
-      'path',
-      'disk',
-      'enabled',
-      'locked',
-    ]);
-    expect(Object.keys((listing.targets[0]['initiators'] as Record<string, unknown>[])[0])).toEqual(
-      ['initiator', 'addresses', 'alias'],
-    );
-  });
-
-  it('reads a target with no alias as having none', async () => {
-    for (const missing of [null, undefined, '']) {
-      expect(await onlyTarget({ ['iscsi.target.query']: [target({ alias: missing })] })).toMatchObject(
-        { alias: null },
-      );
-    }
-  });
-
-  it('reads an initiator with no alias as having none', async () => {
-    for (const missing of [null, '']) {
-      const initiators = (
-        await onlyTarget({ ['iscsi.global.sessions']: [session({ initiator_alias: missing })] })
-      )['initiators'] as Record<string, unknown>[];
-      expect(initiators[0]['alias']).toBeNull();
-    }
-  });
-
-  it('maps every extent of a target, each at its own LUN', async () => {
-    const extents = (
-      await onlyTarget({
-        ['iscsi.extent.query']: [extent(), extent({ id: 8, name: 'logs', type: 'FILE' })],
-        ['iscsi.targetextent.query']: [mapping(), mapping({ id: 5, extent: 8, lunid: 1 })],
-      })
-    )['extents'] as Record<string, unknown>[];
-    expect(extents.map((mapped) => [mapped['lun'], mapped['name']])).toEqual([
-      [0, 'vmstore'],
-      [1, 'logs'],
-    ]);
-  });
-
-  it('reports the backing store of a DISK extent and of a FILE one', async () => {
-    const extents = (
-      await onlyTarget({
-        ['iscsi.extent.query']: [
-          extent(),
-          extent({ id: 8, type: 'FILE', disk: null, path: '/mnt/tank/iscsi/logs' }),
-        ],
-        ['iscsi.targetextent.query']: [mapping(), mapping({ id: 5, extent: 8, lunid: 1 })],
-      })
-    )['extents'] as Record<string, unknown>[];
-    // `path` is set on both kinds, so it is `disk` and `type` that separate
-    // them — a caller reading a set `path` as "file-backed" would be wrong.
-    expect(extents[0]).toMatchObject({
-      type: 'DISK',
-      disk: 'zvol/tank/vmstore',
-      path: '/dev/zvol/tank/vmstore',
-    });
-    expect(extents[1]).toMatchObject({ type: 'FILE', disk: null, path: '/mnt/tank/iscsi/logs' });
-  });
-
-  it('reports an extent field the system omitted as null, not as a value', async () => {
-    const extents = (
-      await onlyTarget({
-        ['iscsi.extent.query']: [{ id: 7, name: 'vmstore', naa: '0x1', vendor: 'TrueNAS' }],
-      })
-    )['extents'] as Record<string, unknown>[];
-    // `enabled` and `locked` especially: false would say the extent is
-    // definitely not serving, which the system did not report either way.
-    expect(extents[0]).toEqual({
-      id: 7,
-      lun: 0,
-      name: 'vmstore',
-      type: null,
-      path: null,
-      disk: null,
-      enabled: null,
-      locked: null,
-    });
-  });
-
-  it('keeps a mapping whose extent record is missing, marked by a null name', async () => {
-    const extents = (await onlyTarget({ ['iscsi.extent.query']: [] }))[
-      'extents'
-    ] as Record<string, unknown>[];
-    // The LUN was configured, and that is worth reporting; a real extent always
-    // carries a name, so the null name is what says the record was not found.
-    expect(extents).toEqual([
-      {
-        id: 7,
-        lun: 0,
-        name: null,
-        type: null,
-        path: null,
-        disk: null,
-        enabled: null,
-        locked: null,
-      },
-    ]);
-  });
-
-  it('reports a target with nothing mapped to it as an empty extent list', async () => {
-    expect(await onlyTarget({ ['iscsi.targetextent.query']: [] })).toMatchObject({ extents: [] });
-  });
-
-  it('reports a target with no session as an empty initiator list', async () => {
-    expect(await onlyTarget({ ['iscsi.global.sessions']: [] })).toMatchObject({ initiators: [] });
-  });
-
-  it('distinguishes sessions that could not be read from a target with none', async () => {
-    const listing = await listed({}, { ['iscsi.global.sessions']: new Error('service not running') });
-    // Null rather than empty: an empty list would say nothing is connected,
-    // which is the one answer this tool must not invent.
-    expect(listing.targets[0]['initiators']).toBeNull();
-    expect(listing.failures).toEqual([
-      { source: 'initiators', error: 'service not running' },
-    ]);
-  });
-
-  it('distinguishes extents that could not be read from a target with none', async () => {
-    for (const method of ['iscsi.extent.query', 'iscsi.targetextent.query']) {
-      const listing = await listed({}, { [method]: new Error('denied') });
-      expect(listing.targets[0]['extents']).toBeNull();
-      expect(listing.failures).toEqual([{ source: 'extents', error: 'denied' }]);
-      // The other read is unaffected, which is why they are separate failures.
-      expect(listing.targets[0]['initiators']).not.toBeNull();
-    }
-  });
-
-  it('reports both reads failing without losing the targets themselves', async () => {
-    const listing = await listed(
-      {},
-      {
-        ['iscsi.extent.query']: new Error('denied'),
-        ['iscsi.global.sessions']: new Error('service not running'),
-      },
-    );
-    expect(listing.targets).toEqual([
-      {
-        id: 1,
-        name: 'tgt0',
-        alias: 'VMware datastore',
-        mode: 'ISCSI',
-        extents: null,
-        initiators: null,
-      },
-    ]);
-    expect(listing.failures).toEqual([
-      { source: 'extents', error: 'denied' },
-      { source: 'initiators', error: 'service not running' },
-    ]);
-  });
-
-  it('names a failure that is not an Error, and one that says nothing', async () => {
-    expect(
-      (await listed({}, { ['iscsi.global.sessions']: 'connection reset' })).failures,
-    ).toEqual([{ source: 'initiators', error: 'connection reset' }]);
-    for (const silent of [new Error(''), { code: 500 }]) {
-      expect((await listed({}, { ['iscsi.global.sessions']: silent })).failures).toEqual([
-        { source: 'initiators', error: 'the system reported no reason' },
-      ]);
-    }
-  });
-
-  it('raises rather than reporting a system that serves nothing when targets fail', async () => {
-    await expect(
-      listed({}, { ['iscsi.target.query']: new Error('denied') }),
-    ).rejects.toThrow('denied');
-  });
-
-  it('attributes a session naming its target by the full IQN', async () => {
-    expect(
-      await onlyTarget({
-        ['iscsi.global.sessions']: [session({ target: 'iqn.2005-10.org.freenas.ctl:tgt0' })],
-      }),
-    ).toMatchObject({ initiators: [{ initiator: 'iqn.1998-01.com.vmware:esx1' }] });
-  });
-
-  it('groups each session under the one target it is on', async () => {
-    const listing = await listed({
-      ['iscsi.target.query']: [target(), target({ id: 2, name: 'tgt1', alias: null })],
-      ['iscsi.global.sessions']: [
-        session(),
-        session({ initiator: 'iqn.1998-01.com.vmware:esx2', target: 'tgt1' }),
-        session({ initiator: 'iqn.1998-01.com.vmware:esx3', target: 'tgt1' }),
-      ],
-    });
-    expect(
-      listing.targets.map((entry) => [
-        entry['name'],
-        (entry['initiators'] as Record<string, unknown>[]).map((one) => one['initiator']),
-      ]),
-    ).toEqual([
-      ['tgt0', ['iqn.1998-01.com.vmware:esx1']],
-      ['tgt1', ['iqn.1998-01.com.vmware:esx2', 'iqn.1998-01.com.vmware:esx3']],
-    ]);
-  });
-
-  it('counts a multipathed initiator once, keeping every path it reaches from', async () => {
-    // Two sessions, one initiator down two paths. Two entries would make one
-    // host with two NICs read as two hosts attached to the target.
-    const initiators = (
-      await onlyTarget({
-        ['iscsi.global.sessions']: [
-          session(),
-          session({ initiator_addr: '10.0.1.20' }),
-          session({ initiator_addr: '10.0.0.20' }),
-        ],
-      })
-    )['initiators'] as Record<string, unknown>[];
-    expect(initiators).toEqual([
-      {
-        initiator: 'iqn.1998-01.com.vmware:esx1',
-        addresses: ['10.0.0.20', '10.0.1.20'],
-        alias: 'esx1',
-      },
-    ]);
-  });
-
-  it('takes an initiator alias from whichever session carries one', async () => {
-    const initiators = (
-      await onlyTarget({
-        ['iscsi.global.sessions']: [
-          session({ initiator_alias: null }),
-          session({ initiator_addr: '10.0.1.20', initiator_alias: 'esx1' }),
-        ],
-      })
-    )['initiators'] as Record<string, unknown>[];
-    expect(initiators[0]).toMatchObject({ alias: 'esx1' });
-  });
-
-  it('keeps two different initiators on one target apart', async () => {
-    const initiators = (
-      await onlyTarget({
-        ['iscsi.global.sessions']: [
-          session(),
-          session({ initiator: 'iqn.1998-01.com.vmware:esx2', initiator_addr: '10.0.0.21' }),
-        ],
-      })
-    )['initiators'] as Record<string, unknown>[];
-    expect(initiators.map((one) => one['initiator'])).toEqual([
-      'iqn.1998-01.com.vmware:esx1',
-      'iqn.1998-01.com.vmware:esx2',
-    ]);
-  });
-
-  it('reports how a target is served, so an FC target is not read as idle', async () => {
-    // An FC target holds no iSCSI session by definition, so without `mode` its
-    // empty initiator list is indistinguishable from an idle iSCSI target.
-    const listing = await listed({
-      ['iscsi.target.query']: [
-        target({ id: 2, name: 'fctgt', mode: 'FC' }),
-        target({ id: 3, name: 'bothtgt', mode: 'BOTH' }),
-        target({ mode: undefined }),
-      ],
-      ['iscsi.global.sessions']: [],
-    });
-    expect(listing.targets.map((entry) => [entry['name'], entry['mode'], entry['initiators']])).toEqual(
-      [
-        ['fctgt', 'FC', []],
-        ['bothtgt', 'BOTH', []],
-        ['tgt0', null, []],
-      ],
-    );
-  });
-
-  it('groups mappings under the target each names', async () => {
-    const listing = await listed({
-      ['iscsi.target.query']: [target(), target({ id: 2, name: 'tgt1' })],
-      ['iscsi.extent.query']: [extent(), extent({ id: 8, name: 'logs' })],
-      ['iscsi.targetextent.query']: [
-        mapping(),
-        mapping({ id: 5, target: 2, extent: 8, lunid: 0 }),
-      ],
-    });
-    expect(
-      listing.targets.map((entry) => [
-        entry['name'],
-        (entry['extents'] as Record<string, unknown>[]).map((one) => one['name']),
-      ]),
-    ).toEqual([
-      ['tgt0', ['vmstore']],
-      ['tgt1', ['logs']],
-    ]);
-  });
-
-  it('reports a session it could not attribute rather than dropping it', async () => {
-    const listing = await listed({
-      ['iscsi.global.sessions']: [session({ target: 'some-other-spelling' })],
-    });
-    // Silently dropping it would leave the target reading as unused, which is
-    // exactly the answer this tool exists to be trusted on.
-    expect(listing.targets[0]['initiators']).toEqual([]);
-    expect(listing.unattributed_initiators).toEqual([
-      {
-        initiator: 'iqn.1998-01.com.vmware:esx1',
-        addresses: ['10.0.0.20'],
-        alias: 'esx1',
-        target: 'some-other-spelling',
-      },
-    ]);
-  });
-
-  it('groups unattributed sessions by target and initiator, as attributed ones are', async () => {
-    const listing = await listed({
-      ['iscsi.global.sessions']: [
-        session({ target: 'unknown-a' }),
-        session({ target: 'unknown-a', initiator_addr: '10.0.1.20' }),
-        session({ target: 'unknown-b' }),
-        session({ target: 'unknown-a', initiator: 'iqn.1998-01.com.vmware:esx2' }),
-      ],
-    });
-    expect(
-      listing.unattributed_initiators.map((one) => [
-        one['target'],
-        one['initiator'],
-        one['addresses'],
-      ]),
-    ).toEqual([
-      ['unknown-a', 'iqn.1998-01.com.vmware:esx1', ['10.0.0.20', '10.0.1.20']],
-      ['unknown-a', 'iqn.1998-01.com.vmware:esx2', ['10.0.0.20']],
-      ['unknown-b', 'iqn.1998-01.com.vmware:esx1', ['10.0.0.20']],
-    ]);
-  });
-
-  it('leaves a session unattributed where two targets answer to its IQN', async () => {
-    const listing = await listed({
-      ['iscsi.target.query']: [target({ id: 2, name: 'a:tgt0' }), target()],
-      ['iscsi.global.sessions']: [session({ target: 'iqn.2005-10.org.freenas.ctl:a:tgt0' })],
-    });
-    // Both `a:tgt0` and `tgt0` are colon-anchored suffixes of that IQN.
-    // Reporting it against both would invent a connection to one of them.
-    expect(listing.targets.map((entry) => entry['initiators'])).toEqual([[], []]);
-    expect(listing.unattributed_initiators).toHaveLength(1);
-  });
-
-  it('prefers an exact target name over a suffix that also matches', async () => {
-    const listing = await listed({
-      ['iscsi.target.query']: [target({ id: 2, name: 'x:tgt0' }), target()],
-      ['iscsi.global.sessions']: [session({ target: 'x:tgt0' })],
-    });
-    expect(listing.targets.map((entry) => [entry['name'], entry['initiators']])).toEqual([
-      [
-        'x:tgt0',
-        [{ initiator: 'iqn.1998-01.com.vmware:esx1', addresses: ['10.0.0.20'], alias: 'esx1' }],
-      ],
-      ['tgt0', []],
-    ]);
-    expect(listing.unattributed_initiators).toEqual([]);
-  });
-
-  it('reports a system with no targets as an empty list', async () => {
-    expect(
-      await listed({ ['iscsi.target.query']: [], ['iscsi.global.sessions']: [] }),
-    ).toEqual({
-      targets: [],
-      failures: [],
-      unattributed_initiators: [],
-    });
-  });
-
-  it('does not lose a live session on a system whose targets listed as none', async () => {
-    // A session with no target to hang it on is the one case where the tool
-    // has evidence of block storage in use and nothing to attribute it to.
-    const listing = await listed({ ['iscsi.target.query']: [] });
-    expect(listing.targets).toEqual([]);
-    expect(listing.unattributed_initiators).toMatchObject([{ target: 'tgt0' }]);
-  });
-
-  it('issues every read before awaiting any of them', async () => {
-    const { ctx, query } = failingSystem({
-      ['iscsi.target.query']: [target()],
-      ['iscsi.extent.query']: [extent()],
-      ['iscsi.targetextent.query']: [mapping()],
-      ['iscsi.global.sessions']: [session()],
-    });
-    const listing = iscsiList.handler(ctx, {});
-    // Asserted before the handler is awaited at all, which is what makes this
-    // about concurrency rather than order: every read is subscribed while the
-    // handler still holds the thread, so a handler that awaited one read
-    // before starting the next would have made one call by this point. The
-    // same assertion after the await passes either way.
-    expect(query.mock.calls.map((one) => one[0])).toEqual([
-      'iscsi.target.query',
-      'iscsi.extent.query',
-      'iscsi.targetextent.query',
-      'iscsi.global.sessions',
-    ]);
-    await listing;
-  });
-});
-
+/**
+ * `iscsi_list` was split out to `iscsi-list.spec.ts` under #87's exception when
+ * #138 grew two of this module's three tools past the 1,500-line trigger this
+ * file already sat three lines under. The two below stay here: the split is by
+ * tool, and the module's own spec keeping the tools a split did not have to
+ * move is #121's shape rather than a half-finished state to tidy.
+ */
 describe('nvmeof_list', () => {
   /**
    * A subsystem as `nvmet.subsys.query` reports one. `serial`, `pi_enable`,
@@ -585,13 +58,45 @@ describe('nvmeof_list', () => {
     ...over,
   });
 
+  /**
+   * A port as `nvmet.port.query` reports one. `inline_data_size`,
+   * `max_queue_size` and `pi_enable` are real fields of the payload the tool
+   * does not name, and are here to be dropped.
+   */
+  const port = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    index: 1,
+    addr_trtype: 'TCP',
+    addr_trsvcid: 4420,
+    addr_traddr: '10.0.0.10',
+    addr_adrfam: 'IPV4',
+    inline_data_size: null,
+    max_queue_size: null,
+    pi_enable: null,
+    enabled: true,
+    ...over,
+  });
+
+  /**
+   * A row of the join table publishing one subsystem on one port. It embeds
+   * BOTH entities whole, and neither may be forwarded.
+   */
+  const portJoin = (over: Record<string, unknown> = {}) => ({
+    id: 5,
+    port: port(),
+    subsys: subsystem(),
+    ...over,
+  });
+
   type Listing = {
     supported: boolean;
     unsupported_reason: string | null;
     subsystems: Record<string, unknown>[] | null;
+    ports: Record<string, unknown>[] | null;
     failures: Record<string, unknown>[];
     unattributed_namespaces: Record<string, unknown>[];
     unattributed_hosts: Record<string, unknown>[];
+    unattributed_port_subsystems: Record<string, unknown>[];
   };
 
   const listed = async (
@@ -603,12 +108,20 @@ describe('nvmeof_list', () => {
         ['nvmet.subsys.query']: [subsystem()],
         ['nvmet.namespace.query']: [namespace()],
         ['nvmet.host_subsys.query']: [hostJoin()],
+        ['nvmet.port.query']: [port()],
+        ['nvmet.port_subsys.query']: [portJoin()],
         ...rows,
       },
       failures,
     );
     return (await nvmeofList.handler(ctx, {})) as Listing;
   };
+
+  /** The single port of a listing, for the cases about one port's fields. */
+  const onlyPort = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => ((await listed(rows, failures)).ports ?? [])[0];
 
   /** The single subsystem of a listing, for the cases about one's fields. */
   const onlySubsystem = async (
@@ -640,9 +153,23 @@ describe('nvmeof_list', () => {
           ],
         },
       ],
+      ports: [
+        {
+          id: 1,
+          index: 1,
+          transport: 'TCP',
+          address_family: 'IPV4',
+          address: '10.0.0.10',
+          service_id: 4420,
+          enabled: true,
+          enabled_reported: true,
+          subsystems: [{ subsystem_id: 1, subsystem: 'nvme0' }],
+        },
+      ],
       failures: [],
       unattributed_namespaces: [],
       unattributed_hosts: [],
+      unattributed_port_subsystems: [],
     });
   });
 
@@ -651,14 +178,42 @@ describe('nvmeof_list', () => {
       ['nvmet.subsys.query']: [subsystem({ future_field: 'added by a later release' })],
       ['nvmet.namespace.query']: [namespace({ future_field: 'added by a later release' })],
       ['nvmet.host_subsys.query']: [hostJoin({ future_field: 'added by a later release' })],
+      ['nvmet.port.query']: [port({ future_field: 'added by a later release' })],
+      ['nvmet.port_subsys.query']: [
+        portJoin({
+          future_field: 'added by a later release',
+          // Both embedded entities carry one, and forwarding either is what
+          // this assertion exists to catch (#100).
+          port: port({ future_field: 'added by a later release' }),
+          subsys: subsystem({ future_field: 'added by a later release' }),
+        }),
+      ],
     });
     expect(Object.keys(listing)).toEqual([
       'supported',
       'unsupported_reason',
       'subsystems',
+      'ports',
       'failures',
       'unattributed_namespaces',
       'unattributed_hosts',
+      'unattributed_port_subsystems',
+    ]);
+    const onePort = (listing.ports ?? [])[0];
+    expect(Object.keys(onePort)).toEqual([
+      'id',
+      'index',
+      'transport',
+      'address_family',
+      'address',
+      'service_id',
+      'enabled',
+      'enabled_reported',
+      'subsystems',
+    ]);
+    expect(Object.keys((onePort['subsystems'] as Record<string, unknown>[])[0])).toEqual([
+      'subsystem_id',
+      'subsystem',
     ]);
     const only = (listing.subsystems ?? [])[0];
     expect(Object.keys(only)).toEqual([
@@ -1016,14 +571,18 @@ describe('nvmeof_list', () => {
         ['nvmet.subsys.query']: [],
         ['nvmet.namespace.query']: [],
         ['nvmet.host_subsys.query']: [],
+        ['nvmet.port.query']: [],
+        ['nvmet.port_subsys.query']: [],
       }),
     ).toEqual({
       supported: true,
       unsupported_reason: null,
       subsystems: [],
+      ports: [],
       failures: [],
       unattributed_namespaces: [],
       unattributed_hosts: [],
+      unattributed_port_subsystems: [],
     });
   });
 
@@ -1032,6 +591,8 @@ describe('nvmeof_list', () => {
       ['nvmet.subsys.query']: [subsystem()],
       ['nvmet.namespace.query']: [namespace()],
       ['nvmet.host_subsys.query']: [hostJoin()],
+      ['nvmet.port.query']: [port()],
+      ['nvmet.port_subsys.query']: [portJoin()],
     });
     const listing = nvmeofList.handler(ctx, {});
     // Asserted before the handler is awaited at all, which is what makes this
@@ -1041,18 +602,223 @@ describe('nvmeof_list', () => {
       'nvmet.subsys.query',
       'nvmet.namespace.query',
       'nvmet.host_subsys.query',
+      'nvmet.port.query',
+      'nvmet.port_subsys.query',
     ]);
     await listing;
+  });
+
+  describe('where the service listens', () => {
+    it('reports each port with the subsystems published through it', async () => {
+      const listing = await listed({
+        ['nvmet.subsys.query']: [subsystem(), subsystem({ id: 2, name: 'nvme1' })],
+        ['nvmet.port.query']: [port(), port({ id: 2, index: 2, addr_traddr: '10.0.1.10' })],
+        ['nvmet.port_subsys.query']: [
+          portJoin(),
+          portJoin({ id: 6, port: port({ id: 2 }), subsys: subsystem({ id: 2, name: 'nvme1' }) }),
+          portJoin({ id: 7, port: port({ id: 2 }) }),
+        ],
+      });
+      expect((listing.ports ?? []).map((one) => [one['id'], one['subsystems']])).toEqual([
+        [1, [{ subsystem_id: 1, subsystem: 'nvme0' }]],
+        [
+          2,
+          [
+            { subsystem_id: 2, subsystem: 'nvme1' },
+            { subsystem_id: 1, subsystem: 'nvme0' },
+          ],
+        ],
+      ]);
+      expect(listing.unattributed_port_subsystems).toEqual([]);
+    });
+
+    it('reports the service id as the system spelled it, without coercing it', async () => {
+      // `addr_trsvcid` is declared `number | string | null`: a TCP port number
+      // on a TCP port and something else on an FC one. Converting either way
+      // would assert a meaning the surface does not state.
+      for (const [sent, reported] of [
+        [4420, 4420],
+        ['4420', '4420'],
+        ['none', 'none'],
+        [null, null],
+        ['', null],
+        [Number.NaN, null],
+        [{ port: 4420 }, null],
+      ] as [unknown, unknown][]) {
+        expect(
+          await onlyPort({ ['nvmet.port.query']: [port({ addr_trsvcid: sent })] }),
+        ).toMatchObject({ service_id: reported });
+      }
+    });
+
+    it('tells a port that did not report `enabled` from a disabled one', async () => {
+      expect(await onlyPort({ ['nvmet.port.query']: [port({ enabled: false })] })).toMatchObject({
+        enabled: false,
+        enabled_reported: true,
+      });
+      // The field is optional on the payload, so its absence is a TrueNAS that
+      // does not report it rather than a port that is switched off.
+      const without = port();
+      delete (without as Record<string, unknown>)['enabled'];
+      expect(await onlyPort({ ['nvmet.port.query']: [without] })).toMatchObject({
+        enabled: null,
+        enabled_reported: false,
+      });
+      // Reported, and not a boolean: the system said something this tool could
+      // not read, which is a third answer again.
+      expect(await onlyPort({ ['nvmet.port.query']: [port({ enabled: 'yes' })] })).toMatchObject({
+        enabled: null,
+        enabled_reported: true,
+      });
+    });
+
+    it('does not read `enabled` off the prototype chain', async () => {
+      // Plain property access walks the prototype and `Object.hasOwn` does not,
+      // so a value read that way could sit beside `enabled_reported: false`.
+      const inherited = Object.assign(Object.create({ enabled: true }), port());
+      delete (inherited as Record<string, unknown>)['enabled'];
+      expect(await onlyPort({ ['nvmet.port.query']: [inherited] })).toMatchObject({
+        enabled: null,
+        enabled_reported: false,
+      });
+    });
+
+    it('reports a port field the system did not report as null', async () => {
+      expect(await onlyPort({ ['nvmet.port.query']: [{ addr_traddr: '' }] })).toEqual({
+        id: null,
+        index: null,
+        transport: null,
+        address_family: null,
+        // An empty address is reported as null, as a field that could not be
+        // read is: the catalog does not establish what an empty one means.
+        address: null,
+        service_id: null,
+        enabled: null,
+        enabled_reported: false,
+        // Null rather than empty, because the port carries no id for a
+        // publication to be joined on — the case below.
+        subsystems: null,
+      });
+    });
+
+    it('reports an FC port as a transport rather than as FC hardware', async () => {
+      expect(
+        await onlyPort({
+          ['nvmet.port.query']: [
+            port({ addr_trtype: 'FC', addr_adrfam: 'FC', addr_trsvcid: null }),
+          ],
+        }),
+      ).toMatchObject({ transport: 'FC', address_family: 'FC', service_id: null });
+      expect(nvmeofList.description).toContain('NOT A STATEMENT ABOUT THE FC HARDWARE');
+    });
+
+    it('keeps a publication naming a subsystem it could not identify', async () => {
+      // Dropping it would say the port publishes less than it does; keeping it
+      // costs a row that cannot be joined against the listing, which the
+      // description states (#93).
+      const only = await onlyPort({
+        ['nvmet.port_subsys.query']: [
+          portJoin({ subsys: { id: 'one', name: 42 } }),
+          // The whole embedded record being something else answers the same
+          // way, rather than throwing and taking every publication with it.
+          portJoin({ id: 6, subsys: 'nvme0' }),
+        ],
+      });
+      expect(only['subsystems']).toEqual([
+        { subsystem_id: null, subsystem: null },
+        { subsystem_id: null, subsystem: null },
+      ]);
+    });
+
+    it('sets aside a publication naming a port this listing does not report', async () => {
+      const listing = await listed({
+        ['nvmet.port_subsys.query']: [
+          portJoin({ port: port({ id: 9 }) }),
+          portJoin({ id: 6, port: 'not a record' }),
+        ],
+      });
+      // Dropped, both would leave the port reading as publishing nothing.
+      expect((listing.ports ?? [])[0]['subsystems']).toEqual([]);
+      expect(listing.unattributed_port_subsystems).toEqual([
+        { subsystem_id: 1, subsystem: 'nvme0', port_id: 9 },
+        { subsystem_id: 1, subsystem: 'nvme0', port_id: null },
+      ]);
+    });
+
+    it('sets every publication aside when the ports themselves could not be read', async () => {
+      const listing = await listed({}, { ['nvmet.port.query']: new Error('denied') });
+      expect(listing.ports).toBeNull();
+      expect(listing.unattributed_port_subsystems).toEqual([
+        { subsystem_id: 1, subsystem: 'nvme0', port_id: 1 },
+      ]);
+      expect(listing.failures).toEqual([{ source: 'ports', error: 'denied' }]);
+    });
+
+    it('distinguishes publications that could not be read from a port with none', async () => {
+      const listing = await listed({}, { ['nvmet.port_subsys.query']: new Error('denied') });
+      // Null rather than empty: empty would say nothing is reachable through
+      // the port, which is the answer this tool must not invent.
+      expect((listing.ports ?? [])[0]['subsystems']).toBeNull();
+      expect(listing.unattributed_port_subsystems).toEqual([]);
+      expect(listing.failures).toEqual([{ source: 'port_subsystems', error: 'denied' }]);
+      expect((listing.subsystems ?? [])[0]['namespaces']).not.toBeNull();
+    });
+
+    it('reports no publications for a port the system did not number', async () => {
+      const listing = await listed({ ['nvmet.port.query']: [port({ id: null })] });
+      // There is nothing for a publication to be joined on, which is not the
+      // same answer as a read that failed.
+      expect((listing.ports ?? [])[0]['subsystems']).toBeNull();
+      expect(listing.unattributed_port_subsystems).toEqual([
+        { subsystem_id: 1, subsystem: 'nvme0', port_id: 1 },
+      ]);
+      expect(listing.failures).toEqual([]);
+    });
+
+    it('distinguishes a system with no port from one whose ports failed', async () => {
+      expect((await listed({ ['nvmet.port.query']: [] })).ports).toEqual([]);
+      expect((await listed({}, { ['nvmet.port.query']: 'connection reset' })).ports).toBeNull();
+    });
+
+    it('keeps the subsystems when both listener reads failed', async () => {
+      const listing = await listed(
+        {},
+        {
+          ['nvmet.port.query']: new Error('denied'),
+          ['nvmet.port_subsys.query']: new Error('service not running'),
+        },
+      );
+      expect((listing.subsystems ?? [])[0]).toMatchObject({ id: 1, name: 'nvme0' });
+      expect(listing.failures).toEqual([
+        { source: 'ports', error: 'denied' },
+        { source: 'port_subsystems', error: 'service not running' },
+      ]);
+    });
+  });
+
+  describe('its description', () => {
+    it('says where a subsystem\'s ports are read from, now that they are reported', () => {
+      // The tool used to say outright that it did not report this. A caller
+      // reading that sentence beside the field it denies is the failure the
+      // reconciliation prevents.
+      expect(nvmeofList.description).toContain('READ FROM `ports[].subsystems`');
+      expect(nvmeofList.description).not.toContain('does not report which ports');
+    });
+
+    it('says that a service id is not converted between its two spellings', () => {
+      expect(nvmeofList.description).toContain('AS THE SYSTEM SPELLED IT');
+    });
   });
 });
 
 /**
  * Here rather than in a spec of its own, under #87's default: the split
- * exception is checked and was not met. This file was 1,047 lines and this
- * block is around 450, so the merged file is 1,497 — under the 1,500-line
- * trigger, which is #97's case rather than #121's. THE MARGIN IS THREE LINES:
- * the next tool added to this family meets the exception on arrival, and takes
- * its own spec named for it rather than growing this one.
+ * exception is checked each time this file grows, and the margin it recorded —
+ * three lines — is what #138 spent. That ticket grew `iscsi_list` and
+ * `nvmeof_list`, so `iscsi_list` took the spec named for it and this block did
+ * not move: the trigger is a file size, and moving the largest block a ticket
+ * touched brought this one back under it. A tool added to this family now
+ * measures again against what is left rather than against the old number.
  */
 describe('fc_list', () => {
   /**

--- a/src/tools/block.spec.ts
+++ b/src/tools/block.spec.ts
@@ -536,12 +536,16 @@ describe('nvmeof_list', () => {
       expect(await listed({}, { ['nvmet.subsys.query']: reason })).toMatchObject({
         supported: false,
         subsystems: null,
-        // The other two reads fail the same way on such a system; naming them
-        // would report one absent feature three times, as three defects. No row
+        // Null here for the OTHER of the two causes the description names:
+        // nothing was read, rather than a port read that failed.
+        ports: null,
+        // The other four reads fail the same way on such a system; naming them
+        // would report one absent feature five times, as five defects. No row
         // was read either, so nothing was left out of a list.
         failures: [],
         unattributed_namespaces: [],
         unattributed_hosts: [],
+        unattributed_port_subsystems: [],
       });
     }
     expect(

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -24,21 +24,30 @@ import {
  * subsystems, namespaces and hosts on the second, host adapters, ports and
  * WWPNs on the third, with no field meaning the same thing in any two.
  *
- * iSCSI takes four middleware namespaces to answer, and none of them nests
+ * iSCSI takes five middleware namespaces to answer, and none of them nests
  * inside another. `iscsi.target.query` names the targets; `iscsi.extent.query`
  * names the backing stores; `iscsi.targetextent.query` is the join table that
- * maps an extent onto a target at a LUN; and `iscsi.global.sessions` is live
+ * maps an extent onto a target at a LUN; `iscsi.portal.query` names the
+ * addresses the service listens on; and `iscsi.global.sessions` is live
  * state from the running service rather than configuration at all — it is the
  * only one that says whether anything is actually connected. The last is the
  * reason the tool exists: a target with no session is the shape of a hypervisor
- * that quietly dropped its storage, and nothing in the first three can tell that
+ * that quietly dropped its storage, and nothing in the others can tell that
  * from a target nobody has ever used.
  *
- * NVMe-oF takes three, and unlike the iSCSI four they do nest: a namespace
- * carries the subsystem it belongs to, and the host/subsystem join carries both
- * sides whole. None of them is live state — the middleware exposes no
- * equivalent of `iscsi.global.sessions` for NVMe-oF in this client, so
- * `nvmeof_list` answers what is configured and cannot say what is attached.
+ * NVMe-oF takes five, and unlike the iSCSI five three of them nest: a namespace
+ * carries the subsystem it belongs to, and the host/subsystem and
+ * port/subsystem joins carry both sides whole. None of them is live state — the
+ * middleware exposes no equivalent of `iscsi.global.sessions` for NVMe-oF in
+ * this client, so `nvmeof_list` answers what is configured and cannot say what
+ * is attached.
+ *
+ * Both families read where the service listens, and neither read is allowed to
+ * fail its tool: a portal and a port are facts about the protocol rather than
+ * parts of a target or a subsystem, which is #135's test answered the way
+ * `fc_list` answers it. A target's own record carries the portal group it is
+ * published in and this tool does not read it, so where a system has more than
+ * one portal, which target is reachable at which address is not answered here.
  *
  * Fibre Channel takes three that do not nest at all, and unlike the other two
  * families one of them is untyped: `fc.fc_host.query` and `fcport.query` are
@@ -50,11 +59,11 @@ import {
  * tool.
  */
 
-/** Which of the two secondary iSCSI reads failed. */
-type IscsiSource = 'extents' | 'initiators';
+/** Which of the three secondary iSCSI reads failed. */
+type IscsiSource = 'extents' | 'initiators' | 'portals';
 
-/** Which of the two secondary NVMe-oF reads failed. */
-type NvmeofSource = 'namespaces' | 'hosts';
+/** Which of the four secondary NVMe-oF reads failed. */
+type NvmeofSource = 'namespaces' | 'hosts' | 'ports' | 'port_subsystems';
 
 /**
  * One read that failed, and why, for the caller to act on.
@@ -181,6 +190,59 @@ async function readExtents(system: SystemHandle): Promise<Map<number, Extent[]>>
 }
 
 /**
+ * One address a portal accepts connections on, and the TCP port on it.
+ *
+ * Both fields are read rather than trusted, and either is null on its own: an
+ * address with no readable port still says which interface the service is bound
+ * to, which is the half of the answer a caller most often needs.
+ */
+interface Listen {
+  ip: string | null;
+  port: number | null;
+}
+
+/**
+ * One portal: the set of addresses the iSCSI service accepts connections on,
+ * under the tag a target's portal group names it by.
+ *
+ * `listen` is null where the portal reported no list at all and an empty list
+ * where it reported one naming nothing — a portal listening nowhere, which is a
+ * real configuration and not a failed read. An entry inside a list that could
+ * not be read is KEPT as a row of nulls rather than dropped, per #93's direction
+ * rule: a listen list one entry shorter says the service is not reachable at an
+ * address it is in fact bound to, which is a claim, while the kept row of nulls
+ * says only that this tool could not read one of them.
+ */
+interface Portal {
+  id: number | null;
+  tag: number | null;
+  comment: string | null;
+  listen: Listen[] | null;
+}
+
+/** Every portal the system reported, each reduced to named fields. */
+async function readPortals(system: SystemHandle): Promise<Portal[]> {
+  const portals = await firstValueFrom(system.client.api.query('iscsi.portal.query'));
+  return portals.map((portal) => ({
+    id: numberOrNull(portal.id),
+    // The portal group number a target's `groups[].portal` names it by. It is
+    // reported because it is what such a mapping would be read against; this
+    // tool does not make that join, and says so in its description.
+    tag: numberOrNull(portal.tag),
+    comment: textOrNull(portal.comment),
+    listen: Array.isArray(portal.listen)
+      ? portal.listen.map((entry) => {
+          const record = recordOrNull(entry);
+          return {
+            ip: record === null ? null : textOrNull(record['ip']),
+            port: record === null ? null : numberOrNull(record['port']),
+          };
+        })
+      : null,
+  }));
+}
+
+/**
  * One entry per initiator, rather than one per session.
  *
  * A multipathed initiator opens a session down each path — that is what
@@ -299,9 +361,34 @@ export const iscsiList: ReadOnlyTool = {
     '`BOTH` target is one nothing is currently using; null means the sessions ' +
     'could not be read at all, and ' +
     'says nothing about whether anything is connected. `extents` is null in the ' +
-    'same way and for the same reason. `failures` names each read that failed, ' +
-    'as `source` — `extents` or `initiators` — and `error`, and is empty when ' +
-    'both were read. `unattributed_initiators` holds initiators whose sessions ' +
+    'same way and for the same reason. `portals` are the portals the iSCSI ' +
+    'service listens on, and are reported BESIDE the targets rather than under ' +
+    'them: THIS TOOL DOES NOT SAY WHICH PORTAL SERVES WHICH TARGET, so on a ' +
+    'system with more than one portal, which address a given target is reachable ' +
+    'at is not answered here. `id` is the portal\'s numeric identity, `tag` the ' +
+    'portal group number the system knows it by, and `comment` the label it was ' +
+    'given, null where it has none. `listen` is where that portal accepts ' +
+    'connections, one entry per address, with `ip` the address and `port` the ' +
+    'TCP port; either is null where the system reported no readable value. A ' +
+    'LISTEN ADDRESS OF `0.0.0.0` IS NOT AN ADDRESS: it is the wildcard, and ' +
+    'means the portal accepts connections on EVERY IPv4 address the system has, ' +
+    'as `::` does for IPv6. A specific address is the opposite claim — the ' +
+    'service is bound to that address alone, and an initiator pointed at any ' +
+    'other address of the same appliance will not connect, which is the shape ' +
+    'that reads as a working configuration and is not. An entry the system sent ' +
+    'that could not be read is KEPT as a row of nulls rather than dropped, ' +
+    'because a shorter list would say the service is unreachable at an address ' +
+    'it is bound to. AN EMPTY `listen` AND A NULL ONE ARE DIFFERENT ANSWERS: ' +
+    'empty is a portal that listens nowhere, which is a real configuration; ' +
+    'null is a portal that reported no list. AN EMPTY `portals` AND A NULL ONE ' +
+    'ARE DIFFERENT ANSWERS in the same way: empty means the portals were read ' +
+    'and the system has none, so the iSCSI service accepts nothing wherever its ' +
+    'targets point; null means the read failed, which `failures` names, and ' +
+    'says nothing about where the service listens. `failures` names each read ' +
+    'that failed, as `source` — `extents`, `initiators` or `portals` — and ' +
+    '`error`, and is empty when all three were read. NONE OF THOSE THREE FAILS ' +
+    'THE TOOL — the target read is the one that does, and a tool that answered ' +
+    'at all read the targets. `unattributed_initiators` holds initiators whose sessions ' +
     'named a `target` matching none of the targets listed, or matching more ' +
     'than one; each carries that string as `target` so the mismatch is ' +
     'visible, and is grouped by initiator in the same way. WHILE IT IS NOT EMPTY THE ' +
@@ -320,12 +407,16 @@ export const iscsiList: ReadOnlyTool = {
     // describes a target, and with no targets there is nothing for either to
     // describe — while a system whose targets listed and whose sessions did not
     // still has a partial answer worth returning, which is what `failures` is.
-    const [targets, extents, sessions] = await Promise.all([
+    const [targets, extents, sessions, portals] = await Promise.all([
       firstValueFrom(system.client.api.query('iscsi.target.query')),
       attempt('extents', () => readExtents(system)),
       attempt('initiators', () =>
         firstValueFrom(system.client.api.query('iscsi.global.sessions')),
       ),
+      // A portal is where the service listens rather than a fact about any one
+      // target, so it is caught like the other two: a system whose portals did
+      // not read still has targets and sessions worth reporting.
+      attempt('portals', () => readPortals(system)),
     ]);
 
     const byName = new Map(targets.map((target) => [target.name, target.id]));
@@ -345,6 +436,7 @@ export const iscsiList: ReadOnlyTool = {
     const failures: Failure<IscsiSource>[] = [];
     if (extents.failure !== null) failures.push(extents.failure);
     if (sessions.failure !== null) failures.push(sessions.failure);
+    if (portals.failure !== null) failures.push(portals.failure);
 
     return {
       targets: targets.map((target) => ({
@@ -363,6 +455,11 @@ export const iscsiList: ReadOnlyTool = {
         initiators:
           sessions.value === null ? null : groupInitiators(byTarget.get(target.id) ?? []),
       })),
+      // Null for a read that failed and a list for one that succeeded, as the
+      // per-target lists above are — a system with no portal accepts no
+      // connection anywhere, and that must not read the same as a portal read
+      // that did not happen.
+      portals: portals.value,
       failures,
       unattributed_initiators: groupUnattributed(unattributed),
     };
@@ -499,6 +596,144 @@ async function readHosts(system: SystemHandle): Promise<Claim<string | null>[]> 
   }));
 }
 
+/**
+ * One subsystem a port publishes, reduced from the record the join embeds.
+ *
+ * Named for what it is rather than for the entity it came from, and carrying
+ * the same pair the unattributable rows above carry, so the two accounts of a
+ * subsystem cannot be read as two facts. The NQN an initiator connects to is
+ * NOT repeated here: it is reported once, on the subsystem itself, and a caller
+ * reaches it through `subsystem_id`.
+ */
+interface PortSubsystem {
+  subsystem_id: number | null;
+  subsystem: string | null;
+}
+
+/** One row of the port/subsystem join, with the port its record named. */
+interface PortClaim {
+  value: PortSubsystem;
+  port_id: number | null;
+}
+
+/**
+ * The service identifier a port answers on, as the system spelled it.
+ *
+ * `addr_trsvcid` is declared `number | string | null`, which is the surface
+ * refusing to fix a meaning: it is a TCP port number on a TCP port and
+ * something else on an FC one. Both spellings are passed through as themselves
+ * and NEITHER IS COERCED — reading a string as a number would be this
+ * repository asserting a meaning it never read, which is #96's rule about a
+ * unit reaching a value.
+ */
+function serviceId(value: unknown): string | number | null {
+  return typeof value === 'number' ? numberOrNull(value) : textOrNull(value);
+}
+
+/**
+ * One NVMe-oF port: an address the system accepts NVMe-oF connections on, and
+ * the subsystems published through it.
+ *
+ * `enabled` is optional on the declared entity, so `enabled_reported` splits
+ * its null the way `npiv_reported` splits an FC adapter's (#134) — a release
+ * that does not report the field at all from one that reported something this
+ * tool could not read as a boolean. Both read the row's own key, so a value can
+ * never sit beside a `false` there.
+ */
+interface Port {
+  id: number | null;
+  index: number | null;
+  transport: 'TCP' | 'RDMA' | 'FC' | null;
+  address_family: 'IPV4' | 'IPV6' | 'FC' | null;
+  address: string | null;
+  service_id: string | number | null;
+  enabled: boolean | null;
+  enabled_reported: boolean;
+  subsystems: PortSubsystem[] | null;
+}
+
+/** Every port the system reported, before any join row has been attributed. */
+async function readPorts(system: SystemHandle): Promise<Omit<Port, 'subsystems'>[]> {
+  const ports = await firstValueFrom(system.client.api.query('nvmet.port.query'));
+  return ports.map((port) => {
+    const reported = Object.hasOwn(port, 'enabled');
+    return {
+      id: numberOrNull(port.id),
+      // The system's own ordinal for the port, which is not its record id and
+      // does not follow it — the same pairing a namespace's `nsid` and `id`
+      // have above.
+      index: numberOrNull(port.index),
+      transport: port.addr_trtype ?? null,
+      address_family: port.addr_adrfam ?? null,
+      address: textOrNull(port.addr_traddr),
+      service_id: serviceId(port.addr_trsvcid),
+      enabled: reported ? booleanOrNull(port.enabled) : null,
+      enabled_reported: reported,
+    };
+  });
+}
+
+/**
+ * Every port/subsystem publication the system reported, each with the port its
+ * record named.
+ *
+ * `nvmet.port_subsys.query` embeds BOTH sides whole — a full port record and a
+ * full subsystem record on every row — and neither is forwarded (#100): each is
+ * reduced to the identifiers that let a caller attach one to the other, which
+ * is what keeps a field a later release adds to either entity out of a tool
+ * result. Both are read through `recordOrNull` first, so a row that embedded
+ * something other than a record is a row that names nothing rather than a read
+ * that throws and takes the whole publication list with it.
+ */
+async function readPortSubsystems(system: SystemHandle): Promise<PortClaim[]> {
+  const joins = await firstValueFrom(system.client.api.query('nvmet.port_subsys.query'));
+  return joins.map((join) => {
+    const port = recordOrNull(join.port);
+    const subsys = recordOrNull(join.subsys);
+    return {
+      value: {
+        subsystem_id: subsys === null ? null : numberOrNull(subsys['id']),
+        subsystem: subsys === null ? null : textOrNull(subsys['name']),
+      },
+      port_id: port === null ? null : numberOrNull(port['id']),
+    };
+  });
+}
+
+/** Publications filed under the port each named, and the ones that could not be. */
+interface PortAttribution {
+  byPort: Map<number, PortSubsystem[]>;
+  unattributed: (PortSubsystem & { port_id: number | null })[];
+}
+
+/**
+ * The join rows filed under the port each named, where that names a port this
+ * listing reports, and set aside where it does not.
+ *
+ * Set aside rather than dropped, for `attribute`'s reason one read over: a
+ * dropped row leaves an empty `subsystems` behind that says the port publishes
+ * nothing, which is a claim this read did not make. A row naming a port and no
+ * readable subsystem is KEPT UNDER THAT PORT as a pair of nulls, because
+ * dropping it moves the same list towards empty and says the same wrong thing;
+ * what it costs is a row a caller cannot join against `subsystems[]`, which the
+ * description states.
+ */
+function attributePorts(rows: PortClaim[], listed: Set<number>): PortAttribution {
+  const byPort = new Map<number, PortSubsystem[]>();
+  const unattributed: PortAttribution['unattributed'] = [];
+  for (const row of rows) {
+    const id = row.port_id;
+    if (id === null || !listed.has(id)) {
+      unattributed.push({ ...row.value, port_id: id });
+      continue;
+    }
+    const filed = byPort.get(id);
+    if (filed === undefined) byPort.set(id, [row.value]);
+    else filed.push(row.value);
+  }
+  return { byPort, unattributed };
+}
+
 /** The JSON-RPC code for a method the server does not have. */
 const METHOD_NOT_FOUND = -32601;
 
@@ -612,8 +847,49 @@ export const nvmeofList: ReadOnlyTool = {
     'all. `hosts` is null in the same way and for the same reason. Both are ' +
     "also null where `id` is null, because the subsystem's own identity is " +
     'what each is joined on and there is then nothing to attribute to it. ' +
-    '`failures` names each read that failed, as `source` — `namespaces` or ' +
-    '`hosts` — and `error`, and is empty when both were read. ' +
+    '`ports` are the addresses the system accepts NVMe-oF connections on, ' +
+    'reported beside the subsystems rather than under them. `id` is the ' +
+    "port's numeric identity and `index` the system's own ordinal for it — " +
+    'different numbers, and neither follows the other. `transport` is `TCP`, ' +
+    '`RDMA` or `FC` (the payload\'s `addr_trtype`), `address_family` `IPV4`, ' +
+    '`IPV6` or `FC` (`addr_adrfam`), and `address` the address it listens on ' +
+    '(`addr_traddr`). `service_id` is what it answers on (`addr_trsvcid`): a ' +
+    'TCP port number on a TCP port and something else on an FC one, REPORTED ' +
+    'AS THE SYSTEM SPELLED IT — as a number or as text — and never converted ' +
+    'between the two, because the payload declares both and fixing one would ' +
+    'assert a meaning it does not state. `enabled` is whether the port is ' +
+    'switched on, and `enabled_reported` whether the system reported that field ' +
+    'at all: false there means this TrueNAS does not report it, and A PORT THAT ' +
+    'DID NOT REPORT `enabled` IS NOT A DISABLED PORT. True beside a null ' +
+    '`enabled` means it reported something that could not be read as a boolean. ' +
+    'A NULL `address` IS NOT EVIDENCE THAT A PORT LISTENS NOWHERE: the ' +
+    'middleware accepts an empty address on a TCP or RDMA port, this catalog ' +
+    'does not establish what an empty one means there, and an empty address and ' +
+    'a field that could not be read are both reported as null. A port whose ' +
+    '`transport` is `FC` is an NVMe-oF port carried over Fibre Channel, and ' +
+    'THAT IS THE PORT\'S TRANSPORT AND NOT A STATEMENT ABOUT THE FC HARDWARE — ' +
+    'the host adapters, the FC ports and their link state are `fc_list`, and ' +
+    'nothing here reports them. This tool does not report a port\'s tuning ' +
+    'fields — `inline_data_size`, `max_queue_size` and `pi_enable` — which the ' +
+    'system carries and which say nothing about where it listens. ' +
+    '`subsystems` on a port names which subsystems are published through it, ' +
+    'each as the `subsystem_id` and `subsystem` name the join\'s own record ' +
+    'spelled; `subsystem_id` is joinable against `subsystems[].id`, and the NQN ' +
+    'an initiator connects to is reported there rather than repeated here. An ' +
+    'entry whose `subsystem_id` is null is a publication naming a subsystem ' +
+    'this tool could not identify: it is kept, because dropping it would say ' +
+    'the port publishes less than it does, and it cannot be joined against the ' +
+    'listing. AN EMPTY `subsystems` AND A NULL ONE ARE DIFFERENT ANSWERS: empty ' +
+    'means the publications were read and none names this port, so nothing is ' +
+    'reachable through it; null means they could not be read at all, or that ' +
+    'this port carries no `id` for a publication to be joined on. AN EMPTY ' +
+    '`ports` AND A NULL ONE ARE DIFFERENT ANSWERS in the same way: empty is a ' +
+    'system with no NVMe-oF port configured, which is a system whose subsystems ' +
+    'are unreachable however they are configured; null is a read that failed, ' +
+    'which `failures` names. ' +
+    '`failures` names each read that failed, as `source` — `namespaces`, ' +
+    '`hosts`, `ports` or `port_subsystems` — and `error`, and is empty when all ' +
+    'four were read. ' +
     '`unattributed_namespaces` and `unattributed_hosts` hold the rows that ' +
     'WERE read and could not be placed on any subsystem listed here. Each ' +
     'carries the `subsystem_id` and `subsystem` name its own record named, so ' +
@@ -627,12 +903,21 @@ export const nvmeofList: ReadOnlyTool = {
     'the read that would fill it failed, because nothing was read to place, ' +
     'and the other list is unaffected — `failures` names which read that was, ' +
     'and is also what tells a list that could not be read from one that could ' +
-    'not be attributed. This tool reads only ' +
+    'not be attributed. `unattributed_port_subsystems` holds publications that ' +
+    'name a port not listed here, each carrying the `port_id` its record named ' +
+    'and null where it named none. WHILE IT IS NOT EMPTY THE PER-PORT ' +
+    '`subsystems` LISTS ARE INCOMPLETE, and an empty one there is not a port ' +
+    'publishing nothing. Where the port read itself failed there is nothing to ' +
+    'attribute against and every publication lands in it. This tool reads only ' +
     'NVMe-oF: iSCSI targets are `iscsi_list`, Fibre Channel host adapters and ' +
     'ports are `fc_list`, and SMB or NFS shares are ' +
-    '`shares_list`. It does not report which ports a subsystem is published ' +
-    'on, so a subsystem listed here is not necessarily reachable over the ' +
-    'network.',
+    '`shares_list`. WHICH PORTS A SUBSYSTEM IS PUBLISHED ON IS READ FROM ' +
+    '`ports[].subsystems` AND NOT FROM THE SUBSYSTEM ROW, which carries no port ' +
+    'field: a subsystem named in no port\'s `subsystems` is one nothing ' +
+    'publishes and so is not reachable over the network — but ONLY where the ' +
+    'port and publication reads both succeeded and no publication is ' +
+    'unattributed. Where either read failed, or a publication could not be ' +
+    'placed, that absence says nothing.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
@@ -641,10 +926,15 @@ export const nvmeofList: ReadOnlyTool = {
     // as in `iscsi_list` only the first is allowed to fail the tool: a namespace
     // and a host describe a subsystem, and with no subsystems there is nothing
     // for either to describe.
-    const [subsystems, namespaces, hosts] = await Promise.all([
+    const [subsystems, namespaces, hosts, ports, publications] = await Promise.all([
       readSubsystems(system),
       attempt('namespaces', () => readNamespaces(system)),
       attempt('hosts', () => readHosts(system)),
+      // Caught like the other three, and for `iscsi_list`'s reason: a port is
+      // where the service listens rather than a part of any one subsystem, so a
+      // system whose ports did not read still has subsystems worth reporting.
+      attempt('ports', () => readPorts(system)),
+      attempt('port_subsystems', () => readPortSubsystems(system)),
     ]);
 
     if (subsystems.rows === null) {
@@ -656,18 +946,22 @@ export const nvmeofList: ReadOnlyTool = {
         supported: false,
         unsupported_reason: errorText(subsystems.reason),
         subsystems: null,
-        // The other two reads fail the same way on such a system. Naming them
-        // would report one absent feature three times, as three defects — and
+        ports: null,
+        // The other four reads fail the same way on such a system. Naming them
+        // would report one absent feature five times, as five defects — and
         // no row was read, so nothing was left out of a list either.
         failures: [],
         unattributed_namespaces: [],
         unattributed_hosts: [],
+        unattributed_port_subsystems: [],
       };
     }
 
     const failures: Failure<NvmeofSource>[] = [];
     if (namespaces.failure !== null) failures.push(namespaces.failure);
     if (hosts.failure !== null) failures.push(hosts.failure);
+    if (ports.failure !== null) failures.push(ports.failure);
+    if (publications.failure !== null) failures.push(publications.failure);
 
     // Read rather than trusted, and read once: the id is both the reported
     // identity and what the other two reads are attributed by, so a subsystem
@@ -683,6 +977,16 @@ export const nvmeofList: ReadOnlyTool = {
     const listed = new Set(identified.flatMap(({ id }) => (id === null ? [] : [id])));
     const attributed = namespaces.value === null ? null : attribute(namespaces.value, listed);
     const allowed = hosts.value === null ? null : attribute(hosts.value, listed);
+
+    // What a publication has to name to be filed under a port. Built from the
+    // ports that were read: where the port read failed there is nothing to file
+    // against, and every publication is reported unattributed instead — the
+    // same shape `fc_list` gives an unattributable status row.
+    const listedPorts = new Set(
+      (ports.value ?? []).flatMap((port) => (port.id === null ? [] : [port.id])),
+    );
+    const published =
+      publications.value === null ? null : attributePorts(publications.value, listedPorts);
 
     return {
       supported: true,
@@ -701,6 +1005,20 @@ export const nvmeofList: ReadOnlyTool = {
         namespaces:
           attributed === null || id === null ? null : (attributed.bySubsystem.get(id) ?? []),
       })),
+      ports:
+        ports.value === null
+          ? null
+          : ports.value.map((port) => ({
+              ...port,
+              // Null for a publication read that failed and for a port the
+              // system did not number, which is what a publication is joined
+              // on; an empty list for a read that succeeded and placed nothing
+              // here.
+              subsystems:
+                published === null || port.id === null
+                  ? null
+                  : (published.byPort.get(port.id) ?? []),
+            })),
       failures,
       // Flat rather than nested, as `iscsi_list` reports its own unattributable
       // rows: what the row said is beside what it named, so a caller reading one
@@ -715,6 +1033,7 @@ export const nvmeofList: ReadOnlyTool = {
         subsystem_id: row.subsystem_id,
         subsystem: row.subsystem,
       })),
+      unattributed_port_subsystems: published?.unattributed ?? [],
     };
   },
 };

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -874,8 +874,9 @@ export const nvmeofList: ReadOnlyTool = {
     'system carries and which say nothing about where it listens. ' +
     '`subsystems` on a port names which subsystems are published through it, ' +
     'each as the `subsystem_id` and `subsystem` name the join\'s own record ' +
-    'spelled; `subsystem_id` is joinable against `subsystems[].id`, and the NQN ' +
-    'an initiator connects to is reported there rather than repeated here. An ' +
+    'spelled; `subsystem_id` is joinable against the `id` of an entry in THIS ' +
+    'RESULT\'S TOP-LEVEL `subsystems` LIST, which is where the NQN an initiator ' +
+    'connects to is reported rather than repeated here. An ' +
     'entry whose `subsystem_id` is null is a publication naming a subsystem ' +
     'this tool could not identify: it is kept, because dropping it would say ' +
     'the port publishes less than it does, and it cannot be joined against the ' +
@@ -885,8 +886,10 @@ export const nvmeofList: ReadOnlyTool = {
     'this port carries no `id` for a publication to be joined on. AN EMPTY ' +
     '`ports` AND A NULL ONE ARE DIFFERENT ANSWERS in the same way: empty is a ' +
     'system with no NVMe-oF port configured, which is a system whose subsystems ' +
-    'are unreachable however they are configured; null is a read that failed, ' +
-    'which `failures` names. ' +
+    'are unreachable however they are configured. NULL HAS TWO CAUSES, and ' +
+    '`supported` is what separates them: where it is false the system has no ' +
+    'NVMe-oF at all and nothing was read, so `failures` is empty; where it is ' +
+    'true the port read failed, and `failures` names it. ' +
     '`failures` names each read that failed, as `source` — `namespaces`, ' +
     '`hosts`, `ports` or `port_subsystems` — and `error`, and is empty when all ' +
     'four were read. ' +

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -874,13 +874,17 @@ export const nvmeofList: ReadOnlyTool = {
     'system carries and which say nothing about where it listens. ' +
     '`subsystems` on a port names which subsystems are published through it, ' +
     'each as the `subsystem_id` and `subsystem` name the join\'s own record ' +
-    'spelled; `subsystem_id` is joinable against the `id` of an entry in THIS ' +
-    'RESULT\'S TOP-LEVEL `subsystems` LIST, which is where the NQN an initiator ' +
-    'connects to is reported rather than repeated here. An ' +
-    'entry whose `subsystem_id` is null is a publication naming a subsystem ' +
-    'this tool could not identify: it is kept, because dropping it would say ' +
-    'the port publishes less than it does, and it cannot be joined against the ' +
-    'listing. AN EMPTY `subsystems` AND A NULL ONE ARE DIFFERENT ANSWERS: empty ' +
+    'spelled. THEY ARE WHAT THE PUBLICATION CLAIMED RATHER THAN A LOOKUP: an ' +
+    'entry is reported here whether or not its `subsystem_id` answers to an ' +
+    'entry in this result\'s top-level `subsystems` list, so a caller joining ' +
+    'the two can find nothing under it — the reads are separate round trips, ' +
+    'and a subsystem deleted between them leaves a publication naming it. Such ' +
+    'an entry is KEPT, because dropping it would say the port publishes less ' +
+    'than it does. An entry whose `subsystem_id` is null is a publication ' +
+    'naming a subsystem this tool could not identify at all, and is kept for ' +
+    'the same reason. WHERE THE JOIN DOES LAND, the top-level entry is where ' +
+    'the NQN an initiator connects to is reported, rather than repeated here. ' +
+    'AN EMPTY `subsystems` AND A NULL ONE ARE DIFFERENT ANSWERS: empty ' +
     'means the publications were read and none names this port, so nothing is ' +
     'reachable through it; null means they could not be read at all, or that ' +
     'this port carries no `id` for a publication to be joined on. AN EMPTY ' +
@@ -911,7 +915,9 @@ export const nvmeofList: ReadOnlyTool = {
     'and null where it named none. WHILE IT IS NOT EMPTY THE PER-PORT ' +
     '`subsystems` LISTS ARE INCOMPLETE, and an empty one there is not a port ' +
     'publishing nothing. Where the port read itself failed there is nothing to ' +
-    'attribute against and every publication lands in it. This tool reads only ' +
+    'attribute against and every publication lands in it; where the ' +
+    'PUBLICATION read failed it is EMPTY, because nothing was read to place, ' +
+    'and every port\'s `subsystems` is null instead. This tool reads only ' +
     'NVMe-oF: iSCSI targets are `iscsi_list`, Fibre Channel host adapters and ' +
     'ports are `fc_list`, and SMB or NFS shares are ' +
     '`shares_list`. WHICH PORTS A SUBSYSTEM IS PUBLISHED ON IS READ FROM ' +

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -367,7 +367,10 @@ export const iscsiList: ReadOnlyTool = {
     'system with more than one portal, which address a given target is reachable ' +
     'at is not answered here. `id` is the portal\'s numeric identity, `tag` the ' +
     'portal group number the system knows it by, and `comment` the label it was ' +
-    'given, null where it has none. `listen` is where that portal accepts ' +
+    'given; EVERY ONE OF THE THREE IS NULL WHERE THE SYSTEM REPORTED NO ' +
+    'READABLE VALUE, which for `comment` is also a portal that was never ' +
+    'labelled, and a portal with a null `id` or `tag` is one this tool could ' +
+    'not identify rather than one that is not there. `listen` is where that portal accepts ' +
     'connections, one entry per address, with `ip` the address and `port` the ' +
     'TCP port; either is null where the system reported no readable value. A ' +
     'LISTEN ADDRESS OF `0.0.0.0` IS NOT AN ADDRESS: it is the wildcard, and ' +
@@ -630,6 +633,30 @@ function serviceId(value: unknown): string | number | null {
   return typeof value === 'number' ? numberOrNull(value) : textOrNull(value);
 }
 
+/** The transports a port can be carried over, as the pinned surface declares them. */
+const TRANSPORTS = ['TCP', 'RDMA', 'FC'] as const;
+
+/** The address families a port's address can be in, on the same surface. */
+const ADDRESS_FAMILIES = ['IPV4', 'IPV6', 'FC'] as const;
+
+/**
+ * One member of a declared string union, or null for anything else.
+ *
+ * The union is read rather than passed through, which is #101's rule about a
+ * mapping keyed off `ApiSurface`: that surface is the OLDEST supported TrueNAS
+ * directory, so a later release can send a transport these three do not name
+ * with nothing failing to compile. Passing the value through would put a fourth
+ * value in a field whose type says it holds one of three, and a caller
+ * switching on it would fall through every arm. Null is the honest answer, and
+ * the description says it covers a value this catalog does not recognise as
+ * well as one the system did not report.
+ */
+function oneOf<T extends string>(allowed: readonly T[], value: unknown): T | null {
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : null;
+}
+
 /**
  * One NVMe-oF port: an address the system accepts NVMe-oF connections on, and
  * the subsystems published through it.
@@ -663,8 +690,8 @@ async function readPorts(system: SystemHandle): Promise<Omit<Port, 'subsystems'>
       // does not follow it — the same pairing a namespace's `nsid` and `id`
       // have above.
       index: numberOrNull(port.index),
-      transport: port.addr_trtype ?? null,
-      address_family: port.addr_adrfam ?? null,
+      transport: oneOf(TRANSPORTS, port.addr_trtype),
+      address_family: oneOf(ADDRESS_FAMILIES, port.addr_adrfam),
       address: textOrNull(port.addr_traddr),
       service_id: serviceId(port.addr_trsvcid),
       enabled: reported ? booleanOrNull(port.enabled) : null,
@@ -853,7 +880,12 @@ export const nvmeofList: ReadOnlyTool = {
     'different numbers, and neither follows the other. `transport` is `TCP`, ' +
     '`RDMA` or `FC` (the payload\'s `addr_trtype`), `address_family` `IPV4`, ' +
     '`IPV6` or `FC` (`addr_adrfam`), and `address` the address it listens on ' +
-    '(`addr_traddr`). `service_id` is what it answers on (`addr_trsvcid`): a ' +
+    '(`addr_traddr`). EITHER OF THE FIRST TWO IS NULL WHERE THE SYSTEM ' +
+    'REPORTED NO VALUE OR ONE THIS CATALOG DOES NOT RECOGNISE, and those are ' +
+    'not distinguished: the three values each can take are read off the oldest ' +
+    'supported TrueNAS, so a later release adding a fourth reports null here ' +
+    'rather than a word a caller cannot switch on — and a null transport is ' +
+    'never a port carried over nothing. `service_id` is what it answers on (`addr_trsvcid`): a ' +
     'TCP port number on a TCP port and something else on an FC one, REPORTED ' +
     'AS THE SYSTEM SPELLED IT — as a number or as text — and never converted ' +
     'between the two, because the payload declares both and fixing one would ' +

--- a/src/tools/block.ts
+++ b/src/tools/block.ts
@@ -923,10 +923,13 @@ export const nvmeofList: ReadOnlyTool = {
     '`shares_list`. WHICH PORTS A SUBSYSTEM IS PUBLISHED ON IS READ FROM ' +
     '`ports[].subsystems` AND NOT FROM THE SUBSYSTEM ROW, which carries no port ' +
     'field: a subsystem named in no port\'s `subsystems` is one nothing ' +
-    'publishes and so is not reachable over the network — but ONLY where the ' +
-    'port and publication reads both succeeded and no publication is ' +
-    'unattributed. Where either read failed, or a publication could not be ' +
-    'placed, that absence says nothing.',
+    'publishes and so is not reachable over the network — but ONLY WHERE EVERY ' +
+    'PUBLICATION WAS READ, PLACED AND IDENTIFIED, which is four conditions a ' +
+    'caller has to check together: `failures` names neither `ports` nor ' +
+    '`port_subsystems`, `unattributed_port_subsystems` is empty, and no ' +
+    '`subsystems` entry anywhere carries a null `subsystem_id`. ANY ONE OF ' +
+    'THOSE IS A PUBLICATION THAT COULD HAVE BEEN THIS SUBSYSTEM\'S, and the ' +
+    'absence then establishes nothing.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/iscsi-list.spec.ts
+++ b/src/tools/iscsi-list.spec.ts
@@ -7,9 +7,10 @@ import { iscsiList } from '@/tools/index';
  * That file was 1,497 lines with a stated margin of three, and #138 grows two
  * of its three tools — so the merged file would be well over the 1,500-line
  * trigger and the split is by tool, this one taking the spec named for it.
- * `nvmeof_list` and `fc_list` stay in the module's own spec: re-homing tests a
- * ticket did not have to touch is a separate change (#121), and a part-split is
- * not a half-finished state to tidy.
+ * `nvmeof_list` and `fc_list` stay in the module's own spec: moving one block is
+ * what the file size asked for, moving a block it did not ask for is the
+ * re-homing #121 rules out, and a part-split is not a half-finished state to
+ * tidy.
  */
 describe('iscsi_list', () => {
   /**

--- a/src/tools/iscsi-list.spec.ts
+++ b/src/tools/iscsi-list.spec.ts
@@ -1,0 +1,702 @@
+import { describe, expect, it } from 'vitest';
+import { failingSystem } from '@/testing/fake-systems';
+import { iscsiList } from '@/tools/index';
+
+/**
+ * Split out of `block.spec.ts` under #87's exception rather than for tidiness.
+ * That file was 1,497 lines with a stated margin of three, and #138 grows two
+ * of its three tools — so the merged file would be well over the 1,500-line
+ * trigger and the split is by tool, this one taking the spec named for it.
+ * `nvmeof_list` and `fc_list` stay in the module's own spec: re-homing tests a
+ * ticket did not have to touch is a separate change (#121), and a part-split is
+ * not a half-finished state to tidy.
+ */
+describe('iscsi_list', () => {
+  /**
+   * A target as `iscsi.target.query` reports one. `rel_tgt_id`, `mode`,
+   * `groups` and `auth_networks` are real fields of the payload the tool does
+   * not name, and are here to be dropped.
+   */
+  const target = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'tgt0',
+    alias: 'VMware datastore',
+    rel_tgt_id: 1,
+    mode: 'ISCSI',
+    groups: [{ portal: 1, initiator: 1 }],
+    auth_networks: [],
+    ...over,
+  });
+
+  /**
+   * An extent as `iscsi.extent.query` reports one. A `DISK` extent carries
+   * BOTH `disk` and `path` — the system reports the device node in `path` too,
+   * so `path` is not evidence that an extent is file-backed.
+   */
+  const extent = (over: Record<string, unknown> = {}) => ({
+    id: 7,
+    name: 'vmstore',
+    type: 'DISK',
+    disk: 'zvol/tank/vmstore',
+    path: '/dev/zvol/tank/vmstore',
+    enabled: true,
+    locked: false,
+    naa: '0x6589cfc000000',
+    vendor: 'TrueNAS',
+    serial: 'abc123',
+    ...over,
+  });
+
+  /** A row of the join table mapping an extent onto a target at a LUN. */
+  const mapping = (over: Record<string, unknown> = {}) => ({
+    id: 4,
+    target: 1,
+    extent: 7,
+    lunid: 0,
+    ...over,
+  });
+
+  /**
+   * A portal as `iscsi.portal.query` reports one, listening on one address.
+   * `tag` is the portal group number a target's `groups[].portal` names.
+   */
+  const portal = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    tag: 1,
+    comment: 'VMware network',
+    listen: [{ ip: '10.0.0.10', port: 3260 }],
+    ...over,
+  });
+
+  /** A live session as `iscsi.global.sessions` reports one. */
+  const session = (over: Record<string, unknown> = {}) => ({
+    initiator: 'iqn.1998-01.com.vmware:esx1',
+    initiator_addr: '10.0.0.20',
+    initiator_alias: 'esx1',
+    target: 'tgt0',
+    target_alias: 'VMware datastore',
+    header_digest: null,
+    data_digest: null,
+    immediate_data: true,
+    iser: false,
+    offload: false,
+    ...over,
+  });
+
+  type Listing = {
+    targets: Record<string, unknown>[];
+    portals: Record<string, unknown>[] | null;
+    failures: Record<string, unknown>[];
+    unattributed_initiators: Record<string, unknown>[];
+  };
+
+  const listed = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Listing> => {
+    const { ctx } = failingSystem(
+      {
+        ['iscsi.target.query']: [target()],
+        ['iscsi.extent.query']: [extent()],
+        ['iscsi.targetextent.query']: [mapping()],
+        ['iscsi.global.sessions']: [session()],
+        ['iscsi.portal.query']: [portal()],
+        ...rows,
+      },
+      failures,
+    );
+    return (await iscsiList.handler(ctx, {})) as Listing;
+  };
+
+  /** The single portal of a listing, for the cases about one portal's fields. */
+  const onlyPortal = async (
+    rows: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => ((await listed(rows)).portals ?? [])[0];
+
+  /** The single target of a listing, for the cases about one target's fields. */
+  const onlyTarget = async (
+    rows: Partial<Record<string, unknown>> = {},
+    failures: Partial<Record<string, unknown>> = {},
+  ): Promise<Record<string, unknown>> => (await listed(rows, failures)).targets[0];
+
+  it('reports each target with its extents and connected initiators', async () => {
+    expect(await listed()).toEqual({
+      targets: [
+        {
+          id: 1,
+          name: 'tgt0',
+          alias: 'VMware datastore',
+          mode: 'ISCSI',
+          extents: [
+            {
+              id: 7,
+              lun: 0,
+              name: 'vmstore',
+              type: 'DISK',
+              path: '/dev/zvol/tank/vmstore',
+              disk: 'zvol/tank/vmstore',
+              enabled: true,
+              locked: false,
+            },
+          ],
+          initiators: [
+            {
+              initiator: 'iqn.1998-01.com.vmware:esx1',
+              addresses: ['10.0.0.20'],
+              alias: 'esx1',
+            },
+          ],
+        },
+      ],
+      portals: [
+        {
+          id: 1,
+          tag: 1,
+          comment: 'VMware network',
+          listen: [{ ip: '10.0.0.10', port: 3260 }],
+        },
+      ],
+      failures: [],
+      unattributed_initiators: [],
+    });
+  });
+
+  it('surfaces no field a later release adds', async () => {
+    const listing = await listed({
+      ['iscsi.target.query']: [target({ future_field: 'added by a later release' })],
+      ['iscsi.extent.query']: [extent({ future_field: 'added by a later release' })],
+      ['iscsi.targetextent.query']: [mapping({ future_field: 'added by a later release' })],
+      ['iscsi.global.sessions']: [session({ future_field: 'added by a later release' })],
+      ['iscsi.portal.query']: [
+        portal({
+          future_field: 'added by a later release',
+          listen: [{ ip: '10.0.0.10', port: 3260, future_field: 'added by a later release' }],
+        }),
+      ],
+    });
+    expect(Object.keys(listing)).toEqual([
+      'targets',
+      'portals',
+      'failures',
+      'unattributed_initiators',
+    ]);
+    expect(Object.keys((listing.portals ?? [])[0])).toEqual(['id', 'tag', 'comment', 'listen']);
+    expect(
+      Object.keys(
+        (((listing.portals ?? [])[0]['listen'] as Record<string, unknown>[]) ?? [])[0],
+      ),
+    ).toEqual(['ip', 'port']);
+    expect(Object.keys(listing.targets[0])).toEqual([
+      'id',
+      'name',
+      'alias',
+      'mode',
+      'extents',
+      'initiators',
+    ]);
+    expect(Object.keys((listing.targets[0]['extents'] as Record<string, unknown>[])[0])).toEqual([
+      'id',
+      'lun',
+      'name',
+      'type',
+      'path',
+      'disk',
+      'enabled',
+      'locked',
+    ]);
+    expect(Object.keys((listing.targets[0]['initiators'] as Record<string, unknown>[])[0])).toEqual(
+      ['initiator', 'addresses', 'alias'],
+    );
+  });
+
+  it('reads a target with no alias as having none', async () => {
+    for (const missing of [null, undefined, '']) {
+      expect(await onlyTarget({ ['iscsi.target.query']: [target({ alias: missing })] })).toMatchObject(
+        { alias: null },
+      );
+    }
+  });
+
+  it('reads an initiator with no alias as having none', async () => {
+    for (const missing of [null, '']) {
+      const initiators = (
+        await onlyTarget({ ['iscsi.global.sessions']: [session({ initiator_alias: missing })] })
+      )['initiators'] as Record<string, unknown>[];
+      expect(initiators[0]['alias']).toBeNull();
+    }
+  });
+
+  it('maps every extent of a target, each at its own LUN', async () => {
+    const extents = (
+      await onlyTarget({
+        ['iscsi.extent.query']: [extent(), extent({ id: 8, name: 'logs', type: 'FILE' })],
+        ['iscsi.targetextent.query']: [mapping(), mapping({ id: 5, extent: 8, lunid: 1 })],
+      })
+    )['extents'] as Record<string, unknown>[];
+    expect(extents.map((mapped) => [mapped['lun'], mapped['name']])).toEqual([
+      [0, 'vmstore'],
+      [1, 'logs'],
+    ]);
+  });
+
+  it('reports the backing store of a DISK extent and of a FILE one', async () => {
+    const extents = (
+      await onlyTarget({
+        ['iscsi.extent.query']: [
+          extent(),
+          extent({ id: 8, type: 'FILE', disk: null, path: '/mnt/tank/iscsi/logs' }),
+        ],
+        ['iscsi.targetextent.query']: [mapping(), mapping({ id: 5, extent: 8, lunid: 1 })],
+      })
+    )['extents'] as Record<string, unknown>[];
+    // `path` is set on both kinds, so it is `disk` and `type` that separate
+    // them — a caller reading a set `path` as "file-backed" would be wrong.
+    expect(extents[0]).toMatchObject({
+      type: 'DISK',
+      disk: 'zvol/tank/vmstore',
+      path: '/dev/zvol/tank/vmstore',
+    });
+    expect(extents[1]).toMatchObject({ type: 'FILE', disk: null, path: '/mnt/tank/iscsi/logs' });
+  });
+
+  it('reports an extent field the system omitted as null, not as a value', async () => {
+    const extents = (
+      await onlyTarget({
+        ['iscsi.extent.query']: [{ id: 7, name: 'vmstore', naa: '0x1', vendor: 'TrueNAS' }],
+      })
+    )['extents'] as Record<string, unknown>[];
+    // `enabled` and `locked` especially: false would say the extent is
+    // definitely not serving, which the system did not report either way.
+    expect(extents[0]).toEqual({
+      id: 7,
+      lun: 0,
+      name: 'vmstore',
+      type: null,
+      path: null,
+      disk: null,
+      enabled: null,
+      locked: null,
+    });
+  });
+
+  it('keeps a mapping whose extent record is missing, marked by a null name', async () => {
+    const extents = (await onlyTarget({ ['iscsi.extent.query']: [] }))[
+      'extents'
+    ] as Record<string, unknown>[];
+    // The LUN was configured, and that is worth reporting; a real extent always
+    // carries a name, so the null name is what says the record was not found.
+    expect(extents).toEqual([
+      {
+        id: 7,
+        lun: 0,
+        name: null,
+        type: null,
+        path: null,
+        disk: null,
+        enabled: null,
+        locked: null,
+      },
+    ]);
+  });
+
+  it('reports a target with nothing mapped to it as an empty extent list', async () => {
+    expect(await onlyTarget({ ['iscsi.targetextent.query']: [] })).toMatchObject({ extents: [] });
+  });
+
+  it('reports a target with no session as an empty initiator list', async () => {
+    expect(await onlyTarget({ ['iscsi.global.sessions']: [] })).toMatchObject({ initiators: [] });
+  });
+
+  it('distinguishes sessions that could not be read from a target with none', async () => {
+    const listing = await listed({}, { ['iscsi.global.sessions']: new Error('service not running') });
+    // Null rather than empty: an empty list would say nothing is connected,
+    // which is the one answer this tool must not invent.
+    expect(listing.targets[0]['initiators']).toBeNull();
+    expect(listing.failures).toEqual([
+      { source: 'initiators', error: 'service not running' },
+    ]);
+  });
+
+  it('distinguishes extents that could not be read from a target with none', async () => {
+    for (const method of ['iscsi.extent.query', 'iscsi.targetextent.query']) {
+      const listing = await listed({}, { [method]: new Error('denied') });
+      expect(listing.targets[0]['extents']).toBeNull();
+      expect(listing.failures).toEqual([{ source: 'extents', error: 'denied' }]);
+      // The other read is unaffected, which is why they are separate failures.
+      expect(listing.targets[0]['initiators']).not.toBeNull();
+    }
+  });
+
+  it('reports every read failing without losing the targets themselves', async () => {
+    const listing = await listed(
+      {},
+      {
+        ['iscsi.extent.query']: new Error('denied'),
+        ['iscsi.global.sessions']: new Error('service not running'),
+        ['iscsi.portal.query']: new Error('no such method'),
+      },
+    );
+    expect(listing.targets).toEqual([
+      {
+        id: 1,
+        name: 'tgt0',
+        alias: 'VMware datastore',
+        mode: 'ISCSI',
+        extents: null,
+        initiators: null,
+      },
+    ]);
+    expect(listing.portals).toBeNull();
+    expect(listing.failures).toEqual([
+      { source: 'extents', error: 'denied' },
+      { source: 'initiators', error: 'service not running' },
+      { source: 'portals', error: 'no such method' },
+    ]);
+  });
+
+  it('names a failure that is not an Error, and one that says nothing', async () => {
+    expect(
+      (await listed({}, { ['iscsi.global.sessions']: 'connection reset' })).failures,
+    ).toEqual([{ source: 'initiators', error: 'connection reset' }]);
+    for (const silent of [new Error(''), { code: 500 }]) {
+      expect((await listed({}, { ['iscsi.global.sessions']: silent })).failures).toEqual([
+        { source: 'initiators', error: 'the system reported no reason' },
+      ]);
+    }
+  });
+
+  it('raises rather than reporting a system that serves nothing when targets fail', async () => {
+    await expect(
+      listed({}, { ['iscsi.target.query']: new Error('denied') }),
+    ).rejects.toThrow('denied');
+  });
+
+  it('attributes a session naming its target by the full IQN', async () => {
+    expect(
+      await onlyTarget({
+        ['iscsi.global.sessions']: [session({ target: 'iqn.2005-10.org.freenas.ctl:tgt0' })],
+      }),
+    ).toMatchObject({ initiators: [{ initiator: 'iqn.1998-01.com.vmware:esx1' }] });
+  });
+
+  it('groups each session under the one target it is on', async () => {
+    const listing = await listed({
+      ['iscsi.target.query']: [target(), target({ id: 2, name: 'tgt1', alias: null })],
+      ['iscsi.global.sessions']: [
+        session(),
+        session({ initiator: 'iqn.1998-01.com.vmware:esx2', target: 'tgt1' }),
+        session({ initiator: 'iqn.1998-01.com.vmware:esx3', target: 'tgt1' }),
+      ],
+    });
+    expect(
+      listing.targets.map((entry) => [
+        entry['name'],
+        (entry['initiators'] as Record<string, unknown>[]).map((one) => one['initiator']),
+      ]),
+    ).toEqual([
+      ['tgt0', ['iqn.1998-01.com.vmware:esx1']],
+      ['tgt1', ['iqn.1998-01.com.vmware:esx2', 'iqn.1998-01.com.vmware:esx3']],
+    ]);
+  });
+
+  it('counts a multipathed initiator once, keeping every path it reaches from', async () => {
+    // Two sessions, one initiator down two paths. Two entries would make one
+    // host with two NICs read as two hosts attached to the target.
+    const initiators = (
+      await onlyTarget({
+        ['iscsi.global.sessions']: [
+          session(),
+          session({ initiator_addr: '10.0.1.20' }),
+          session({ initiator_addr: '10.0.0.20' }),
+        ],
+      })
+    )['initiators'] as Record<string, unknown>[];
+    expect(initiators).toEqual([
+      {
+        initiator: 'iqn.1998-01.com.vmware:esx1',
+        addresses: ['10.0.0.20', '10.0.1.20'],
+        alias: 'esx1',
+      },
+    ]);
+  });
+
+  it('takes an initiator alias from whichever session carries one', async () => {
+    const initiators = (
+      await onlyTarget({
+        ['iscsi.global.sessions']: [
+          session({ initiator_alias: null }),
+          session({ initiator_addr: '10.0.1.20', initiator_alias: 'esx1' }),
+        ],
+      })
+    )['initiators'] as Record<string, unknown>[];
+    expect(initiators[0]).toMatchObject({ alias: 'esx1' });
+  });
+
+  it('keeps two different initiators on one target apart', async () => {
+    const initiators = (
+      await onlyTarget({
+        ['iscsi.global.sessions']: [
+          session(),
+          session({ initiator: 'iqn.1998-01.com.vmware:esx2', initiator_addr: '10.0.0.21' }),
+        ],
+      })
+    )['initiators'] as Record<string, unknown>[];
+    expect(initiators.map((one) => one['initiator'])).toEqual([
+      'iqn.1998-01.com.vmware:esx1',
+      'iqn.1998-01.com.vmware:esx2',
+    ]);
+  });
+
+  it('reports how a target is served, so an FC target is not read as idle', async () => {
+    // An FC target holds no iSCSI session by definition, so without `mode` its
+    // empty initiator list is indistinguishable from an idle iSCSI target.
+    const listing = await listed({
+      ['iscsi.target.query']: [
+        target({ id: 2, name: 'fctgt', mode: 'FC' }),
+        target({ id: 3, name: 'bothtgt', mode: 'BOTH' }),
+        target({ mode: undefined }),
+      ],
+      ['iscsi.global.sessions']: [],
+    });
+    expect(listing.targets.map((entry) => [entry['name'], entry['mode'], entry['initiators']])).toEqual(
+      [
+        ['fctgt', 'FC', []],
+        ['bothtgt', 'BOTH', []],
+        ['tgt0', null, []],
+      ],
+    );
+  });
+
+  it('groups mappings under the target each names', async () => {
+    const listing = await listed({
+      ['iscsi.target.query']: [target(), target({ id: 2, name: 'tgt1' })],
+      ['iscsi.extent.query']: [extent(), extent({ id: 8, name: 'logs' })],
+      ['iscsi.targetextent.query']: [
+        mapping(),
+        mapping({ id: 5, target: 2, extent: 8, lunid: 0 }),
+      ],
+    });
+    expect(
+      listing.targets.map((entry) => [
+        entry['name'],
+        (entry['extents'] as Record<string, unknown>[]).map((one) => one['name']),
+      ]),
+    ).toEqual([
+      ['tgt0', ['vmstore']],
+      ['tgt1', ['logs']],
+    ]);
+  });
+
+  it('reports a session it could not attribute rather than dropping it', async () => {
+    const listing = await listed({
+      ['iscsi.global.sessions']: [session({ target: 'some-other-spelling' })],
+    });
+    // Silently dropping it would leave the target reading as unused, which is
+    // exactly the answer this tool exists to be trusted on.
+    expect(listing.targets[0]['initiators']).toEqual([]);
+    expect(listing.unattributed_initiators).toEqual([
+      {
+        initiator: 'iqn.1998-01.com.vmware:esx1',
+        addresses: ['10.0.0.20'],
+        alias: 'esx1',
+        target: 'some-other-spelling',
+      },
+    ]);
+  });
+
+  it('groups unattributed sessions by target and initiator, as attributed ones are', async () => {
+    const listing = await listed({
+      ['iscsi.global.sessions']: [
+        session({ target: 'unknown-a' }),
+        session({ target: 'unknown-a', initiator_addr: '10.0.1.20' }),
+        session({ target: 'unknown-b' }),
+        session({ target: 'unknown-a', initiator: 'iqn.1998-01.com.vmware:esx2' }),
+      ],
+    });
+    expect(
+      listing.unattributed_initiators.map((one) => [
+        one['target'],
+        one['initiator'],
+        one['addresses'],
+      ]),
+    ).toEqual([
+      ['unknown-a', 'iqn.1998-01.com.vmware:esx1', ['10.0.0.20', '10.0.1.20']],
+      ['unknown-a', 'iqn.1998-01.com.vmware:esx2', ['10.0.0.20']],
+      ['unknown-b', 'iqn.1998-01.com.vmware:esx1', ['10.0.0.20']],
+    ]);
+  });
+
+  it('leaves a session unattributed where two targets answer to its IQN', async () => {
+    const listing = await listed({
+      ['iscsi.target.query']: [target({ id: 2, name: 'a:tgt0' }), target()],
+      ['iscsi.global.sessions']: [session({ target: 'iqn.2005-10.org.freenas.ctl:a:tgt0' })],
+    });
+    // Both `a:tgt0` and `tgt0` are colon-anchored suffixes of that IQN.
+    // Reporting it against both would invent a connection to one of them.
+    expect(listing.targets.map((entry) => entry['initiators'])).toEqual([[], []]);
+    expect(listing.unattributed_initiators).toHaveLength(1);
+  });
+
+  it('prefers an exact target name over a suffix that also matches', async () => {
+    const listing = await listed({
+      ['iscsi.target.query']: [target({ id: 2, name: 'x:tgt0' }), target()],
+      ['iscsi.global.sessions']: [session({ target: 'x:tgt0' })],
+    });
+    expect(listing.targets.map((entry) => [entry['name'], entry['initiators']])).toEqual([
+      [
+        'x:tgt0',
+        [{ initiator: 'iqn.1998-01.com.vmware:esx1', addresses: ['10.0.0.20'], alias: 'esx1' }],
+      ],
+      ['tgt0', []],
+    ]);
+    expect(listing.unattributed_initiators).toEqual([]);
+  });
+
+  it('reports a system with no targets as an empty list', async () => {
+    expect(
+      await listed({
+        ['iscsi.target.query']: [],
+        ['iscsi.global.sessions']: [],
+        ['iscsi.portal.query']: [],
+      }),
+    ).toEqual({
+      targets: [],
+      portals: [],
+      failures: [],
+      unattributed_initiators: [],
+    });
+  });
+
+  it('does not lose a live session on a system whose targets listed as none', async () => {
+    // A session with no target to hang it on is the one case where the tool
+    // has evidence of block storage in use and nothing to attribute it to.
+    const listing = await listed({ ['iscsi.target.query']: [] });
+    expect(listing.targets).toEqual([]);
+    expect(listing.unattributed_initiators).toMatchObject([{ target: 'tgt0' }]);
+  });
+
+  it('issues every read before awaiting any of them', async () => {
+    const { ctx, query } = failingSystem({
+      ['iscsi.target.query']: [target()],
+      ['iscsi.extent.query']: [extent()],
+      ['iscsi.targetextent.query']: [mapping()],
+      ['iscsi.global.sessions']: [session()],
+      ['iscsi.portal.query']: [portal()],
+    });
+    const listing = iscsiList.handler(ctx, {});
+    // Asserted before the handler is awaited at all, which is what makes this
+    // about concurrency rather than order: every read is subscribed while the
+    // handler still holds the thread, so a handler that awaited one read
+    // before starting the next would have made one call by this point. The
+    // same assertion after the await passes either way.
+    expect(query.mock.calls.map((one) => one[0])).toEqual([
+      'iscsi.target.query',
+      'iscsi.extent.query',
+      'iscsi.targetextent.query',
+      'iscsi.global.sessions',
+      'iscsi.portal.query',
+    ]);
+    await listing;
+  });
+
+  describe('where the service listens', () => {
+    it('reports each portal with every address it accepts connections on', async () => {
+      const listing = await listed({
+        ['iscsi.portal.query']: [
+          portal({ listen: [{ ip: '10.0.0.10', port: 3260 }, { ip: '10.0.1.10', port: 3261 }] }),
+          portal({ id: 2, tag: 2, comment: '', listen: [{ ip: '0.0.0.0', port: 3260 }] }),
+        ],
+      });
+      expect(listing.portals).toEqual([
+        {
+          id: 1,
+          tag: 1,
+          comment: 'VMware network',
+          listen: [
+            { ip: '10.0.0.10', port: 3260 },
+            { ip: '10.0.1.10', port: 3261 },
+          ],
+        },
+        // `0.0.0.0` is passed through as the system spelled it: it is the
+        // wildcard, and it is the description's job to say so rather than this
+        // tool's to translate it into an address the system does not have.
+        { id: 2, tag: 2, comment: null, listen: [{ ip: '0.0.0.0', port: 3260 }] },
+      ]);
+    });
+
+    it('reads a listen entry it could not read as a row of nulls, not as absent', async () => {
+      // Dropping it would say the service is unreachable at an address it is
+      // bound to, which is a claim this read did not make (#93).
+      const listen = (
+        await onlyPortal({
+          ['iscsi.portal.query']: [
+            portal({ listen: [{ ip: 10, port: '3260' }, 'not a record', { ip: '10.0.0.10' }] }),
+          ],
+        })
+      )['listen'];
+      expect(listen).toEqual([
+        { ip: null, port: null },
+        { ip: null, port: null },
+        { ip: '10.0.0.10', port: null },
+      ]);
+    });
+
+    it('distinguishes a portal that listens nowhere from one that reported no list', async () => {
+      expect(await onlyPortal({ ['iscsi.portal.query']: [portal({ listen: [] })] })).toMatchObject({
+        listen: [],
+      });
+      for (const missing of [null, undefined, 'everywhere']) {
+        expect(
+          await onlyPortal({ ['iscsi.portal.query']: [portal({ listen: missing })] }),
+        ).toMatchObject({ listen: null });
+      }
+    });
+
+    it('reports a portal field the system did not report as null', async () => {
+      expect(
+        await onlyPortal({ ['iscsi.portal.query']: [{ listen: [], comment: '' }] }),
+      ).toEqual({ id: null, tag: null, comment: null, listen: [] });
+    });
+
+    it('distinguishes a system with no portal from one whose portals failed', async () => {
+      // Empty is an iSCSI service that accepts nothing wherever its targets
+      // point; null is a read that says nothing about where it listens.
+      expect((await listed({ ['iscsi.portal.query']: [] })).portals).toEqual([]);
+      const failed = await listed({}, { ['iscsi.portal.query']: new Error('denied') });
+      expect(failed.portals).toBeNull();
+      expect(failed.failures).toEqual([{ source: 'portals', error: 'denied' }]);
+      // The other reads are unaffected, which is why it is its own failure.
+      expect(failed.targets[0]['extents']).not.toBeNull();
+      expect(failed.targets[0]['initiators']).not.toBeNull();
+    });
+
+    it('keeps reporting the portals when a target read succeeded and the others did not', async () => {
+      const listing = await listed(
+        {},
+        {
+          ['iscsi.extent.query']: new Error('denied'),
+          ['iscsi.global.sessions']: new Error('service not running'),
+        },
+      );
+      expect(listing.portals).toEqual([
+        { id: 1, tag: 1, comment: 'VMware network', listen: [{ ip: '10.0.0.10', port: 3260 }] },
+      ]);
+    });
+  });
+
+  describe('its description', () => {
+    it('says what a wildcard listen address means', () => {
+      // The one field a caller is most likely to misread as a misconfiguration:
+      // a portal on `0.0.0.0` is bound to every address rather than to none.
+      expect(iscsiList.description).toContain('`0.0.0.0` IS NOT AN ADDRESS');
+      expect(iscsiList.description).toContain('EVERY IPv4 address');
+      expect(iscsiList.description).toContain('`::`');
+    });
+
+    it('says that a target is not related to a portal here', () => {
+      // The tool reports both and joins neither, which a caller reading two
+      // lists side by side would otherwise assume it had done.
+      expect(iscsiList.description).toContain('DOES NOT SAY WHICH PORTAL SERVES WHICH TARGET');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #138.

`iscsi_list` and `nvmeof_list` each described what is exported and who may
reach it, and neither said **where the service listens**. "The initiator can't
connect" splits into three causes and the catalog could rule out only two of
them.

## What changed

- **`iscsi_list` reports `portals`** from `iscsi.portal.query`: each portal's
  `id`, `tag`, `comment` and `listen`, with `ip` and `port` per address.
- **`nvmeof_list` reports `ports`** from `nvmet.port.query`, each carrying
  `subsystems` — which subsystems are published through it — from
  `nvmet.port_subsys.query`.
- Both reads go through `attempt`, so a listener read that fails names itself in
  `failures` and takes nothing else down. That is #135's test answered the way
  `fc_list` answers it: a listener is a fact about the protocol rather than a
  part of a target or a subsystem.
- `iscsi_list`'s tests moved to `src/tools/iscsi-list.spec.ts`. `block.spec.ts`
  had recorded a three-line margin under #87's 1,500-line trigger, and growing
  two of its three tools spends it. `nvmeof_list` and `fc_list` stay put — a
  part-split is #121's shape, not a half-finished state.
- `app/CLAUDE.md` gains the decision for this ticket, and the #87 section gains
  the case where the split trigger is met by growing tools rather than by adding
  one.

## The decisions worth checking

**`0.0.0.0` is passed through and explained, not translated.** A portal on the
wildcard is bound to *every* address, which is the opposite of what a reader
seeing a placeholder assumes; `::` is the same answer for IPv6. Same division for
`addr_trsvcid`, declared `number | string | null`: reported as whichever arrived
and never converted, since fixing one spelling asserts a meaning the surface
refuses to (#96).

**Both embedded entities in the join are reduced, never forwarded** (#100). A
port's `subsystems` entry carries `subsystem_id` and `subsystem` and not the
NQN, which is reported once on the subsystem itself.

**`ports[].subsystems` is what the publication CLAIMED, not a lookup.** The reads
are separate round trips, so a subsystem deleted between them leaves a
publication naming an id no listed subsystem answers to. The row is kept —
dropping it would say the port publishes less than it does — and the description
says a join can find nothing under one. That also adds a fourth condition to
reading a subsystem as unreachable, and all four are named as fields a caller can
check in the result it already has.

**`transport` and `address_family` are read against the union rather than
trusted.** `ApiSurface` is the oldest supported directory (#101), so a later
TrueNAS can send a fourth transport; null there covers a value this catalog does
not recognise as well as one the system did not report, and the two are not
distinguished.

**A port that did not report `enabled` is not a disabled port.** The field is
optional on the payload, so `enabled_reported` splits its null the way
`npiv_reported` does for an FC adapter (#134), reading the row's own key.

## What this deliberately does NOT do

**It does not say which portal serves which target**, and the description says so
outright. A target's own `groups[].portal` is that join, and `groups` also holds
`initiator` and `auth` — the initiator allowlist and the CHAP credential — both
of which this ticket scopes out. Reading one field of that record is a decision a
ticket should make deliberately rather than a side effect of this one. **This is
worth its own ticket** and I have not filed one, since a worker cannot: the shape
would be "attribute each target to the portals its groups name, reading `portal`
and nothing else from the group".

It also omits a port's `inline_data_size`, `max_queue_size` and `pi_enable`,
which say nothing about where it listens; that omission is named in the
description.

## Local checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all pass
here — every job `.github/workflows/ci.yml` gates on. Coverage on `block.ts` is
100/100/100/100.

Five local review rounds ran through `local-review.py`, which runs this
repository's own reviewer in a separate process — so these are the check's own
verdicts rather than a subagent's. The fifth returned nothing at or above MEDIUM.
Four MEDIUMs were found and fixed on the way, each of them a description
promising more than the normalization delivers: a null `ports` attributed to a
failed read on the branch where nothing was read at all, the join described as
joinable when nothing checks that it lands, the reachability inference naming two
disqualifiers where there are four, and the two enum fields above.

## LOW findings from the clean round, left as they are

Left per the round rule — each is a new diff and a new round, and none blocks.

- **`service_id`'s null case is not stated**, though an FC port reports null there
  normally. Correct, and worth a line whenever this description is next touched.
- **Both tools' opening sentences do not mention the new top-level list.** True;
  each list is described in full further down.
- **`readPorts` and `readPortals` do not guard a row with `recordOrNull`** where
  `readPortSubsystems` does. The difference is deliberate but undocumented: the
  join reads an *embedded* record whose shape a row can get wrong on its own,
  while the two listings read the row the client declares — and every field of it
  is already read through a guard. A malformed row there answers nulls rather
  than throwing.
- **`TRANSPORTS`/`ADDRESS_FAMILIES` have no compile-time tie to the declared
  union**, so a client bump widening it degrades silently to null rather than
  failing to compile. Real, and it is the honest degradation #101 asks for; a tie
  that made it a compile error would be worth having and is its own change.
- **`attributePorts` is a third file-under-a-key helper beside `attribute` and
  `attributeStatus`.** I think this one is right as it stands: the three key on
  different things (a subsystem id inside a `Claim`, a port name off the row, a
  port id off the claim) and produce different unattributed shapes, so sharing
  them means generalising over a key extractor and a result type. That is the
  distinction `common.ts` already draws for the per-family `Attempt`/`attempt`
  pairs — the overlap is the shape, not the function.
