### PR TITLE
feat(tools): add pool_resilver_config, the window resilvering runs at raised priority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1583,6 +1583,45 @@ alerts are still active conditions and are included. A pointer between tools is
 a claim about the other tool, and it can be false the same way any description
 can.
 
+### Match a numbering by stating it, not by importing the family that renders it (#141)
+
+`pool_resilver_config` reports `weekday` as the NUMBERS the middleware sent,
+and the ticket asked for the numbering `tasks.ts` already settled for cron
+day-of-week fields. Two things were in tension: #95 refuses to copy a family's
+vocabulary into a second family — the cron rendering (`dayName`,
+`describeSchedule`) is the tasks family's own — while a second, disagreeing
+account of what day `1` is would be exactly the drift `common.ts` was cut to
+stop.
+
+**The way out was that there was nothing to choose between.** The surface
+declares `weekday?: number[]` and states no numbering, so the reading is a
+guess in the #98 sense; what makes it a checkable one is that the two candidate
+numberings AGREE ON EVERY VALUE BOTH DEFINE. Cron runs 0 and 7 for Sunday with
+1 Monday through 6 Saturday (`dayName` maps `n % 7` over a Sunday-first list);
+ISO-8601 runs 1 Monday through 7 Sunday and has no 0. So 1–7 name the same day
+under both, and 0 is cron's alone. The description states that agreement and
+stops there — it does not claim the field IS cron-numbered — and `pools.ts`
+imports nothing from `tasks.ts`. **Matching a convention is stating it; it is
+not re-siting the code that implements it**, and where two readings coincide,
+saying so is a stronger claim than picking one (#102's reduction that both
+shapes satisfy, reached from the numbering instead of from the payload).
+
+**The range check is what keeps that statement true**, which is why it is
+all-or-nothing. An entry outside 0–7 is a day neither numbering names, so the
+list has been misread rather than partially read — the same reading
+`numberList` gives an out-of-range cron field — and under #93 a `weekday` one
+day shorter would say the window does not apply on that day, which is a claim.
+`[]` stays `[]`: the system reported a list and it names no day.
+
+**A middleware field name inherits none of the tool's care, and `enabled` is
+the case to watch.** `enabled: false` on this payload means the priority window
+is not in force — the system still resilvers, at ordinary priority — so the
+name promises a great deal more than it delivers, and the correction lives in
+the description because the name is the middleware's to spell. That is
+`storage_scrub_history`'s finding arriving through a field this repository did
+not name, and it is why the description says what the flag does NOT mean before
+it says anything else about it.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,6 +1613,16 @@ list has been misread rather than partially read — the same reading
 day shorter would say the window does not apply on that day, which is a claim.
 `[]` stays `[]`: the system reported a list and it names no day.
 
+**"System-local" is itself an unconfirmed reading, and the ticket asking for it
+does not make it a confirmed one.** `begin` and `end` are clock times with no
+zone in them, and the surface states the zone for these no more than it does
+for any other schedule the catalog reports. What is established is the
+negative — nothing in the strings says which zone, so the instant either names
+is not fixed by this read — and the local-time reading is carried as
+`(unconfirmed)`, in `ups_config`'s form, with `system_general_config` named as
+where to confirm it. **A ticket can ask for a sentence and still not supply the
+evidence for it**; state what the read establishes, and mark the rest.
+
 **A middleware field name inherits none of the tool's care, and `enabled` is
 the case to watch.** `enabled: false` on this payload means the priority window
 is not in force — the system still resilvers, at ordinary priority — so the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `audit_log_query`, `audit_config`, `security_config`, `system_general_config`,
   `system_ntp_status`, `ups_config`,
   `storage_pool_status`, `storage_pool_topology`, `storage_scrub_history`,
-  `boot_pool_status`,
+  `pool_resilver_config`, `boot_pool_status`,
   `storage_list_datasets`, `datasets_quota_report`, `system_dataset_config`,
   `disks_list`, `disks_temperature`, `apps_list`,
   `app_engine_status`, `apps_update_summary`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ export {
   poolStatus,
   poolTopology,
   scrubHistory,
+  poolResilverConfig,
   bootPoolStatus,
   listDatasets,
   quotaReport,

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the sixty-one sketch tools', () => {
+  it('registers the sixty-two sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -17,6 +17,7 @@ describe('createDefaultCatalog', () => {
       'storage_pool_status',
       'storage_pool_topology',
       'storage_scrub_history',
+      'pool_resilver_config',
       'boot_pool_status',
       'storage_list_datasets',
       'datasets_quota_report',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,7 +10,7 @@ import { disksList, disksTemperature } from '@/tools/disks';
 import { fleetComplianceReport, fleetHealthRollup, haStatus } from '@/tools/fleet';
 import { networkConfig, networkInterfaces } from '@/tools/network';
 import { nfsClients } from '@/tools/nfs';
-import { poolTopology, scrubHistory } from '@/tools/pools';
+import { poolResilverConfig, poolTopology, scrubHistory } from '@/tools/pools';
 import { replicationStatus, replicationTopology } from '@/tools/replication';
 import {
   reportingAppVmUsage,
@@ -45,7 +45,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: fifty-five read-only tools plus six mutating tools. */
+/** The sketch's catalog: fifty-six read-only tools plus six mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -60,6 +60,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(poolStatus);
   catalog.register(poolTopology);
   catalog.register(scrubHistory);
+  catalog.register(poolResilverConfig);
   catalog.register(bootPoolStatus);
   catalog.register(listDatasets);
   catalog.register(quotaReport);
@@ -143,6 +144,7 @@ export {
   networkInterfaces,
   nfsClients,
   nvmeofList,
+  poolResilverConfig,
   poolStatus,
   poolTopology,
   privilegesList,

--- a/src/tools/pools.spec.ts
+++ b/src/tools/pools.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { fakeSystem } from '@/testing/fake-systems';
-import { poolTopology, scrubHistory } from '@/tools/index';
+import { Role } from '@/interfaces';
+import { failingSystem, fakeSystem } from '@/testing/fake-systems';
+import { poolResilverConfig, poolTopology, scrubHistory } from '@/tools/index';
 
 /** The shape `storage_pool_topology` returns, for the assertions below. */
 interface MappedDevice {
@@ -634,5 +635,144 @@ describe('storage_scrub_history', () => {
   it('returns [] for a system with no pools', async () => {
     const { ctx } = fakeSystem({ ['pool.query']: [] });
     expect(await scrubHistory.handler(ctx, {})).toEqual([]);
+  });
+});
+
+describe('pool_resilver_config', () => {
+  /** The configuration as `pool.resilver.config` reports one. */
+  const config = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    enabled: true,
+    begin: '18:00',
+    end: '09:00',
+    weekday: [1, 2, 3, 4, 5, 6, 7],
+    ...over,
+  });
+
+  const read = async (payload: unknown): Promise<Record<string, unknown>> => {
+    const { ctx } = fakeSystem({ ['pool.resilver.config']: payload });
+    return (await poolResilverConfig.handler(ctx, {})) as Record<string, unknown>;
+  };
+
+  it('is advertised as a read-only, non-mutating tool taking no arguments', () => {
+    expect(poolResilverConfig.name).toBe('pool_resilver_config');
+    expect(poolResilverConfig.mutating).toBe(false);
+    expect(poolResilverConfig.requiredRole).toBe(Role.ReadOnly);
+    expect(poolResilverConfig.inputSchema).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('reads the one system-wide configuration, with no parameters', async () => {
+    const { ctx, call } = fakeSystem({ ['pool.resilver.config']: config() });
+    expect(await poolResilverConfig.handler(ctx, {})).toEqual({
+      enabled: true,
+      begin: '18:00',
+      end: '09:00',
+      weekday: [1, 2, 3, 4, 5, 6, 7],
+    });
+    expect(call).toHaveBeenCalledWith('pool.resilver.config');
+  });
+
+  it('reports the four fields and nothing else, whatever the payload adds', async () => {
+    // `id` is dropped deliberately — there is one such configuration — and the
+    // allowlist is what keeps a field a later release adds out of the result.
+    const result = await read(
+      config({ future_field: 'added by a later TrueNAS release', weekday: [2] }),
+    );
+    expect(Object.keys(result)).toEqual(['enabled', 'begin', 'end', 'weekday']);
+  });
+
+  it('keeps an unreported field distinct from a configured-off one', async () => {
+    // The whole difficulty of this payload: every field is optional, so
+    // `enabled` absent must not read as `enabled: false`, and a `weekday` the
+    // system did not send must not read as a window applying on no day.
+    const absent = await read({ id: 1 });
+    expect(absent).toEqual({ enabled: null, begin: null, end: null, weekday: null });
+
+    const off = await read(config({ enabled: false, weekday: [] }));
+    expect(off).toEqual({ enabled: false, begin: '18:00', end: '09:00', weekday: [] });
+  });
+
+  it('reads a window that wraps midnight as the two times the system recorded', async () => {
+    // 22:00 to 06:00 is eight hours across the night. Nothing here subtracts
+    // one end from the other, so there is no way for it to read as empty or
+    // negative — this test is what pins that the times are passed through.
+    const result = await read(config({ begin: '22:00', end: '06:00' }));
+    expect(result['begin']).toBe('22:00');
+    expect(result['end']).toBe('06:00');
+  });
+
+  it('reports `enabled: true` beside an empty weekday as that combination', async () => {
+    // Not resolved into either reading: nothing on this surface says what the
+    // system does with a window that names no day.
+    expect(await read(config({ enabled: true, weekday: [] }))).toEqual({
+      enabled: true,
+      begin: '18:00',
+      end: '09:00',
+      weekday: [],
+    });
+  });
+
+  it('keeps every day number the two candidate numberings agree on', async () => {
+    // 0 is cron's Sunday and 7 is Sunday under both numberings, so the whole
+    // 0-7 range is readable and none of it is dropped.
+    const result = await read(config({ weekday: [0, 1, 2, 3, 4, 5, 6, 7] }));
+    expect(result['weekday']).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('nulls the whole weekday list rather than returning a shorter one', async () => {
+    // A list one day shorter would say the window does not apply on that day,
+    // which is a claim the read did not establish (#93). Every entry that is
+    // not a whole number in range takes the list with it.
+    const unreadable = [[1, 8], [1, -1], [1, 2.5], [1, 'monday'], [1, null], [1, NaN]];
+    for (const weekday of unreadable) {
+      expect((await read(config({ weekday })))['weekday']).toBeNull();
+    }
+  });
+
+  it('nulls weekday where the field is not a list at all', async () => {
+    expect((await read(config({ weekday: 'MONDAY' })))['weekday']).toBeNull();
+    expect((await read(config({ weekday: { 1: true } })))['weekday']).toBeNull();
+  });
+
+  it('nulls a field the system sent as something other than its declared type', async () => {
+    // A declared type is a claim about what the middleware sends, not the value
+    // received (#91), so each field is read through a guard even though the
+    // client declares all four.
+    const result = await read(config({ enabled: 'yes', begin: 18, end: '' }));
+    expect(result['enabled']).toBeNull();
+    expect(result['begin']).toBeNull();
+    expect(result['end']).toBeNull();
+  });
+
+  it('fails naming the read when the system answers with something else', async () => {
+    // Fatal rather than a result of nulls: a configuration of nulls would be
+    // indistinguishable from a system that has configured no window, and only
+    // one of the two was actually read.
+    await expect(read('not a configuration')).rejects.toThrow(
+      'pool.resilver.config did not answer with a resilver configuration',
+    );
+    await expect(read([config()])).rejects.toThrow(
+      'pool.resilver.config did not answer with a resilver configuration',
+    );
+    await expect(read(null)).rejects.toThrow(
+      'pool.resilver.config did not answer with a resilver configuration',
+    );
+  });
+
+  it('lets a failed read fail the tool, naming what the system said', async () => {
+    const { ctx } = failingSystem({}, { ['pool.resilver.config']: new Error('connection reset') });
+    await expect(poolResilverConfig.handler(ctx, {})).rejects.toThrow('connection reset');
+  });
+
+  it('says in its description what `enabled: false` does and does not mean', async () => {
+    // The one reading that costs an operator something: a caller taking the
+    // flag for "resilvering is disabled" would conclude a replaced disk is not
+    // being rebuilt. Pinned, because it lives in prose and nothing else asserts
+    // it (#128).
+    expect(poolResilverConfig.description).toContain(
+      'IT DOES NOT MEAN RESILVERING IS DISABLED',
+    );
+    expect(poolResilverConfig.description).toContain('system_general_config');
+    expect(poolResilverConfig.description).toContain('SPANS MIDNIGHT');
   });
 });

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ReadOnlyTool } from '@/catalog/tool';
+import { booleanOrNull, numberOrNull, recordOrNull, textOrNull } from '@/tools/common';
 
 /** Pool internals: the vdev tree beneath each pool, the state of every device
  * in it, and the outcome of the last scrub that verified it.
@@ -259,5 +260,197 @@ export const scrubHistory: ReadOnlyTool = {
         errors: scrub?.errors ?? null,
       };
     });
+  },
+};
+
+/**
+ * The days a `weekday` list can name, as numbers.
+ *
+ * The surface declares `weekday?: number[]` and states no numbering for it. Two
+ * numberings are in ordinary use for such a field and THEY AGREE ON EVERY VALUE
+ * BOTH DEFINE: cron's — which this catalog already reads a `dow` field under,
+ * in `tasks.ts` — runs 0 and 7 for Sunday with 1 Monday through 6 Saturday, and
+ * ISO-8601's runs 1 Monday through 7 Sunday with no 0. So a number in this
+ * range names one day whichever of the two the middleware means, and a number
+ * outside it names none under either.
+ *
+ * That agreement is the whole of what is established here, and it is why this
+ * file states the numbering without reaching into the tasks family for its
+ * rendering: the cron vocabulary — `dayName`, `describeSchedule` and the
+ * helpers under them — is that family's own (#95), and matching a convention is
+ * not the same act as re-siting the code that implements it.
+ */
+const WEEKDAY_MIN = 0;
+const WEEKDAY_MAX = 7;
+
+/**
+ * The days a resilver window applies on, all of them or none.
+ *
+ * All-or-nothing for #93's reason rather than for symmetry with any sibling:
+ * this list is read for which days the window is in force, so a list one entry
+ * shorter says the window does not apply on that day — a CLAIM, and one made
+ * silently. Nulling the whole list refuses it. An entry outside {@link
+ * WEEKDAY_MIN}–{@link WEEKDAY_MAX} is not a day this file can name under either
+ * numbering, so it is a list this tool has misread rather than a day to report,
+ * which is the same reading `numberList` gives an out-of-range cron field in
+ * `tasks.ts`.
+ *
+ * An EMPTY list is not that answer and is returned as itself: the system
+ * reported a list and it names no day.
+ */
+function weekdayList(value: unknown): number[] | null {
+  if (!Array.isArray(value)) return null;
+  const days: number[] = [];
+  for (const entry of value) {
+    const day = numberOrNull(entry);
+    if (day === null || !Number.isInteger(day) || day < WEEKDAY_MIN || day > WEEKDAY_MAX) {
+      return null;
+    }
+    days.push(day);
+  }
+  return days;
+}
+
+/**
+ * When ZFS resilvering is given priority over other I/O, which is one
+ * system-wide setting rather than a per-pool one.
+ *
+ * `pool.resilver.config` takes no parameters and answers with one entity, so
+ * there is nothing here to key on a pool — unlike every other tool in this
+ * file, which maps `pool.query` one row at a time. The middleware row `id` is
+ * dropped: there is one such configuration, and an id names nothing outside the
+ * middleware, the same omission `ups_config` and `system_ntp_status` make.
+ *
+ * WHAT `enabled: false` MEANS IS THE WHOLE RISK IN THIS TOOL. It says the
+ * priority window is not in force; it does not say resilvering is off, and a
+ * system reporting it still rebuilds redundancy after a disk is replaced, at
+ * its ordinary priority. A name promising more than the data holds is this
+ * repository's most common review finding — `storage_scrub_history` promising
+ * history one scan record cannot hold is the same shape — and here the field
+ * name is the middleware's, so the description carries the correction rather
+ * than the name.
+ *
+ * EVERY FIELD IS OPTIONAL ON THE DECLARED ENTRY, and that is what the
+ * normalization is for: `enabled` absent is not `enabled: false`, and a window
+ * with no `begin` is not one starting at midnight. Each is read through a guard
+ * and answers null where the system reported no value this file could read,
+ * which keeps "unreported" distinct from "configured off" per field — for
+ * `weekday` that distinction is null against `[]`, and for `enabled` it is null
+ * against `false`.
+ *
+ * WHAT THIS TOOL DELIBERATELY DOES NOT DO:
+ *
+ * - **It does not say whether a resilver is running, ever ran, or how far
+ *   along one is.** That is the measured half of the question and this read is
+ *   the configured half (#133). A device being replaced is visible in
+ *   `storage_pool_topology`, which nests the outgoing and incoming disks
+ *   beneath the member being replaced.
+ * - **It does not parse, compare or convert `begin` and `end`.** They are
+ *   passed through as the system spelled them. A window whose `end` is earlier
+ *   than its `begin` spans midnight and is a real window; anything here that
+ *   subtracted one from the other would have to decide that, and deciding it
+ *   would assert a time format the surface does not state (#96).
+ * - **It does not resolve `enabled: true` beside an empty `weekday`.** Nothing
+ *   on this surface says what the middleware does with a window that names no
+ *   day, so the combination is reported as the combination it is rather than
+ *   smoothed into either reading (#120).
+ * - **It does not change the window.** `pool.resilver.update` is mutating and
+ *   is not in this catalog.
+ */
+export const poolResilverConfig: ReadOnlyTool = {
+  name: 'pool_resilver_config',
+  description:
+    'When ZFS resilvering on this system is given priority over other I/O. A ' +
+    'resilver is what rebuilds redundancy after a disk is replaced or comes ' +
+    'back, and until it finishes the pool is running without the redundancy ' +
+    'it is configured for — so how quickly it finishes is the thing this ' +
+    'setting is about. Inside the configured window resilvering is prioritised ' +
+    'over other I/O and finishes sooner, at the cost of contending with ' +
+    'production work; outside it, the other work is prioritised instead. THIS ' +
+    'IS ONE SYSTEM-WIDE SETTING AND NOT A PER-POOL ONE: it governs every ' +
+    'resilver on the system, and no field below is about any particular pool. ' +
+    '`enabled` is whether that priority window is in force. It is ' +
+    'THREE-VALUED — true, false, or null where the system reported no value ' +
+    'this tool could read — and A NULL IS NOT A FALSE. `enabled: false` MEANS ' +
+    'THE PRIORITY WINDOW IS NOT IN FORCE. IT DOES NOT MEAN RESILVERING IS ' +
+    'DISABLED, and it is NOT evidence that a replaced disk will not be rebuilt: ' +
+    'a system with the window off still resilvers, at its ordinary priority. ' +
+    'Reporting `enabled: false` as "resilvering is off" is the misreading this ' +
+    'sentence exists to prevent. ' +
+    '`begin` and `end` are the start and end of the window as the system ' +
+    'recorded them, passed through exactly as spelled and NOT parsed, ' +
+    'converted or compared here. THEY CARRY NO TIMEZONE AND ARE NOT UTC: they ' +
+    "are the system's own local time, and `system_general_config` reports the " +
+    '`timezone` that local time is in. AN `end` EARLIER THAN `begin` IS A ' +
+    'WINDOW THAT SPANS MIDNIGHT and is never an empty or a negative one — ' +
+    '`begin` 22:00 with `end` 06:00 is eight hours across the night. Each is ' +
+    'null where the system reported no value this tool could read; a null is ' +
+    'not midnight and is not "no restriction", and a null in one end says ' +
+    'nothing about when the other end applies from or to. ' +
+    '`weekday` is the days of the week the window applies on, as NUMBERS the ' +
+    'system sent and not converted to names here. THE API STATES NO NUMBERING ' +
+    'FOR THIS FIELD. What is established is that the two numberings in ' +
+    'ordinary use for a day-of-the-week field agree on every value both ' +
+    'define: cron numbers Sunday as 0 and again as 7 with 1 Monday through 6 ' +
+    'Saturday, ISO-8601 numbers 1 Monday through 7 Sunday and has no 0, so 1 ' +
+    'to 7 name the same days under both. That is the same numbering this ' +
+    'catalog reads a cron day-of-the-week field under, which ' +
+    '`automated_tasks_list` reports as `dow`. Read a number in 0 to 7 as that ' +
+    'day and do not go further than the agreement above. ' +
+    '`weekday` is null where the system reported no list this tool could read ' +
+    '— no such field, a value that is not a list, or a list holding an entry ' +
+    'that is not a whole number from 0 to 7 — AND NOTHING HERE SEPARATES THOSE ' +
+    'CAUSES. A partial list is never returned, because a list one day shorter ' +
+    'would say the window does not apply on that day, which is a claim this ' +
+    'read did not establish. AN EMPTY `weekday` IS A DIFFERENT ANSWER and is ' +
+    'reported as itself: the system sent a list and it names no day. ' +
+    '`enabled: true` BESIDE AN EMPTY `weekday` IS REPORTED AS THAT ' +
+    'COMBINATION AND IS NOT RESOLVED. Nothing on this surface says what the ' +
+    'system does with a window that names no day, so do not report such a ' +
+    'system as one where resilvering is prioritised, and do not report it as ' +
+    'one where the window is off. ' +
+    'THIS IS THE CONFIGURATION AND NOTHING ELSE. It does NOT establish that a ' +
+    'resilver is running, that one ever ran, how far along one is, or how long ' +
+    'one took, and no field above is evidence about any of that. A device ' +
+    'being replaced right now is visible in `storage_pool_topology`, which ' +
+    'lists the outgoing and incoming disks beneath the member being replaced. ' +
+    '`storage_scrub_history` covers the sibling operation and reports scrubs ' +
+    'rather than resilvers — a pool whose most recent scan was a resilver ' +
+    'reports `UNKNOWN` there, which is that tool refusing to read a resilver ' +
+    'as a scrub and is not a report on the resilver. ' +
+    'THIS TOOL ONLY READS. It does not change the window, does not start, ' +
+    'pause or stop a resilver, and does not replace a disk — ' +
+    '`pool.resilver.update` is the mutating counterpart and is not in this ' +
+    'catalog. The middleware row id is not reported: there is one such ' +
+    'configuration, and an id names nothing outside the middleware. NO field ' +
+    'beyond `enabled`, `begin`, `end` and `weekday` is returned, whatever a ' +
+    'later TrueNAS release adds to this payload. A configuration that could ' +
+    'not be read at all is an error naming what the system said, not a result ' +
+    'of nulls.',
+  inputSchema: { type: 'object', properties: {} },
+  requiredRole: Role.ReadOnly,
+  mutating: false,
+  async handler({ system }) {
+    const config = await firstValueFrom(system.client.api.call('pool.resilver.config'));
+    // Guarded rather than reached into, for the reason `ups_config` gives: a
+    // system answering with something that is not a configuration would
+    // otherwise throw naming a property, and the caller would see the name of a
+    // field rather than the read that failed. Fatal rather than mapped to
+    // nulls, because a result of nulls is indistinguishable from a system that
+    // has configured no window and only one of the two was read.
+    const settings = recordOrNull(config);
+    if (settings === null) {
+      throw new Error('pool.resilver.config did not answer with a resilver configuration');
+    }
+    // Named one at a time rather than trimmed, and read through a guard even
+    // where the client declares the field, which is #91: a declared type is a
+    // claim about what the middleware sends and not the value received. Every
+    // one of these is optional on the declared entry besides.
+    return {
+      enabled: booleanOrNull(settings['enabled']),
+      begin: textOrNull(settings['begin']),
+      end: textOrNull(settings['end']),
+      weekday: weekdayList(settings['weekday']),
+    };
   },
 };

--- a/src/tools/pools.ts
+++ b/src/tools/pools.ts
@@ -280,8 +280,7 @@ export const scrubHistory: ReadOnlyTool = {
  * helpers under them — is that family's own (#95), and matching a convention is
  * not the same act as re-siting the code that implements it.
  */
-const WEEKDAY_MIN = 0;
-const WEEKDAY_MAX = 7;
+const WEEKDAY_RANGE = { min: 0, max: 7 } as const;
 
 /**
  * The days a resilver window applies on, all of them or none.
@@ -289,11 +288,10 @@ const WEEKDAY_MAX = 7;
  * All-or-nothing for #93's reason rather than for symmetry with any sibling:
  * this list is read for which days the window is in force, so a list one entry
  * shorter says the window does not apply on that day — a CLAIM, and one made
- * silently. Nulling the whole list refuses it. An entry outside {@link
- * WEEKDAY_MIN}–{@link WEEKDAY_MAX} is not a day this file can name under either
- * numbering, so it is a list this tool has misread rather than a day to report,
- * which is the same reading `numberList` gives an out-of-range cron field in
- * `tasks.ts`.
+ * silently. Nulling the whole list refuses it. An entry outside
+ * {@link WEEKDAY_RANGE} is not a day this file can name under either numbering,
+ * so it is a list this tool has misread rather than a day to report, which is
+ * the same reading `numberList` gives an out-of-range cron field in `tasks.ts`.
  *
  * An EMPTY list is not that answer and is returned as itself: the system
  * reported a list and it names no day.
@@ -303,7 +301,12 @@ function weekdayList(value: unknown): number[] | null {
   const days: number[] = [];
   for (const entry of value) {
     const day = numberOrNull(entry);
-    if (day === null || !Number.isInteger(day) || day < WEEKDAY_MIN || day > WEEKDAY_MAX) {
+    if (
+      day === null ||
+      !Number.isInteger(day) ||
+      day < WEEKDAY_RANGE.min ||
+      day > WEEKDAY_RANGE.max
+    ) {
       return null;
     }
     days.push(day);
@@ -379,9 +382,14 @@ export const poolResilverConfig: ReadOnlyTool = {
     'sentence exists to prevent. ' +
     '`begin` and `end` are the start and end of the window as the system ' +
     'recorded them, passed through exactly as spelled and NOT parsed, ' +
-    'converted or compared here. THEY CARRY NO TIMEZONE AND ARE NOT UTC: they ' +
-    "are the system's own local time, and `system_general_config` reports the " +
-    '`timezone` that local time is in. AN `end` EARLIER THAN `begin` IS A ' +
+    'converted or compared here. THEY CARRY NO TIMEZONE AND MUST NOT BE READ ' +
+    'AS UTC: the strings name a clock time and nothing in them says which zone ' +
+    'that clock is in, so the instant either one names is not established by ' +
+    'this read. (unconfirmed) They are the system\'s own local time, as every ' +
+    'other schedule the catalog reports is, and `system_general_config` is ' +
+    'where that `timezone` is reported — the API states the zone for none of ' +
+    'them, so confirm it there before converting either value or comparing it ' +
+    'against a time from anywhere else. AN `end` EARLIER THAN `begin` IS A ' +
     'WINDOW THAT SPANS MIDNIGHT and is never an empty or a negative one — ' +
     '`begin` 22:00 with `end` 06:00 is eight hours across the night. Each is ' +
     'null where the system reported no value this tool could read; a null is ' +


### PR DESCRIPTION
Adds `pool_resilver_config`, reporting the window during which ZFS resilvering
runs at raised priority. Read-only, no parameters, over `pool.resilver.config`.

Fixes #141

## What it returns

`enabled`, `begin`, `end`, `weekday`, and nothing else. The middleware row `id`
is dropped — there is one such configuration, and an id names nothing outside
the middleware, the same omission `ups_config` and `system_ntp_status` make.

**This is one system-wide setting, not a per-pool one.** `pool.resilver.config`
takes no parameters and answers with one entity, so the tool returns one object
rather than a row per pool — unlike everything else in `pools.ts`, which maps
`pool.query`. The description says so, because the file it lives in is
otherwise entirely per-pool.

## The three things that were actually hard

**Every field is optional on the declared entry**, which is the whole of the
normalization. `enabled` absent is not `enabled: false`; a window with no
`begin` is not one starting at midnight. Each field is read through a
`common.ts` guard, so "unreported" stays distinguishable from "configured off"
per field: null against `false` for `enabled`, null against `[]` for `weekday`.

**`weekday` numbering is unstated on the surface, and the two candidates agree.**
The ticket asked to match what `tasks.ts` settled for cron day-of-week. #95
refuses to copy a family's vocabulary into a second family, and the cron
rendering (`dayName`, `describeSchedule`) is the tasks family's own. There was
nothing to choose between: cron numbers Sunday 0 and again 7 with 1 Monday
through 6 Saturday, ISO-8601 numbers 1 Monday through 7 Sunday and has no 0, so
**1–7 name the same day under both**. The description states that agreement and
stops there — it does not claim the field *is* cron-numbered — and `pools.ts`
imports nothing from `tasks.ts`. The 0–7 range check is what keeps the statement
true, and it nulls the whole list rather than returning a shorter one, because
a `weekday` one day short says the window does not apply on that day, which is
a claim the read did not establish (#93). `[]` stays `[]`.

**`enabled: false` means the priority window is not in force, not that
resilvering is disabled.** A system reporting it still rebuilds redundancy
after a disk is replaced, at ordinary priority. That is `storage_scrub_history`'s
finding — a name promising more than the data holds — arriving through a field
name this repository did not choose, so the correction is in the description and
is stated before anything else about the flag. It is pinned by a test, because
it lives in prose and nothing else asserts it (#128).

`begin` and `end` are passed through exactly as spelled and never parsed,
compared or converted, so a window whose `end` precedes its `begin` reads as
the wrap across midnight it is rather than as an empty or negative one. There is
no arithmetic here that could make it read otherwise, and a test pins it.

## Acceptance criteria

- [x] Catalog exposes `pool_resilver_config`, `mutating: false`, `Role.ReadOnly`
- [x] Per field, an unreported value is distinguishable from a configured-off one
- [x] Description states `enabled: false` means the window is not in force
- [x] Weekday numbering matches `tasks.ts`'s convention — see above for how, and
      why it is stated rather than imported
- [x] A window that wraps midnight is reported correctly
- [x] Times stated as system-local, `system_general_config` named — **with one
      correction, below**
- [x] `createDefaultCatalog` exact-list test updated in registration order, with
      its count wording (sixty-one → sixty-two)
- [x] `README.md` listing names the new tool
- [x] `yarn test:coverage` meets the floors — `pools.ts` at 100%

## Verification

`yarn typecheck`, `yarn lint`, `yarn test`, `yarn test:coverage` and
`yarn build` all run clean locally — the same five CI gates. 1427 tests pass;
`pools.ts` is at 100% statements and branches. Nothing here needs a service,
a device or a secret, so every gate was runnable on this machine.

## Local review

Two rounds of the project's own reviewer, in a separate process (same rubric,
threshold and parser as the required check).

**Round 1 — one HIGH, fixed.** `poolResilverConfig` was registered in
`createDefaultCatalog` and re-exported from `src/tools/index.ts` but **not from
`src/index.ts`**, the public barrel where an export is a contract. Nothing
failed: the catalog carried the tool and every gate was green, so the only thing
that would have caught it is someone importing the tool by name from the
package. Fixed in the second commit.

**Round 2 — clean.** Nothing at MEDIUM or above; four LOWs, listed below.

## What I did not change, and why

The four LOWs from the clean round. Each is left deliberately — a fix is a new
diff and a new diff is unreviewed, and none of these makes the diff wrong.

- **The file-level doc comment on `pools.ts` describes only the vdev topology
  and the scrub outcome**, and does not mention the resilver config tool now in
  the file. Fair; the tool has its own doc block immediately above it, and
  rewriting the file header is a wider edit than this ticket owns.
- **The description says `automated_tasks_list` reports the cron day-of-week as
  `dow`.** Checked against that tool's own description rather than recalled
  (#140): it does name `dow`, nested under `schedule`, and applies the numbering
  in `schedule_description`. The claim is accurate but underspecified about
  where the field sits.
- **The description test pins three substrings and not the numbering-agreement
  sentence**, which is the decision this ticket turns on. A reasonable thing to
  add; the sentence is recorded in `CLAUDE.md` either way.
- **That test is `async` with nothing to await.** Harmless, and true of the
  assertions rather than of the tool.

Separately, the round-1 HIGH named a real gap wider than this ticket: **nothing
tests `src/index.ts`'s export list**, so any of the sixty-two tools can be
registered, built and shipped while being unimportable by name. That is a
catalog-wide test rather than this tool's, and it is proposed as its own ticket
on #141 rather than folded in here.

## One correction to the ticket

The ticket asks the description to state that `begin` and `end` are
system-local. **It says so with `(unconfirmed)` on it**, in `ups_config`'s form,
because the surface states the zone for these no more than for any other
schedule the catalog reports — a ticket asking for a sentence does not supply
the evidence for it (#102, #120). What the tool asserts outright is the
negative, which is the part the criterion is actually protecting: the strings
carry no zone, the instant either names is not established by this read, and
neither is to be read as UTC. `system_general_config` is named as where to
confirm the zone before converting or comparing either value. The review scored
the unhedged version a LOW in round 1 and the hedge is what answers it.

## `CLAUDE.md`

One `## Decisions` entry, for the two things a later cycle would otherwise
re-derive: that matching a numbering means stating it rather than importing the
family that renders it, and that "system-local" is itself an unconfirmed
reading a ticket cannot confirm on the API's behalf.
