### PR TITLE
test(index): pin the public barrel's tool exports against the catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,9 @@ Two things that rule does not decide on its own:
 - **The catalog-wide test is not any tool's.** The exact-list assertion over
   `createDefaultCatalog()` is about `src/tools/index.ts`, so it lives in
   `index.spec.ts` under the same rule as everything else. Registering a tool
-  means editing that file and the module's own spec, and nothing else.
+  means editing `src/tools/index.ts` and that spec, the module's own source and
+  its spec, and `src/index.ts` — which this bullet used to leave out, and a tool
+  duly shipped registered and unexported. See #151 for what pins it now.
 
 **`src/testing/` is test support, and is neither the library nor code under
 test.** `fakeSystem` and `failingSystem` were declared once at the top of the
@@ -1631,6 +1633,58 @@ the description because the name is the middleware's to spell. That is
 `storage_scrub_history`'s finding arriving through a field this repository did
 not name, and it is why the description says what the flag does NOT mean before
 it says anything else about it.
+
+### The public barrel is pinned by identity, and its spec sits beside it (#151)
+
+`src/index.ts` names every tool by hand and an export there is a contract, and
+until #151 **nothing asserted that it did**. #141 registered a tool, re-exported
+it from `src/tools/index.ts`, and left it out of the public barrel: typecheck,
+lint, 1427 tests, the coverage floors and the build were all green, because the
+exact-list assertion in `src/tools/index.spec.ts` reads
+`createDefaultCatalog().list()` and that says nothing about what the package
+exports. The failure is invisible from inside the repository and lands on a
+consumer.
+
+**The spec is `src/index.spec.ts`, beside the module, not a third block in
+`src/tools/index.spec.ts`.** That is #87's own rule — a spec sits beside the
+module it covers and is named for it — reaching the one module the rule had not
+been applied to. `src/index.ts` being excluded from coverage is not a reason to
+put its spec elsewhere: the exclusion is about a re-export barrel having no
+lines worth counting, and the contract it carries is still a thing to pin.
+
+**Every assertion is by IDENTITY, and that is what makes it worth having.**
+`list()` advertises schema and metadata only, so it cannot answer an identity
+question; `get()` returns the registered `Tool` itself. A name-string comparison
+would pass on a barrel re-exporting a different tool under the right name, which
+is the next shape of the same failure and the one a bulk refactor produces.
+
+**Three assertions, because the catalog cannot answer the third.** Every
+registered tool is exported (missing tools reported by catalog name); no
+tool-shaped export is unregistered; and each tool export NAME is bound to the
+same object `src/tools/index.ts` binds it to. The catalog holds no record of
+which export name a tool belongs under — `poolStatus` is `storage_pool_status`
+and nothing derives one from the other — so a pairwise SWAP of two export names
+satisfies both directions of the catalog comparison. `src/tools/index.ts` is
+where that mapping lives and is the module the barrel re-exports from, so
+pinning the two by name and identity is what closes it.
+
+**A tool export is told apart from the rest by `mutating`.** A tool is the only
+non-null OBJECT in the barrel carrying a string `name`, a string `description`,
+an object `inputSchema` and a boolean `mutating`; `Role`, `RESERVED_ARGS`,
+`fullAccessRoleMapper`, `noopAuditSink` and `consoleAuditSink` are the other
+object-valued exports and none declares it, and everything else is a function or
+a class, which `typeof value === 'object'` excludes — a class would otherwise
+slip past a `name` test, since every class has one. **The predicate must read
+both arms of `Tool`**: one that tested for `handler` would silently stop checking
+the mutating tools rather than fail. A predicate matching something that is not
+a tool fails loudly instead — it lands in the unregistered list by name.
+
+**The non-tool half is pinned by hand, because nothing else can pin it.** The
+tool half has the catalog as its source of truth; the rest of the barrel has
+none, so the export names are listed in the spec and compared sorted. Sorted
+rather than in the file's own order: the key order of a module namespace object
+is a property of the module system, not of `src/index.ts`, and pinning it would
+assert something this repository does not decide.
 
 ## Conventions
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import * as publicBarrel from '@/index';
+import type { Tool } from '@/catalog/tool';
+import { Role } from '@/interfaces';
+import * as toolsBarrel from '@/tools/index';
+
+/**
+ * `src/index.ts` names every tool by hand, and an export there is a contract.
+ * Nothing else asserts that the list is the catalog's: the exact-list assertion
+ * in `src/tools/index.spec.ts` reads `createDefaultCatalog().list()`, which says
+ * nothing about what the package exports, so a tool registered and left out of
+ * the barrel passes typecheck, lint, the whole suite, coverage and build — and
+ * fails only for a consumer, which is where #141 found it.
+ *
+ * How a tool export is told apart from the rest of the barrel: a tool is the
+ * only non-null OBJECT here carrying a string `name`, a string `description`, an
+ * object `inputSchema` and a boolean `mutating`. That last one is what the
+ * non-tool objects lack — `Role`, `RESERVED_ARGS`, `fullAccessRoleMapper`,
+ * `noopAuditSink` and `consoleAuditSink` are the barrel's other object-valued
+ * exports, and none of them declares it. Everything else the barrel exports is a
+ * function or a class, which `typeof value === 'object'` already excludes; a
+ * class would otherwise slip past a `name` test, since every class has one.
+ *
+ * The predicate reads BOTH arms of `Tool` — it tests nothing a `ReadOnlyTool`
+ * has that a `MutatingTool` does not — because a predicate that missed the
+ * mutating arm would silently stop checking the mutating tools rather than fail.
+ * A predicate that matched something that is not a tool fails loudly instead:
+ * the second assertion below reports it by name as an unregistered tool.
+ */
+const isTool = (value: unknown): value is Tool => {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<Tool>;
+  return (
+    typeof candidate.name === 'string' &&
+    typeof candidate.description === 'string' &&
+    typeof candidate.inputSchema === 'object' &&
+    candidate.inputSchema !== null &&
+    typeof candidate.mutating === 'boolean'
+  );
+};
+
+const toolExports = (module: object): [string, Tool][] =>
+  Object.entries(module).filter((entry): entry is [string, Tool] => isTool(entry[1]));
+
+/**
+ * The tools the catalog actually registered, as the objects it holds. `list()`
+ * advertises schema and metadata only, so it cannot answer an identity
+ * question; `get()` returns the registered `Tool` itself, which is what every
+ * assertion below compares against. Comparing names would pass on a barrel that
+ * exported a different tool under the right name.
+ */
+const registeredTools = (): Tool[] => {
+  const catalog = toolsBarrel.createDefaultCatalog();
+  return catalog.list(Role.Full).map((advertised) => catalog.get(advertised.name));
+};
+
+describe('the public barrel', () => {
+  it('exports every tool createDefaultCatalog registers', () => {
+    const exported = new Set<unknown>(Object.values(publicBarrel));
+    const missing = registeredTools()
+      .filter((tool) => !exported.has(tool))
+      .map((tool) => tool.name);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('exports no tool createDefaultCatalog does not register', () => {
+    const registered = new Set<unknown>(registeredTools());
+    const unregistered = toolExports(publicBarrel)
+      .filter(([, tool]) => !registered.has(tool))
+      .map(([exportName, tool]) => `${exportName} (${tool.name})`);
+
+    expect(unregistered).toEqual([]);
+  });
+
+  /**
+   * The two assertions above are identity checks against a catalog that holds no
+   * record of which export NAME a tool belongs under — so a single wrong
+   * re-export fails the first of them (the right tool is then exported nowhere)
+   * and a pairwise SWAP of two export names fails neither. `src/tools/index.ts`
+   * is where that mapping lives, and it is the module `src/index.ts` re-exports
+   * from, so pinning the two together by name AND identity is what closes it.
+   */
+  it('binds each tool export name to the same tool src/tools/index.ts does', () => {
+    const publicExports = new Map<string, unknown>(Object.entries(publicBarrel));
+    const diverged = toolExports(toolsBarrel)
+      .filter(([exportName, tool]) => publicExports.get(exportName) !== tool)
+      .map(([exportName, tool]) => `${exportName} (${tool.name})`);
+
+    expect(diverged).toEqual([]);
+  });
+
+  /**
+   * The tool half of the barrel is pinned by the catalog above; the non-tool
+   * half has no such source of truth, so it is pinned by hand. Sorted rather
+   * than in the file's own order: the key order of a module namespace object is
+   * a property of the module system rather than of `src/index.ts`, and pinning
+   * it would assert something this repository does not decide.
+   */
+  it('still exports the non-tool half of its contract', () => {
+    const nonTools = Object.entries(publicBarrel)
+      .filter(([, value]) => !isTool(value))
+      .map(([exportName]) => exportName);
+
+    expect(nonTools.sort()).toEqual(
+      [
+        'ConfirmationError',
+        'ConfirmationService',
+        'FileContentError',
+        'RESERVED_ARGS',
+        'Role',
+        'SystemRegistry',
+        'ToolCatalog',
+        'ToolExecutor',
+        'assertValidSystemName',
+        'connectSystems',
+        'consoleAuditSink',
+        'createDefaultCatalog',
+        'createDownloadContentReader',
+        'defaultClientFactory',
+        'fanOut',
+        'fullAccessRoleMapper',
+        'noopAuditSink',
+        'planKey',
+        'roleSatisfies',
+        'stableStringify',
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #151

## What this pins

`src/index.ts` names every tool by hand, an export there is a contract, and
nothing asserted that it did. #141 registered a tool, re-exported it from
`src/tools/index.ts`, and left it out of the public barrel — typecheck, lint,
1427 tests, the coverage floors and the build were all green, because the
exact-list assertion in `src/tools/index.spec.ts` reads
`createDefaultCatalog().list()`, which says nothing about what the package
exports. Only a consumer would have found it.

`src/index.spec.ts` (new, 4 tests, no production change) compares the two.

**Where it lives.** Beside the module and named for it — `src/index.spec.ts`,
not a third block in `src/tools/index.spec.ts`. That is #87's own rule reaching
the one module it had not been applied to; `src/tools/index.spec.ts` is about
`src/tools/index.ts`, and this is about a different module. `src/index.ts` being
excluded from coverage was the argument for putting the spec elsewhere and it
does not survive: the exclusion is about a re-export barrel having no lines
worth counting, and the contract it carries is still a thing to pin. Coverage
is unchanged by it either way — every module the barrel pulls in is already
imported by another spec.

**Every assertion is by identity.** `list()` advertises schema and metadata
only and cannot answer an identity question; `get()` returns the registered
`Tool` itself, which is what the assertions compare against. A name-string
comparison would pass on a barrel re-exporting a different tool under the right
name — demonstrated below.

**How the tool exports are told apart from the rest.** A tool is the only
non-null *object* in the barrel carrying a string `name`, a string
`description`, an object `inputSchema` and a boolean `mutating`. That last one
is what the non-tool objects lack: `Role`, `RESERVED_ARGS`,
`fullAccessRoleMapper`, `noopAuditSink` and `consoleAuditSink` are the barrel's
other object-valued exports and none declares it. Everything else is a function
or a class, which `typeof value === 'object'` excludes — a class would otherwise
slip past a `name` test, since every class has one. The predicate reads *both*
arms of `Tool`: one testing for `handler` would silently stop checking the six
mutating tools rather than fail. A predicate matching something that is not a
tool fails loudly instead, since it lands in the unregistered list by name.

## The four tests

| test | catches |
|---|---|
| exports every tool `createDefaultCatalog` registers | a registered tool missing from the barrel, named by its catalog name |
| exports no tool `createDefaultCatalog` does not register | an exported tool the catalog never registered, named by export name and catalog name |
| binds each tool export name to the same tool `src/tools/index.ts` does | a tool exported under the wrong name |
| still exports the non-tool half of its contract | a non-tool export dropped from the barrel |

**Why the third exists, since the ticket asked for two.** The catalog holds no
record of which export *name* a tool belongs under — `poolStatus` is
`storage_pool_status`, and nothing derives one from the other — so a pairwise
*swap* of two export names satisfies both directions of the catalog comparison.
A single wrong re-export does fail the first test, because the right tool is
then exported nowhere; a swap fails neither. `src/tools/index.ts` is where that
mapping lives and is the module the barrel re-exports from, so pinning the two
by name *and* identity is what delivers the acceptance criterion's "a barrel
re-exporting a different tool under the right name still fails" in full.

**Why the fourth exists.** The tool half has the catalog as its source of truth;
the non-tool half has none, so its export names are listed in the spec. Compared
sorted, deliberately: the key order of a module namespace object is a property
of the module system rather than of `src/index.ts`, and pinning it would assert
something this repository does not decide.

## Demonstrated, not asserted

Three temporary edits, each reverted; the diff contains none of them.

**1. Deleting `poolResilverConfig,` from `src/index.ts`'s tool export block**
(the acceptance criterion) — two tests go red and both name the tool:

```
 ❯ src/index.spec.ts (4 tests | 2 failed)
   × the public barrel > exports every tool createDefaultCatalog registers
     → expected [ 'pool_resilver_config' ] to deeply equal []
   ✓ the public barrel > exports no tool createDefaultCatalog does not register
   × the public barrel > binds each tool export name to the same tool src/tools/index.ts does
     → expected [ 'poolResilverConfig (pool_resilver_config)' ] to deeply equal []
   ✓ the public barrel > still exports the non-tool half of its contract
```

**2. Replacing it with `poolTopology as poolResilverConfig`** — the right name
bound to the wrong tool, which a name-string comparison would have passed. Same
two tests red, same messages: identity is doing the work.

**3. Removing `catalog.register(poolResilverConfig);` from
`createDefaultCatalog`** — the other direction:

```
   × the public barrel > exports no tool createDefaultCatalog does not register
     → expected [ 'poolResilverConfig (pool_resilver_config)' ] to deeply equal []
```

## `app/CLAUDE.md`

Two changes. A `## Decisions` entry for #151 recording where the spec lives,
why every assertion is by identity, why there are three rather than two, and how
a tool export is told apart.

And a correction: #87's bullet said *"Registering a tool means editing that file
and the module's own spec, and nothing else."* `src/index.ts` was not in that
list, which is the sentence #141 followed. It now names the barrel.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` (39 files, 1431 tests — the
4 new ones; floors held with no threshold error) and `yarn build` all pass
locally. `git -C app status --short` is clean apart from the spec, so nothing
was written into the tree.

The local review round ran the project's own reviewer in a separate process and
returned **nothing at MEDIUM or above**, so the work stopped there.

## What I did not change, and why

The review's two LOW findings, both left for a reader rather than fixed — a fix
is a new diff, and a new diff is unreviewed:

- **`src/index.spec.ts:100` — the non-tool pin covers runtime value exports
  only.** `src/index.ts` also has roughly twenty-five `export type`
  declarations, and those are erased before a module namespace object exists, so
  no runtime assertion can see them. The test's name reads broader than what it
  checks. Pinning the type surface is a different mechanism (an API-extractor
  report, or a type-level compile assertion) and a different ticket; worth
  filing if the type exports are considered part of the same contract.
- **`src/index.spec.ts:54` — `registeredTools()` reads `list(Role.Full)`.** The
  pin's completeness rests on `Role.Full` being the top rank; a role ranked above
  it would silently narrow the check to fewer tools. `src/tools/index.spec.ts`'s
  exact-list assertion rests on exactly the same assumption, so this is not new
  here — but neither file states it.
