### PR TITLE
feat(tools): report ZFS feature-flag currency per pool in storage_pool_status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1544,11 +1544,14 @@ the one worth keeping: `false` is the answer this tool exists to surface and it
 is also falsy, so a fallback written as `carried || read()` asks a second
 question about a pool that had already answered.
 
-**Null is not a false, and the three causes behind it are not separable.** No
-readable flag beside no readable pool id (nothing to aim the verb at), a verb
-that rejected, and a verb that answered with something that is not a boolean.
-The description says what a null rules out and names what it cannot tell apart,
-per #122, rather than enumerating a partition it does not have. **No companion
+**Null is not a false, and the causes behind it are not separable — nor are they
+enumerable, which is the part a first draft got wrong.** No readable flag beside
+no readable pool id (nothing to aim the verb at), a verb that rejected, a verb
+that answered with something that is not a boolean, and a verb whose observable
+completed without emitting, which `firstValueFrom` raises as an error and the
+same catch takes. The first three read as a partition and are not one; the
+description now says what a null RULES OUT — that this tool read a boolean —
+and says outright that it separates none of the causes, per #122. **No companion
 field splits it**: #134's bar is that a companion earns its place where the
 causes behind one null are ones a caller would act on differently, and every
 cause here leaves the same course of action. The rejection text is dropped for
@@ -1566,10 +1569,19 @@ by dropping fields and never by re-judging them, and #44's is that a composite
 re-reads every field through its own guard by name — which is what kept the new
 field out of `poolEntries` without a line changing there. The composite's spec
 now asserts the pools entry's **exact key list**, so a field reaching it
-unannounced fails a test rather than shipping. `storage_pool_status`'s own
+unannounced fails a test rather than shipping — nothing can arrive there on its
+own, so what that assertion pins is the decision. `storage_pool_status`'s own
 description carries the pointer both ways: a pool that is behind is not a reason
 that report is anything other than `OK`, and this field is where the answer
 lives.
+
+**Describing a NEIGHBOURING tool means reading its description, not recalling
+it.** The first draft said `alerts_list` carries the `PoolUpgraded` alert only
+until it is dismissed, which is what the ticket's own text says and is the
+opposite of what that tool does — its description states outright that dismissed
+alerts are still active conditions and are included. A pointer between tools is
+a claim about the other tool, and it can be false the same way any description
+can.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1515,6 +1515,62 @@ claim the surface does not make, exactly as `RsyncTaskEntry` ties no field to it
 `mode` (#97). Each is described as what the configuration records, and a null in
 them is not evidence the system owns its own UPS.
 
+### One question with two sources on the surface reads the cheaper one first (#140)
+
+`storage_pool_status` reports `feature_flags_current`, and the pinned surface
+answers that question **twice**. A `pool.query` row declares
+`is_upgraded?: boolean` — optional, so a system may or may not send it — and
+`pool.is_upgraded` is a separate verb taking one pool id and answering a bare
+boolean. The ticket named only the verb, and reading only the verb would have
+been an N+1 fan-out over an answer that had usually already arrived; reading
+only the row would have reported "not established" for every pool on a system
+that omits an optional field, when a call could have settled it.
+
+**So the row is read first and the verb is called only where the row carried no
+boolean this file could read.** That is #102's rule — where a fact can arrive in
+more than one shape, a reading that both shapes satisfy is worth more than a
+guard written to one of them — plus #132's lazily-made fallback, where a
+supporting read nothing needs is not issued at all. The fallbacks that ARE
+needed go out together under one `Promise.all`, so the whole thing costs one
+further round trip rather than one per pool, which is `reporting_app_vm_usage`'s
+per-entity shape.
+
+**An unreadable row value falls through to the verb rather than short-circuiting
+to null.** A row that sent `is_upgraded` as something that is not a boolean has
+not answered, and the verb is the authoritative source for this question either
+way — so the fallback condition is "the row produced no boolean", never "the row
+had no key". `false` is a value and not an absence, and the test pinning that is
+the one worth keeping: `false` is the answer this tool exists to surface and it
+is also falsy, so a fallback written as `carried || read()` asks a second
+question about a pool that had already answered.
+
+**Null is not a false, and the three causes behind it are not separable.** No
+readable flag beside no readable pool id (nothing to aim the verb at), a verb
+that rejected, and a verb that answered with something that is not a boolean.
+The description says what a null rules out and names what it cannot tell apart,
+per #122, rather than enumerating a partition it does not have. **No companion
+field splits it**: #134's bar is that a companion earns its place where the
+causes behind one null are ones a caller would act on differently, and every
+cause here leaves the same course of action. The rejection text is dropped for
+the same reason, and the rejection itself is caught per pool — this tool is
+composed by `system_health_report` and, through it, by `fleet_health_rollup`, so
+a flag it cannot read must not take down the catalog's most load-bearing read.
+
+**`system_health_report` deliberately neither carries nor scores the field, and
+that is stated rather than left to omission.** Its verdict is about health, which
+this repository defines (#47); feature-flag currency is a NOTICE-level
+configuration fact — the pool keeps working, which is why an un-upgraded one goes
+unnoticed — and upgrading is ONE-WAY and can prevent a TrueNAS rollback, so it is
+a fact to report and never a defect to fix implicitly. #46's rule is to summarise
+by dropping fields and never by re-judging them, and #44's is that a composite
+re-reads every field through its own guard by name — which is what kept the new
+field out of `poolEntries` without a line changing there. The composite's spec
+now asserts the pools entry's **exact key list**, so a field reaching it
+unannounced fails a test rather than shipping. `storage_pool_status`'s own
+description carries the pointer both ways: a pool that is behind is not a reason
+that report is anything other than `OK`, and this field is where the answer
+lives.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/src/tools/storage.spec.ts
+++ b/src/tools/storage.spec.ts
@@ -1,12 +1,74 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { Observable, of, throwError } from 'rxjs';
 import { fakeSystem } from '@/testing/fake-systems';
+import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { listDatasets, poolStatus, quotaReport, systemDatasetConfig } from '@/tools/index';
 
 describe('storage_pool_status', () => {
+  /** One row of `pool.query`, with the fields this tool reads. */
+  const pool = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    name: 'tank',
+    status: 'ONLINE',
+    healthy: true,
+    size: 100,
+    allocated: 40,
+    free: 60,
+    ...over,
+  });
+
+  interface Row {
+    name: string | null;
+    feature_flags_current: boolean | null;
+  }
+
+  interface Options {
+    pools?: unknown[];
+    /** What `pool.is_upgraded` answers, per pool id. */
+    upgraded?: Record<number, unknown>;
+    /** Keyed `pool.is_upgraded:<id>`, for one pool's read failing on its own. */
+    failures?: Record<string, unknown>;
+  }
+
+  /**
+   * A SystemHandle answering `pool.is_upgraded` PER POOL ID, which neither
+   * `fakeSystem` nor `failingSystem` can do: both key on the method alone, and
+   * every pool's flag comes back from the same method distinguished only by the
+   * id asked for.
+   */
+  const poolSystem = (options: Options = {}) => {
+    const failures = options.failures ?? {};
+    const upgraded = options.upgraded ?? {};
+    const query = vi.fn(() => of(options.pools ?? [pool()]));
+    // The client takes a call's parameters as one tuple, so the id arrives
+    // wrapped: `call('pool.is_upgraded', [1])`.
+    const call = vi.fn((method: string, params: [number]) => {
+      const key = `${method}:${params[0]}`;
+      return key in failures ? throwError(() => failures[key]) : of(upgraded[params[0]]);
+    });
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    return { ctx: { system } as ToolContext, call, query };
+  };
+
+  const rows = async (options: Options = {}): Promise<Row[]> =>
+    (await poolStatus.handler(poolSystem(options).ctx, {})) as Row[];
+
+  const flag = async (options: Options = {}): Promise<boolean | null> =>
+    (await rows(options))[0].feature_flags_current;
+
   it('trims pool.query to health and capacity', async () => {
     const { ctx } = fakeSystem({
       ['pool.query']: [
-        { name: 'tank', status: 'ONLINE', healthy: true, size: 100, allocated: 40, free: 60 },
+        {
+          id: 1,
+          name: 'tank',
+          status: 'ONLINE',
+          healthy: true,
+          size: 100,
+          allocated: 40,
+          free: 60,
+          is_upgraded: true,
+        },
       ],
     });
     expect(await poolStatus.handler(ctx, {})).toEqual([
@@ -17,8 +79,124 @@ describe('storage_pool_status', () => {
         size_bytes: 100,
         allocated_bytes: 40,
         free_bytes: 60,
+        feature_flags_current: true,
       },
     ]);
+  });
+
+  it('reports the feature-flag state the pool row carried, and asks nothing further', async () => {
+    const fake = poolSystem({ pools: [pool({ is_upgraded: true })] });
+    const [row] = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(row.feature_flags_current).toBe(true);
+    // The row already answered, so the separate verb is a call nothing needs.
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('reports a false the pool row carried rather than reading it again', async () => {
+    // `false` is the answer this tool exists to surface and it is also falsy,
+    // so a fallback written as `carried || read()` would ask the middleware a
+    // second question about a pool that had already answered.
+    const fake = poolSystem({ pools: [pool({ is_upgraded: false })], upgraded: { 1: true } });
+    const [row] = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(row.feature_flags_current).toBe(false);
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('reads the flag by the pool own id where the row did not carry one', async () => {
+    const fake = poolSystem({ pools: [pool({ id: 7 })], upgraded: { 7: false } });
+    const [row] = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(row.feature_flags_current).toBe(false);
+    expect(fake.call.mock.calls).toEqual([['pool.is_upgraded', [7]]]);
+  });
+
+  it('reads each pool by its own id, so two pools do not share one answer', async () => {
+    const fake = poolSystem({
+      pools: [pool({ id: 1 }), pool({ id: 2, name: 'vault' })],
+      upgraded: { 1: true, 2: false },
+    });
+    const result = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(result.map((row) => row.feature_flags_current)).toEqual([true, false]);
+    expect(fake.call.mock.calls).toEqual([
+      ['pool.is_upgraded', [1]],
+      ['pool.is_upgraded', [2]],
+    ]);
+  });
+
+  it('issues every fallback read together rather than one pool after another', async () => {
+    // Nothing answers until it is released, so a sequential fan-out would have
+    // subscribed to the first read and stopped there. Both being outstanding at
+    // once is what says the reads were issued together.
+    const release: ((value: boolean) => void)[] = [];
+    const call = vi.fn(
+      () =>
+        new Observable<unknown>((subscriber) => {
+          release.push((value) => {
+            subscriber.next(value);
+            subscriber.complete();
+          });
+        }),
+    );
+    const query = vi.fn(() => of([pool({ id: 1 }), pool({ id: 2, name: 'vault' })]));
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    const answered = poolStatus.handler({ system } as ToolContext, {});
+    await vi.waitFor(() => expect(release).toHaveLength(2));
+    release[0](true);
+    release[1](false);
+    expect(((await answered) as Row[]).map((row) => row.feature_flags_current)).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('reports no flag, and asks nothing, for a pool with no id to ask about', async () => {
+    const fake = poolSystem({ pools: [pool({ id: null })] });
+    const [row] = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(row.feature_flags_current).toBeNull();
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it('reports no flag where the separate read was refused', async () => {
+    expect(await flag({ failures: { ['pool.is_upgraded:1']: { reason: 'no such pool' } } })).toBeNull();
+  });
+
+  it('reports no flag where the read answered with something that is not a boolean', async () => {
+    expect(await flag({ upgraded: { 1: 'yes' } })).toBeNull();
+  });
+
+  it('reports no flag where the row carried one that is not a boolean', async () => {
+    // The row's value is unreadable rather than absent, and the verb is still
+    // asked — it is the authoritative source for this question either way.
+    const fake = poolSystem({ pools: [pool({ is_upgraded: 'yes' })], upgraded: { 1: true } });
+    const [row] = (await poolStatus.handler(fake.ctx, {})) as Row[];
+    expect(row.feature_flags_current).toBe(true);
+    expect(fake.call.mock.calls).toEqual([['pool.is_upgraded', [1]]]);
+  });
+
+  it('keeps every other field of a pool whose flag could not be read', async () => {
+    // This tool is composed by `system_health_report` and, through it, by
+    // `fleet_health_rollup`. A flag that cannot be read must not be able to
+    // take down the catalog's most load-bearing read.
+    const { ctx } = poolSystem({ failures: { ['pool.is_upgraded:1']: new Error('refused') } });
+    expect(await poolStatus.handler(ctx, {})).toEqual([
+      {
+        name: 'tank',
+        status: 'ONLINE',
+        healthy: true,
+        size_bytes: 100,
+        allocated_bytes: 40,
+        free_bytes: 60,
+        feature_flags_current: null,
+      },
+    ]);
+  });
+
+  it('does not let one pool unreadable flag reach another pool', async () => {
+    const result = await rows({
+      pools: [pool({ id: 1 }), pool({ id: 2, name: 'vault' })],
+      upgraded: { 2: true },
+      failures: { ['pool.is_upgraded:1']: new Error('refused') },
+    });
+    expect(result.map((row) => row.feature_flags_current)).toEqual([null, true]);
   });
 });
 

--- a/src/tools/storage.spec.ts
+++ b/src/tools/storage.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Observable, of, throwError } from 'rxjs';
+import { EMPTY, Observable, of, throwError } from 'rxjs';
 import { fakeSystem } from '@/testing/fake-systems';
 import { SystemHandle, ToolContext } from '@/catalog/tool';
 import { listDatasets, poolStatus, quotaReport, systemDatasetConfig } from '@/tools/index';
@@ -161,6 +161,17 @@ describe('storage_pool_status', () => {
 
   it('reports no flag where the read answered with something that is not a boolean', async () => {
     expect(await flag({ upgraded: { 1: 'yes' } })).toBeNull();
+  });
+
+  it('reports no flag where the read completed without answering at all', async () => {
+    // `firstValueFrom` raises on an observable that completes without emitting.
+    // That is neither a refusal nor a non-boolean answer, which is why the
+    // description says what a null rules out rather than listing its causes.
+    const call = vi.fn(() => EMPTY);
+    const query = vi.fn(() => of([pool({ id: 1 })]));
+    const system = { name: 'nas', client: { api: { call, query } } } as unknown as SystemHandle;
+    const [row] = (await poolStatus.handler({ system } as ToolContext, {})) as Row[];
+    expect(row.feature_flags_current).toBeNull();
   });
 
   it('reports no flag where the row carried one that is not a boolean', async () => {

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -29,10 +29,13 @@ interface ZfsProperty {
  *
  * **Null is "not established", and it is never read as either verdict.** A pool
  * reported current when the read failed understates a finding and the reverse
- * invents one, which is the direction #93 turns on. Three causes reach it and
- * this result does not separate them: a row carrying no readable flag beside no
+ * invents one, which is the direction #93 turns on. Several causes reach it and
+ * this result separates none of them: a row carrying no readable flag beside no
  * readable pool id, so there was nothing to aim the verb at; a verb that
- * rejected; and a verb that answered with something that is not a boolean.
+ * rejected; a verb that answered with something that is not a boolean; and a
+ * verb whose observable completed without emitting at all, which `firstValueFrom`
+ * raises as an error and this catch takes with the rest. The description says
+ * what a null RULES OUT rather than enumerating a partition it does not have.
  *
  * **The rejection is caught here rather than reported.** `storage_pool_status`
  * is composed by `system_health_report` and, through it, by
@@ -77,19 +80,21 @@ export const poolStatus: ReadOnlyTool = {
     'implicitly. NOTHING IN THIS CATALOG UPGRADES A POOL: `pool.upgrade` is ' +
     'not a tool here, and the decision belongs to a person in the UI. ' +
     'A NULL `feature_flags_current` IS NOT A FALSE. Null is "this was not ' +
-    'established", and three causes reach it that this result does NOT ' +
-    'separate: the system reported no flag on the pool row and no pool id to ' +
-    'ask about separately, the separate read was refused, and that read ' +
-    'answered with something this tool could not take as a boolean. So a null ' +
-    'is not evidence that the pool is behind, and not evidence that it is ' +
-    'current. ' +
+    'established", and SEVERAL causes reach it that this result separates ' +
+    'NONE of: the system reported no flag on the pool row and no pool id to ' +
+    'ask about separately, a separate read that was refused, a separate read ' +
+    'that answered with something this tool could not take as a boolean, and ' +
+    'any other way that read ended without producing one. What a null DOES ' +
+    'rule out is that this tool read a boolean: it is not evidence that the ' +
+    'pool is behind, and not evidence that it is current. ' +
     '`system_health_report` DOES NOT RAISE A FINDING FOR THIS, and its verdict ' +
     'says nothing about it either way: feature-flag currency is a ' +
-    'configuration fact rather than a health problem. The system reports it as ' +
-    'a NOTICE-level `PoolUpgraded` alert, which `alerts_list` carries for as ' +
-    'long as that alert stands and not after it is dismissed. A pool that is ' +
-    'behind is therefore not a reason that report is anything other than OK, ' +
-    'and this field is where the answer lives.',
+    'configuration fact rather than a health problem. The system also reports ' +
+    'it as a NOTICE-level `PoolUpgraded` alert, which `alerts_list` carries as ' +
+    'prose — dismissed or not, since that tool includes dismissed alerts — for ' +
+    'as long as the system raises it; this field is the same fact as a state ' +
+    'per pool. A pool that is behind is therefore not a reason that report is ' +
+    'anything other than OK, and this field is where the answer lives.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -1,7 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
-import { ReadOnlyTool } from '@/catalog/tool';
-import { booleanOrNull, recordOrNull, textOrNull } from '@/tools/common';
+import { ReadOnlyTool, SystemHandle } from '@/catalog/tool';
+import { booleanOrNull, numberOrNull, recordOrNull, textOrNull } from '@/tools/common';
 
 /** A ZFS property as the middleware reports it. The client declares the property
  * object on the dataset fields it names, but types its `parsed` value `unknown`
@@ -14,23 +14,101 @@ interface ZfsProperty {
 
 /** Storage-health family: read-only inspection of pools and datasets. */
 
+/**
+ * Whether a pool's ZFS feature flags match what the running TrueNAS version
+ * offers — read from wherever the system actually answered it.
+ *
+ * The question has two sources on the pinned surface, and they are the same
+ * fact. A `pool.query` row declares `is_upgraded?: boolean`, OPTIONAL, so a
+ * system may or may not send it; `pool.is_upgraded` is a separate verb taking
+ * one pool id and answering a bare boolean. The row is read first and the verb
+ * is called only where the row carried no boolean this file could read — #102's
+ * rule that a reading both shapes satisfy is worth more than a guard written to
+ * one of them, and #132's lazily-made fallback, since a supporting read nothing
+ * needed should not be issued at all.
+ *
+ * **Null is "not established", and it is never read as either verdict.** A pool
+ * reported current when the read failed understates a finding and the reverse
+ * invents one, which is the direction #93 turns on. Three causes reach it and
+ * this result does not separate them: a row carrying no readable flag beside no
+ * readable pool id, so there was nothing to aim the verb at; a verb that
+ * rejected; and a verb that answered with something that is not a boolean.
+ *
+ * **The rejection is caught here rather than reported.** `storage_pool_status`
+ * is composed by `system_health_report` and, through it, by
+ * `fleet_health_rollup`, so a flag this tool cannot read must not be able to
+ * take down every other field of the catalog's most load-bearing read. The
+ * reason text is dropped rather than carried in a companion field: #134's bar
+ * is that a companion earns its place where the causes behind one null are ones
+ * a caller would act on differently, and every cause above leaves the same
+ * course of action — read the pool's flag some other way.
+ */
+async function featureFlagsCurrent(
+  system: SystemHandle,
+  id: unknown,
+  stated: unknown,
+): Promise<boolean | null> {
+  const carried = booleanOrNull(stated);
+  if (carried !== null) return carried;
+  const poolId = numberOrNull(id);
+  if (poolId === null) return null;
+  try {
+    const answer = await firstValueFrom(system.client.api.call('pool.is_upgraded', [poolId]));
+    return booleanOrNull(answer);
+  } catch {
+    return null;
+  }
+}
+
 export const poolStatus: ReadOnlyTool = {
   name: 'storage_pool_status',
   description:
     'Health and capacity of ZFS storage pools: status, whether the pool is ' +
-    'healthy, and size/allocated/free in bytes.',
+    'healthy, and size/allocated/free in bytes. ' +
+    "`feature_flags_current` is whether the pool's ZFS FEATURE FLAGS match " +
+    'what the running TrueNAS version offers. True is a pool holding every ' +
+    'feature this release has. False is a pool still on an older set, which ' +
+    'keeps working — nothing fails, which is why an un-upgraded pool goes ' +
+    'unnoticed — and simply never gets whatever the newer features were for. ' +
+    "UPGRADING A POOL'S FEATURE FLAGS IS ONE-WAY AND CANNOT BE UNDONE. An " +
+    'upgraded pool can no longer be read by an older ZFS, so upgrading it can ' +
+    'PREVENT ROLLING THE SYSTEM BACK to an earlier TrueNAS version — which is ' +
+    'why a false here is a fact to report and never a defect to fix ' +
+    'implicitly. NOTHING IN THIS CATALOG UPGRADES A POOL: `pool.upgrade` is ' +
+    'not a tool here, and the decision belongs to a person in the UI. ' +
+    'A NULL `feature_flags_current` IS NOT A FALSE. Null is "this was not ' +
+    'established", and three causes reach it that this result does NOT ' +
+    'separate: the system reported no flag on the pool row and no pool id to ' +
+    'ask about separately, the separate read was refused, and that read ' +
+    'answered with something this tool could not take as a boolean. So a null ' +
+    'is not evidence that the pool is behind, and not evidence that it is ' +
+    'current. ' +
+    '`system_health_report` DOES NOT RAISE A FINDING FOR THIS, and its verdict ' +
+    'says nothing about it either way: feature-flag currency is a ' +
+    'configuration fact rather than a health problem. The system reports it as ' +
+    'a NOTICE-level `PoolUpgraded` alert, which `alerts_list` carries for as ' +
+    'long as that alert stands and not after it is dismissed. A pool that is ' +
+    'behind is therefore not a reason that report is anything other than OK, ' +
+    'and this field is where the answer lives.',
   inputSchema: { type: 'object', properties: {} },
   requiredRole: Role.ReadOnly,
   mutating: false,
   async handler({ system }) {
     const pools = await firstValueFrom(system.client.api.query('pool.query'));
-    return pools.map((pool) => ({
+    // One read per pool whose row did not already carry the flag, and all of
+    // them issued together — the listing is what supplies the ids, so the whole
+    // fan-out costs one further round trip rather than one per pool.
+    const current = await Promise.all(
+      pools.map((pool) => featureFlagsCurrent(system, pool.id, pool.is_upgraded)),
+    );
+    return pools.map((pool, position) => ({
       name: pool.name,
       status: pool.status,
       healthy: pool.healthy,
       size_bytes: pool.size,
       allocated_bytes: pool.allocated,
       free_bytes: pool.free,
+      feature_flags_current: current[position],
     }));
   },
 };

--- a/src/tools/system-health-report.spec.ts
+++ b/src/tools/system-health-report.spec.ts
@@ -116,6 +116,28 @@ describe('system_health_report', () => {
     });
   });
 
+  it('raises nothing for a pool still on an older set of ZFS feature flags', async () => {
+    // `storage_pool_status` reports `feature_flags_current`, and this report
+    // neither carries it nor scores it. That is a decision rather than an
+    // omission: the verdict here is about HEALTH, and a pool that has not been
+    // upgraded is a NOTICE-level configuration fact — it keeps working, and
+    // upgrading it is one-way. #46's rule is to summarise by dropping fields
+    // and never by re-judging them, so the field stops at the composed tool.
+    const result = await report(healthy({ ['pool.query']: [pool({ is_upgraded: false })] }));
+    expect(result.verdict).toBe('OK');
+    expect(result.reasons).toEqual([]);
+    // Asserted as the exact key list rather than as an absence, so that a
+    // later field reaching the composite unannounced fails here too.
+    expect(Object.keys((result['pools']['entries'] as object[])[0])).toEqual([
+      'name',
+      'status',
+      'healthy',
+      'size_bytes',
+      'allocated_bytes',
+      'used_percent',
+    ]);
+  });
+
   it('states how full a pool is to one decimal place', async () => {
     const result = await report(
       healthy({ ['pool.query']: [pool({ size: 3000, allocated: 1000 })] }),

--- a/src/tools/system-health-report.spec.ts
+++ b/src/tools/system-health-report.spec.ts
@@ -126,8 +126,11 @@ describe('system_health_report', () => {
     const result = await report(healthy({ ['pool.query']: [pool({ is_upgraded: false })] }));
     expect(result.verdict).toBe('OK');
     expect(result.reasons).toEqual([]);
-    // Asserted as the exact key list rather than as an absence, so that a
-    // later field reaching the composite unannounced fails here too.
+    // Asserted as the exact key list rather than as an absence. Nothing can
+    // arrive here on its own — `poolEntries` names its six fields by hand,
+    // which is #44's guard and is what kept the new field out without a line
+    // changing there — so what this pins is the DECISION: an edit that added
+    // the field to the composite would have to fail a test to land.
     expect(Object.keys((result['pools']['entries'] as object[])[0])).toEqual([
       'name',
       'status',


### PR DESCRIPTION
`storage_pool_status` grows one field, `feature_flags_current`: whether each
pool's ZFS feature flags match what the running TrueNAS version offers.

An un-upgraded pool keeps working — nothing fails, which is why it goes
unnoticed — and simply never gets whatever the newer features were for.
Upgrading is **one-way** and can prevent rolling the system back to an earlier
TrueNAS version, so this is a fact to report precisely and never to act on
implicitly. Nothing in this catalog upgrades a pool.

Fixes #140

## The question has two sources on the surface, and the ticket named one

The ticket's design notes assume one `pool.is_upgraded` call per pool. That is
one of two ways to reach the answer on the pinned client, and the other was not
visible when the ticket was written:

- `PoolEntry` (the `pool.query` row) declares **`is_upgraded?: boolean`** —
  optional, so a system may or may not send it.
- **`pool.is_upgraded`** is a separate verb, `params: [id: number]`,
  `response: boolean`.

Reading only the verb is an N+1 fan-out over an answer that has usually already
arrived. Reading only the row reports "not established" for every pool on a
system that omits an optional field, when a call could have settled it. So the
row is read first, and **the verb is called only where the row carried no
boolean this file could read** — `#102`'s rule that a reading both shapes
satisfy is worth more than a guard written to one of them, plus `#132`'s
lazily-made fallback, where a supporting read nothing needs is not issued at
all. The fallbacks that *are* needed go out together under one `Promise.all`, so
the whole fan-out costs one further round trip rather than one per pool —
`reporting_app_vm_usage`'s per-entity shape.

An unreadable row value falls **through** to the verb rather than
short-circuiting to null: a row that sent `is_upgraded` as something that is not
a boolean has not answered, and the verb is authoritative either way. So the
fallback condition is "the row produced no boolean", never "the row had no key".
`false` is a value and not an absence, and there is a test pinning that — `false`
is the answer this field exists to surface and it is also falsy, so a fallback
written as `carried || read()` would ask a second question about a pool that had
already answered.

## Null is not a false, and its causes are not enumerated

Several causes reach null and the result separates none of them: a row with no
readable flag beside no readable pool id (nothing to aim the verb at), a verb
that rejected, a verb that answered with something that is not a boolean, and a
verb whose observable completed without emitting — which `firstValueFrom` raises
as an error and the same catch takes. The description says what a null **rules
out** (that this tool read a boolean) rather than offering a partition it does
not have, per `#122`, and every case has a test.

No companion field splits it. `#134`'s bar is that a companion earns its place
where the causes behind one null are ones a caller would act on differently, and
every cause here leaves the same course of action.

The read is caught **per pool**: `storage_pool_status` is composed by
`system_health_report` and, through it, by `fleet_health_rollup`, so a flag this
tool cannot read must not take down the catalog's most load-bearing read.

## `system_health_report` neither carries nor scores the field, deliberately

Its verdict is about health, which this repository defines (`#47`); feature-flag
currency is a NOTICE-level configuration fact. `#46`'s rule is to summarise by
dropping fields and never by re-judging them, and `#44`'s is that a composite
re-reads every field through its own guard by name — which is what kept the new
field out of `poolEntries` without a line changing there. **Every existing
`system_health_report` and `fleet_health_rollup` test passes unchanged.** One
test was added pinning the pools entry's exact key list, so that an edit adding
the field to the composite would have to fail a test to land.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test:coverage` and `yarn build` all run
clean locally. 1414 tests pass; `storage.ts` is at 100% statements and branches
and the global floors in `vitest.config.ts` are met. No new tool name; the
`createDefaultCatalog` exact-list test is untouched.

## Review

Run locally through the project's own reviewer (`local-review.py`, exit 0 on the
final round — the same rubric, threshold and parser as the required check, in a
separate process). Round 1 returned one MEDIUM and three LOWs; round 2 returned
nothing at MEDIUM or above.

**Fixed in round 2 (the MEDIUM):** the description claimed `alerts_list` carries
the `PoolUpgraded` alert only until it is dismissed. That is the ticket's own
wording and it is the opposite of what the tool does — `alerts_list` states
outright that dismissed alerts are still active conditions and are included. A
pointer at a neighbouring tool is a claim about that tool, and it is checked by
reading that tool's description; the correction and the lesson are both in
`CLAUDE.md`.

Two prose LOWs were fixed in the same commit, since a round was owed for the
MEDIUM anyway: the three-cause null account above, and a test comment claiming
the key-list assertion catches a field arriving at the composite on its own
(nothing can — it pins the decision).

## What I did not change, and why

Three LOWs from the clean round, left deliberately. Each is a real reading and
none blocks:

- **The fallback is an unbounded fan-out inside two composites that discard the
  field.** True where a system's `pool.query` rows omit `is_upgraded`: the
  composites pay one extra round trip for an answer they drop. It is not fixable
  from inside the handler — `#44` says a composite calls handlers and not the
  API, so a handler cannot know its caller, and the alternatives are an argument
  nobody asked for or reading only the row (which reintroduces the null this
  design exists to avoid). Worth a ticket if it is judged to matter; the cost is
  bounded by the pool count and is zero on any system whose rows carry the field.
- **The two rejection tests would still pass if their `failures` key stopped
  matching**, because the helper's default `of(undefined)` already yields the
  asserted null and neither asserts the call was made. A genuine weakness in the
  tests rather than in the code; fixing it means touching executable test code,
  which starts another review round.
- **The exact-key-list assertion overlaps the `toEqual` in the existing "is OK
  only when every section was read" test**, which already fails on an extra key.
  The new one states the decision under its own name, which is what I wanted it
  to do, but the redundancy is real.
