### PR TITLE
feat(snapshots): report hold state and scheduled removal in snapshots_list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1686,6 +1686,56 @@ rather than in the file's own order: the key order of a module namespace object
 is a property of the module system, not of `src/index.ts`, and pinning it would
 assert something this repository does not decide.
 
+### A field whose read costs more than the tool's own bound is opt-in (#155)
+
+`snapshots_list` reports `held` and `scheduled_removal` only where the caller
+passed `report_held` or `report_scheduled_removal`, and both default false.
+That is not caution about a wider response — it is where the cost lands.
+`holds` and `retention` on `pool.snapshot.query`'s `extra` set
+`get_holds`/`get_user_properties` on the underlying ZFS query and add
+zettarepl's annotation pass, and both apply to the WHOLE query before the
+middleware's own `limit` reaches anything: a listing bounded to 100 snapshots
+pays them over every snapshot the system holds. **Ask where a read's cost is
+applied relative to the bound the tool advertises** — `select` (#115) narrows
+what comes back and is bandwidth, and this is the other direction.
+
+**The argument-was-not-passed cause of a null is NOT split off by a companion
+field, and that is #134's bar being applied rather than skipped.** Null on
+either field covers the argument not having been passed as well as a payload
+that would not read — and on `scheduled_removal` a third, ordinary cause, no
+enabled task owning the snapshot at all. That first cause is the two-cause null
+`temperature_reported` exists to split in #120, and a companion for it earns
+nothing here: the caller set the flag itself, so it already knows whether the
+field was asked for, and a companion field earns its place only where the causes
+are ones the caller cannot tell apart and would act on differently. What it
+cannot tell apart — an unreadable retention from no removal scheduled — no flag
+of the caller's own settles, so the description says outright that the tool does
+not separate them. **A rule that adds a
+field is still a rule about the CALLER's answer**, and an argument the caller
+passed is part of what the caller knows.
+
+**Inside a record, the direction rule (#93) points the other way from the field
+that holds it.** `held: false` and `scheduled_removal: null` are both claims
+that nothing is protecting or scheduling this snapshot, and a caller acting on
+either prunes — so an unreadable holds payload is null and never false, while a
+retention record whose `datetime` will not read KEEPS the object, with `at`
+null, because nulling it would say no removal is scheduled when one is. The
+same reading, applied one level in, produces opposite-looking answers.
+
+**`held` is TrueNAS's own hold tag and the description says so before it says
+anything else.** `_transform_snapshot_entry` reports `{ truenas: 1 }` where that
+one tag is present and `{}` otherwise, normalising the count — so a ZFS hold
+under any other tag is invisible to this field, and the name promises a great
+deal more than the payload delivers. That is `pool_resilver_config`'s `enabled`
+(#141) in a field this repository DID name: the correction still lives in the
+description, because the honest name would be `truenas_hold_tag_present`.
+
+**`scheduled_removal` does not account for holds**, and the two fields are
+independent — `annotate_snapshots` never reads holds, so a held snapshot can
+report a removal date it will survive. Stated in the description as the reading
+a caller is most likely to get wrong, since side-by-side fields are what an
+implied relationship looks like from the outside (#138).
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/src/tools/snapshots.spec.ts
+++ b/src/tools/snapshots.spec.ts
@@ -51,6 +51,10 @@ describe('snapshots_list', () => {
           dataset: 'tank/media',
           created: '2025-08-28T02:00:00.000Z',
           referenced_bytes: 98304,
+          // Neither argument was passed, so neither field was asked of the
+          // system and neither is reported.
+          held: null,
+          scheduled_removal: null,
         },
       ],
       truncated: false,
@@ -59,13 +63,25 @@ describe('snapshots_list', () => {
   });
 
   it('surfaces no field a later release adds', async () => {
-    const result = await listing([snapshot({ future_field: 'added by a later TrueNAS release' })]);
+    const result = await listing([
+      snapshot({
+        future_field: 'added by a later TrueNAS release',
+        // Sent by the system though nothing asked for them: a field is
+        // reported because this tool names it, not because a row carried it.
+        holds: { truenas: 1 },
+        retention: { datetime: { $date: 1756346400000 }, source: 'property' },
+      }),
+    ]);
     expect(Object.keys(result.snapshots[0])).toEqual([
       'name',
       'dataset',
       'created',
       'referenced_bytes',
+      'held',
+      'scheduled_removal',
     ]);
+    expect(result.snapshots[0]['held']).toBeNull();
+    expect(result.snapshots[0]['scheduled_removal']).toBeNull();
   });
 
   it('asks for one more row than the bound, and for only the two properties it reports', async () => {
@@ -251,6 +267,239 @@ describe('snapshots_list', () => {
       dataset: 'tank/media',
       created: null,
       referenced_bytes: null,
+      held: null,
+      scheduled_removal: null,
+    });
+  });
+
+  describe('hold state and scheduled removal', () => {
+    /** The two fields of one entry, for the assertions below. */
+    const fields = async (
+      row: Record<string, unknown>,
+      args: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      const result = await listing([snapshot(row)], args);
+      return result.snapshots[0];
+    };
+
+    it('asks the system for neither field unless the caller did', async () => {
+      const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [snapshot()] });
+      await snapshotsList.handler(ctx, { report_held: false, report_scheduled_removal: false });
+      // No `holds` and no `retention`: both widen the read over every snapshot
+      // on the system, before this tool's `limit` bounds anything.
+      expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], {
+        limit: 101,
+        extra: { properties: ['creation', 'referenced'] },
+      });
+    });
+
+    it('asks for each flag only where its own argument was passed', async () => {
+      // The option names are the middleware's own and the client types `extra`
+      // as an open record, so nothing about them is compiler-checked: a
+      // misspelling would be dropped rather than refused, and the field would
+      // read null on every entry. This pins the spelling; the tests below pin
+      // that what comes back is actually read.
+      const asked = async (args: Record<string, unknown>, extra: Record<string, unknown>) => {
+        const { ctx, query } = fakeSystem({ ['pool.snapshot.query']: [] });
+        await snapshotsList.handler(ctx, args);
+        expect(query).toHaveBeenCalledWith('pool.snapshot.query', [], { limit: 101, extra });
+      };
+      await asked(
+        { report_held: true },
+        { properties: ['creation', 'referenced'], holds: true },
+      );
+      await asked(
+        { report_scheduled_removal: true },
+        { properties: ['creation', 'referenced'], retention: true },
+      );
+      await asked({ report_held: true, report_scheduled_removal: true }, {
+        properties: ['creation', 'referenced'],
+        holds: true,
+        retention: true,
+      });
+    });
+
+    it('rejects an argument that is not a boolean rather than reading it as false', async () => {
+      // Coerced, the flag would be false, the middleware would never be asked,
+      // and every entry would report null — which is what a system that does
+      // not report the field answers with, so a caller could not tell.
+      for (const bad of ['true', 1, 0, 'yes', {}]) {
+        await expect(listing([snapshot()], { report_held: bad })).rejects.toThrow(
+          /"report_held" must be a boolean/,
+        );
+        await expect(listing([snapshot()], { report_scheduled_removal: bad })).rejects.toThrow(
+          /"report_scheduled_removal" must be a boolean/,
+        );
+      }
+    });
+
+    it('reports the truenas hold tag as held, and its absence as not held', async () => {
+      // `false` and null are different answers: the first is a hold state that
+      // was read, the second is one that was not.
+      expect(await fields({ holds: { truenas: 1 } }, { report_held: true })).toMatchObject({
+        held: true,
+      });
+      expect(await fields({ holds: {} }, { report_held: true })).toMatchObject({ held: false });
+      // The refcount the middleware normalises to 1, and the count of none.
+      expect(await fields({ holds: { truenas: 3 } }, { report_held: true })).toMatchObject({
+        held: true,
+      });
+      expect(await fields({ holds: { truenas: 0 } }, { report_held: true })).toMatchObject({
+        held: false,
+      });
+      // A tag that is not TrueNAS's own is not this field's subject at all.
+      expect(await fields({ holds: { keep: 1 } }, { report_held: true })).toMatchObject({
+        held: false,
+      });
+    });
+
+    it('reports a hold state it cannot read as null rather than as not held', async () => {
+      // Null and never false: `false` says nothing is protecting the snapshot,
+      // and a caller acting on that prunes it.
+      for (const holds of [undefined, null, 'held', 7, [], { truenas: 'yes' }, { truenas: null }]) {
+        expect(await fields({ holds }, { report_held: true })).toMatchObject({ held: null });
+      }
+    });
+
+    it('reports the removal the system annotated, with the owning task', async () => {
+      expect(
+        await fields(
+          {
+            retention: {
+              datetime: { $date: 1756346400000 },
+              source: 'periodic_snapshot_task',
+              periodic_snapshot_task_id: 4,
+            },
+          },
+          { report_scheduled_removal: true },
+        ),
+      ).toMatchObject({
+        scheduled_removal: {
+          at: '2025-08-28T02:00:00.000Z',
+          source: 'periodic_snapshot_task',
+          periodic_snapshot_task_id: 4,
+        },
+      });
+    });
+
+    it('reports no task id where the removal comes from the property', async () => {
+      expect(
+        await fields(
+          { retention: { datetime: { $date: 1756346400000 }, source: 'property' } },
+          { report_scheduled_removal: true },
+        ),
+      ).toMatchObject({
+        scheduled_removal: {
+          at: '2025-08-28T02:00:00.000Z',
+          source: 'property',
+          periodic_snapshot_task_id: null,
+        },
+      });
+    });
+
+    it('reads the removal time as an envelope, a bare number or a zoned ISO string', async () => {
+      const at = async (datetime: unknown): Promise<unknown> => {
+        const row = await fields({ retention: { datetime, source: 'property' } }, {
+          report_scheduled_removal: true,
+        });
+        return (row['scheduled_removal'] as Record<string, unknown>)['at'];
+      };
+      expect(await at({ $date: 1756346400000 })).toBe('2025-08-28T02:00:00.000Z');
+      expect(await at(1756346400000)).toBe('2025-08-28T02:00:00.000Z');
+      // The shape the client declares: a string. Only with a zone in it.
+      expect(await at('2025-08-28T02:00:00Z')).toBe('2025-08-28T02:00:00.000Z');
+      expect(await at('2025-08-28T04:00:00+02:00')).toBe('2025-08-28T02:00:00.000Z');
+      expect(await at('2025-08-28T02:00:00.500Z')).toBe('2025-08-28T02:00:00.500Z');
+      // No zone: reading it as UTC would be a guess off by hours.
+      expect(await at('2025-08-28T02:00:00')).toBeNull();
+      expect(await at('Thu Aug 28 02:00 2025')).toBeNull();
+      expect(await at('2025-13-28T02:00:00Z')).toBeNull();
+      expect(await at(undefined)).toBeNull();
+      expect(await at(null)).toBeNull();
+      expect(await at({ $date: 'soon' })).toBeNull();
+      // Beyond what a Date can hold: one absurd row must not take the listing
+      // down through `toISOString`.
+      expect(await at({ $date: 1e16 })).toBeNull();
+      expect(await at(Number.POSITIVE_INFINITY)).toBeNull();
+    });
+
+    it('keeps a removal whose time could not be read, rather than nulling it', async () => {
+      // The opposite direction to a null: this snapshot IS scheduled for
+      // removal and the time is what was unreadable.
+      expect(
+        await fields(
+          { retention: { datetime: 'whenever', source: 'periodic_snapshot_task' } },
+          { report_scheduled_removal: true },
+        ),
+      ).toMatchObject({
+        scheduled_removal: {
+          at: null,
+          source: 'periodic_snapshot_task',
+          periodic_snapshot_task_id: null,
+        },
+      });
+    });
+
+    it('passes an unfamiliar source through as the system spelled it', async () => {
+      expect(
+        await fields(
+          { retention: { datetime: { $date: 1756346400000 }, source: 'something_later' } },
+          { report_scheduled_removal: true },
+        ),
+      ).toMatchObject({
+        scheduled_removal: { source: 'something_later', periodic_snapshot_task_id: null },
+      });
+      expect(
+        await fields(
+          { retention: { datetime: { $date: 1756346400000 }, source: 42 } },
+          { report_scheduled_removal: true },
+        ),
+      ).toMatchObject({ scheduled_removal: { source: null } });
+    });
+
+    it('reports no scheduled removal where the system annotated none', async () => {
+      // The ordinary answer for a snapshot taken by hand — it parses against
+      // no task's naming schema — and the same answer an unreadable payload
+      // gives, which is why the description says a null establishes nothing.
+      for (const retention of [null, undefined, 'none', [], 5]) {
+        expect(await fields({ retention }, { report_scheduled_removal: true })).toMatchObject({
+          scheduled_removal: null,
+        });
+      }
+    });
+
+    it('reports each field only where its own argument was passed', async () => {
+      const row = {
+        holds: { truenas: 1 },
+        retention: { datetime: { $date: 1756346400000 }, source: 'property' },
+      };
+      expect(await fields(row, { report_held: true })).toMatchObject({
+        held: true,
+        scheduled_removal: null,
+      });
+      expect(await fields(row, { report_scheduled_removal: true })).toMatchObject({
+        held: null,
+        scheduled_removal: { at: '2025-08-28T02:00:00.000Z' },
+      });
+    });
+
+    it('surfaces no field of a retention record the tool does not name', async () => {
+      const row = await fields(
+        {
+          retention: {
+            datetime: { $date: 1756346400000 },
+            source: 'periodic_snapshot_task',
+            periodic_snapshot_task_id: 4,
+            future_field: 'added by a later TrueNAS release',
+          },
+        },
+        { report_scheduled_removal: true },
+      );
+      expect(Object.keys(row['scheduled_removal'] as Record<string, unknown>)).toEqual([
+        'at',
+        'source',
+        'periodic_snapshot_task_id',
+      ]);
     });
   });
 });

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -2,7 +2,14 @@ import type { CallParams } from '@truenas/api-client';
 import { firstValueFrom } from 'rxjs';
 import { Role } from '@/interfaces';
 import { ApiSurface, MutatingTool, ReadOnlyTool, ToolContext } from '@/catalog/tool';
-import { MAX_TIME_MS, effectiveLimit } from '@/tools/common';
+import {
+  MAX_TIME_MS,
+  MiddlewareDate,
+  effectiveLimit,
+  numberOrNull,
+  recordOrNull,
+  textOrNull,
+} from '@/tools/common';
 
 /** Snapshots family: the snapshots that exist, and taking a new one. */
 
@@ -222,6 +229,120 @@ function snapshotProperty(properties: unknown, name: string): unknown {
 }
 
 /**
+ * Whether TrueNAS's own hold tag is on the snapshot, or null where the system
+ * reported no hold state this tool can read.
+ *
+ * The middleware answers `holds` as `{ truenas: 1 }` where that tag is present
+ * and `{}` where it is not: a hold placed under any other tag never reaches
+ * this field, and the count is normalised to 1 whatever the real refcount is.
+ * So `false` is "no `truenas` tag" and NOT "no ZFS hold", which is a weaker
+ * claim than the field name makes on its own and is why the description says it
+ * before it says anything else about the field.
+ *
+ * A payload that is not a record — including the field being absent, which is
+ * what a system that ignored the `holds` request answers with — is null and
+ * never false. That is #93's direction rule: `false` says nothing is protecting
+ * this snapshot, and a caller acting on that prunes it.
+ */
+function heldOf(value: unknown): boolean | null {
+  const holds = recordOrNull(value);
+  if (holds === null) return null;
+  // `Object.hasOwn` and not `in`, which walks the prototype.
+  if (!Object.hasOwn(holds, 'truenas')) return false;
+  const count = numberOrNull(holds['truenas']);
+  return count === null ? null : count > 0;
+}
+
+/**
+ * An ISO 8601 instant carrying an explicit zone. A string with no zone in it is
+ * deliberately not matched: reading one as UTC would be a guess that is
+ * confidently off by hours, which is the reading `tasks.ts` refuses for the
+ * same reason.
+ */
+const ZONED_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * When the middleware says the snapshot is due to be removed, in milliseconds
+ * since the epoch, or null where it reported no time this tool can read.
+ *
+ * Two shapes, because the surface and the wire disagree about this one and
+ * neither could be checked against a live middleware: the client declares
+ * `datetime` a `string`, while a middleware time reaches this repository as the
+ * `{ "$date": … }` envelope every other date-reading tool here unwraps. A
+ * reading both shapes satisfy is worth more than one written to whichever
+ * arrives (#102), and a bare number is accepted beside the envelope for
+ * `tasks.ts`'s reason — the envelope exists only to tag a number as a date in
+ * transit, and both are epoch milliseconds.
+ *
+ * Bounded by {@link MAX_TIME_MS} like every other instant this file reports:
+ * one absurd removal date must not take the listing down through
+ * `toISOString`.
+ */
+function removalMillis(value: unknown): number | null {
+  const raw = typeof value === 'object' && value !== null ? (value as MiddlewareDate).$date : value;
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) && Math.abs(raw) <= MAX_TIME_MS ? raw : null;
+  }
+  if (typeof raw !== 'string' || !ZONED_INSTANT.test(raw)) return null;
+  const millis = Date.parse(raw);
+  return Number.isFinite(millis) && Math.abs(millis) <= MAX_TIME_MS ? millis : null;
+}
+
+/** What the system says is scheduled to remove a snapshot. */
+interface ScheduledRemoval {
+  at: string | null;
+  source: string | null;
+  periodic_snapshot_task_id: number | null;
+}
+
+/**
+ * The removal the middleware annotated the snapshot with, or null where it
+ * annotated none.
+ *
+ * `retention` is `null` on a snapshot no ENABLED periodic snapshot task owns,
+ * which is the ordinary answer for one taken by hand, and absent where the
+ * system was not asked — so null here covers "nothing will remove it", "the
+ * payload could not be read" and "the argument was not passed", and the
+ * description says so rather than letting a null read as the first.
+ *
+ * A record whose `datetime` could not be read is NOT nulled: it still says a
+ * removal is scheduled and names its source, where a null would say the
+ * opposite. Same direction rule as {@link heldOf}, one level in.
+ *
+ * `source` is passed through as the system spelled it, so a source a later
+ * release adds reaches the caller rather than being flattened; the task id is
+ * read by name, and is null on the arm that has none — the snapshot's own
+ * removal-date property — exactly as it is on one that could not be read.
+ */
+function scheduledRemovalOf(value: unknown): ScheduledRemoval | null {
+  const retention = recordOrNull(value);
+  if (retention === null) return null;
+  const millis = removalMillis(retention['datetime']);
+  return {
+    at: millis === null ? null : new Date(millis).toISOString(),
+    // `textOrNull` rather than this file's `stringOrNull`: a source is a name,
+    // and an empty one has told the caller nothing.
+    source: textOrNull(retention['source']),
+    periodic_snapshot_task_id: numberOrNull(retention['periodic_snapshot_task_id']),
+  };
+}
+
+/**
+ * Whether the caller asked for one of the two opt-in fields.
+ *
+ * Strict, as `snapshots_create` is about `recursive` and `tasks_recent_runs`
+ * about `failed_only`. A coerced `"true"` would leave the flag false, the
+ * middleware never asked, and every entry reporting null — which is exactly
+ * what a system that does not report the field answers with, so the caller
+ * could not tell that its argument had been dropped.
+ */
+function requestedField(raw: unknown, name: string): boolean {
+  if (raw == null) return false;
+  if (typeof raw !== 'boolean') throw new Error(`"${name}" must be a boolean`);
+  return raw;
+}
+
+/**
  * The dataset to restrict the listing to, or null for every dataset.
  *
  * Strict where {@link effectiveLimit} is lenient. A `dataset` argument that is
@@ -275,9 +396,9 @@ export const snapshotsList: ReadOnlyTool = {
     '`dataset`, the dataset the snapshot was taken of, which matches `id` in ' +
     '`storage_list_datasets`; `created`, when it was taken, as an ISO 8601 ' +
     'UTC timestamp; and `referenced_bytes`, the data that snapshot ' +
-    'references. Each of the four is null where the system reported no value ' +
-    'this tool can read, and null is not zero: a snapshot referencing nothing ' +
-    'reports `referenced_bytes: 0`. A snapshot with no readable `created` is ' +
+    'references. Each of those four is null where the system reported no ' +
+    'value this tool can read, and null is not zero: a snapshot referencing ' +
+    'nothing reports `referenced_bytes: 0`. A snapshot with no readable `created` is ' +
     'ordered last rather than first. Pass `dataset` to list only that ' +
     "dataset's snapshots; a dataset that does not exist is an error naming " +
     'it, so an empty list always means that dataset has no snapshots rather ' +
@@ -291,7 +412,38 @@ export const snapshotsList: ReadOnlyTool = {
     'snapshots it names and about nothing else: it cannot show that a ' +
     'snapshot is absent. Narrow it with `dataset`, or raise `limit`, until ' +
     '`truncated` is false, and only then read the list as everything that ' +
-    'exists.',
+    'exists. Two further fields say whether a snapshot is protected and ' +
+    'whether anything is scheduled to remove it, and both are opt-in: `held` ' +
+    'is reported only when `report_held` is true, `scheduled_removal` only ' +
+    'when `report_scheduled_removal` is true, and each is null on every entry ' +
+    'when its own argument was not passed. `held` REPORTS TRUENAS\'S OWN HOLD ' +
+    'TAG AND NOT ANY ZFS HOLD: the system answers whether the `truenas` tag ' +
+    'is on the snapshot and nothing else, so a hold placed under a different ' +
+    'tag is invisible here and `held: false` means "no `truenas` tag" rather ' +
+    'than "nothing is holding this". `scheduled_removal` is the system\'s own ' +
+    'computation of when a snapshot is due to be removed rather than a ' +
+    're-derivation from task schedules, and it carries `at`, that time as an ' +
+    'ISO 8601 UTC timestamp; `source`, what schedules it, as the system ' +
+    'spelled it; and `periodic_snapshot_task_id`, the owning task where the ' +
+    'source is a periodic snapshot task and null where it is the snapshot\'s ' +
+    'own removal-date property. ONLY ENABLED periodic snapshot tasks are ' +
+    'considered — a snapshot owned solely by a disabled task reports null, ' +
+    'and enabling that task changes the answer — and where several tasks own ' +
+    'one snapshot the latest removal time is the one reported. IT DOES NOT ' +
+    'ACCOUNT FOR HOLDS: the two fields are independent, and a held snapshot ' +
+    'can report a removal time it will survive. `scheduled_removal: null` is ' +
+    'the ordinary answer for a snapshot taken by hand, which parses against ' +
+    "no task's naming schema and so is scheduled for removal by none, but it " +
+    'is also what a snapshot whose retention the system reported unreadably ' +
+    'answers with, and what every entry answers with when the argument was ' +
+    'not passed — so a null does not on its own establish that nothing will ' +
+    'remove the snapshot, and this tool does not separate those three. A ' +
+    '`scheduled_removal` whose `at` is null is the other way round: a removal ' +
+    'IS scheduled and its time could not be read. `held: null` reads the same ' +
+    'way — the argument was not passed, or the hold state could not be read, ' +
+    'and never "not held". Both arguments widen the read the system makes ' +
+    'over every snapshot it holds, before `limit` bounds anything, so ask for ' +
+    'them when they are wanted rather than by default.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -307,6 +459,25 @@ export const snapshotsList: ReadOnlyTool = {
         default: 100,
         description: 'Return at most this many snapshots. Default 100, maximum 1000.',
       },
+      report_held: {
+        type: 'boolean',
+        default: false,
+        description:
+          "Also report whether TrueNAS's own hold tag is on each snapshot. " +
+          'Default false, which reports `held: null` on every entry. Widens ' +
+          'the read the system makes over every snapshot it holds, before ' +
+          '`limit` bounds anything.',
+      },
+      report_scheduled_removal: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Also report when an enabled periodic snapshot task is due to ' +
+          'remove each snapshot. Default false, which reports ' +
+          '`scheduled_removal: null` on every entry. Widens the read the ' +
+          'system makes over every snapshot it holds, before `limit` bounds ' +
+          'anything.',
+      },
     },
   },
   requiredRole: Role.ReadOnly,
@@ -314,6 +485,13 @@ export const snapshotsList: ReadOnlyTool = {
   async handler(ctx, args) {
     const dataset = requestedDataset(args['dataset']);
     const limit = snapshotLimit(args['limit']);
+    // Read before the call, so an unreadable flag is an error rather than a
+    // question the system answers and this tool then discards.
+    const reportHeld = requestedField(args['report_held'], 'report_held');
+    const reportRemoval = requestedField(
+      args['report_scheduled_removal'],
+      'report_scheduled_removal',
+    );
     const snapshots = await firstValueFrom(
       // Filters and options are inlined so the call's own parameter types
       // apply, as in `storage.ts`.
@@ -339,7 +517,23 @@ export const snapshotsList: ReadOnlyTool = {
           limit: limit + 1,
           // Only the two properties this tool reports. A snapshot row
           // otherwise carries every ZFS property of the snapshot, on every row.
-          extra: { properties: ['creation', 'referenced'] },
+          //
+          // The two opt-in flags are passed only where the caller asked for
+          // the field they produce: each widens the read the middleware makes
+          // over every snapshot on the system — `holds` reads the ZFS holds,
+          // `retention` reads the user properties and runs zettarepl's
+          // annotation pass — and both are applied before this tool's `limit`
+          // reaches anything, so the cost is not bounded by it. Their names
+          // are the middleware's own and the client types `extra` as an open
+          // record, so nothing here is compiler-checked: a misspelling would
+          // be dropped rather than refused, and the field would read null on
+          // every entry. That is what the tests asserting them populated are
+          // for.
+          extra: {
+            properties: ['creation', 'referenced'],
+            ...(reportHeld ? { holds: true } : {}),
+            ...(reportRemoval ? { retention: true } : {}),
+          },
         },
       ),
     );
@@ -360,6 +554,11 @@ export const snapshotsList: ReadOnlyTool = {
           dataset: stringOrNull(snapshot['dataset']),
           created: created === null ? null : new Date(created).toISOString(),
           referenced_bytes: propertyBytes(snapshotProperty(properties, 'referenced')),
+          // Null where the caller did not ask, rather than absent: a key that
+          // is not there serializes to no key at all, and the description
+          // promises both fields on every entry.
+          held: reportHeld ? heldOf(snapshot['holds']) : null,
+          scheduled_removal: reportRemoval ? scheduledRemovalOf(snapshot['retention']) : null,
         },
       };
     });


### PR DESCRIPTION
Fixes #155

`snapshots_list` grows two reported fields, `held` and `scheduled_removal`, each behind an optional boolean argument that defaults false. Both come from one call — `pool.snapshot.query` — through `options.extra`.

## What it does

**`held` is TrueNAS's own hold tag and not any ZFS hold.** `_transform_snapshot_entry` reports `{ truenas: 1 }` where that one tag is present and `{}` where it is not, normalising the count, so a hold placed under any other tag is invisible to this field. `held: false` therefore means "no `truenas` tag", and the description says that before it says anything else about the field. An unreadable holds payload is `null` and never `false` — `false` is the claim that nothing is protecting the snapshot, and a caller acting on it prunes.

**`scheduled_removal` is the middleware's own answer**, carrying `at` (ISO 8601 UTC), `source` as the system spelled it, and `periodic_snapshot_task_id` where the source is a task. Enabled periodic snapshot tasks only; it does not account for holds, so a held snapshot can report a removal time it will survive — stated in the description as the reading a caller is most likely to get wrong. A retention record whose `datetime` will not read KEEPS the object with `at: null`, because collapsing it to `null` would say no removal is scheduled when one is.

**Both arguments are opt-in because of where the cost lands.** `holds` and `retention` apply to the whole query before the middleware's `limit`, so they are paid over every snapshot on the system whatever bound this tool asked for. With neither passed, the call is byte-for-byte the one it was before and both fields are `null` on every entry.

**The `extra` names are not compiler-checked** — the client types `extra` as `Record<string, unknown>`, so a typo would be dropped rather than refused and would look exactly like a working call. Tests pin both spellings and assert the fields come back populated, per the ticket.

**The removal time is read three ways.** The client declares `datetime` a `string`; a middleware time reaches this repository as the `{ "$date": … }` envelope every other date-reading tool here unwraps. Both are read, plus a bare number, per #102 — a reading that both shapes satisfy is worth more than one written to whichever arrives. A string with no zone in it is deliberately NOT read: taking it as UTC would be a guess confidently off by hours.

`README.md` enumerates tool names rather than fields, so it does not change — confirmed rather than assumed. No tool is registered or exported, so `src/tools/index.ts`, `src/index.ts` and their specs are untouched.

## Verification

`yarn lint`, `yarn typecheck`, `yarn test` (1444 passing) and `yarn test:coverage` all pass locally, as does `yarn build`. Coverage is above the floors in `vitest.config.ts` with every new branch covered; the one uncovered branch reported in `snapshots.ts` is the pre-existing `recursive` ternary in `snapshots_create`'s plan.

## Review

The local review round ran the project's own reviewer in a separate process and returned **nothing at MEDIUM or above** (six LOW findings). The `app/CLAUDE.md` decision entry was written after that round and is prose only.

### LOW findings not acted on, and why

- **`removalMillis`'s `MAX_TIME_MS` bound is unreachable on the string branch** — a four-digit year caps a parsed value far below it. True; the bound is kept because the number branch needs it and one guard reading the same way on both arms is easier to keep right than two.
- **`ZONED_INSTANT` rejects the `+HHMM` offset that `certificates.ts`'s `ZONED` accepts.** Real inconsistency between two families' readings of "explicit zone". Widening it is a change to what the tool reads, so it is named here rather than made after a clean round.
- **A fourth private copy of the `{$date}`-or-bare-number epoch reader** (`replication.ts`, `tasks.ts`, `system.ts` hold the others), and not identical to them. Promoting it to `common.ts` is the #86 move and is worth its own ticket — the four differ in what they accept beside the envelope, so unifying them changes what three existing tools read.
- **A retention record with nothing readable in it still reports a non-null `scheduled_removal`**, where a non-record `retention` is nulled, and that case is untested. That asymmetry is deliberate and is written up in the decision entry — inside the record, keeping the object refuses the "nothing will remove this" claim — but the reviewer is right that the all-null case has no test of its own.
- **The description states middleware behaviour this repository does not establish** (enabled tasks only, latest removal date wins, the widening precedes `limit`) without an `(unconfirmed)` marking. Those three are cited to middleware and zettarepl source in #155 with file and line, and the acceptance criteria require them stated; they are not readable from this repository, so a later reader should treat the citation as the evidence.
