### PR TITLE
feat(snapshots): add snapshot_clone, the non-destructive route back to a snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1769,11 +1769,25 @@ count reads as "it exists". **That fails in opposite directions on one call**:
 `snapshot_clone` would refuse every destination on the system. Neither looks
 like a filter problem from the outside.
 
-**Both declared name fields are compared for the snapshot.** A snapshot row
-declares `id` and `name` as two separate required strings and the surface states
-no relationship between them — the same shape as an alert's `uuid` and `id`
-(#119) — so a match on either is what keeps the plan from failing for a snapshot
-that is plainly there. #91's rule reaching an equality nobody wrote down.
+**Both declared name fields are compared for the snapshot, and the read asks
+both ways.** A snapshot row declares `id` and `name` as two separate required
+strings and the surface states no relationship between them — the same shape as
+an alert's `uuid` and `id` (#119) — so a match on either is what keeps the plan
+from failing for a snapshot that is plainly there. #91's rule reaching an
+equality nobody wrote down.
+
+**A comparison over two fields needs a FILTER over both, or it rescues nothing
+on the system it was written for.** Comparing `name` after filtering on `id`
+alone reads as belt and braces and is not: where the two differ and the caller
+passes the `name` — which is what the description asks for — a filter the
+middleware honours answers with no row, and the second comparison has nothing to
+run against. It is reachable only on the dropped-filter path, which is a
+different case. The client declares the disjunction itself
+(`['OR', QueryFilters<T>[]]`, each arm a filter LIST), so this is checkable
+against the surface rather than guessed. **Ask which rows the filter can return
+before deciding what comparing them establishes** — the filter and the
+comparison do different jobs (#121: bandwidth versus the control) and a
+mismatched pair silently covers neither case.
 
 ### `reversible` is not "this catalog can undo it" (#153)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1751,10 +1751,16 @@ readable afterwards. **Ask when the fact the result reports is readable, and put
 the step there** — a plan that lists a read first because the sibling tool does
 is a plan describing an order that will not happen.
 
-The plan step's `params` and the call `execute` makes come from one helper, and
-a test takes the step out of the plan and asserts the `query` spy was called
-with it. Two hand-written copies of the same params is how a plan stops being
-true one edit at a time, and nothing else in the repository would catch it.
+Half of that step's params are closed by construction and half are held by a
+test, which is worth being exact about. The OPTIONS come from one hoisted
+`const` the read and the step both name; the FILTER is written twice, because
+written to a `const` it widens out of the filter tuple. So a test takes the
+read step back out of the plan and asserts the `query` spy was called with it —
+that assertion, and not the shared helper, is what keeps the filter halves in
+step. Two hand-written copies of the same params is how a plan stops being true
+one edit at a time, and **where construction cannot close a half, say which
+half the test is holding** — a note claiming one helper covers both invites a
+later reader to drop the assertion as redundant.
 
 ### An existence check reads the response, not the row count (#153)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1736,6 +1736,68 @@ report a removal date it will survive. Stated in the description as the reading
 a caller is most likely to get wrong, since side-by-side fields are what an
 implied relationship looks like from the outside (#138).
 
+### The read a plan names can come after the mutation (#153)
+
+`snapshot_clone` returns two plan steps in the order `pool.snapshot.clone`,
+then `pool.dataset.query` — the mutation first and the read second, where
+`alerts_dismiss` and `scheduled_task_set_enabled` both read first. #119's rule
+is unchanged and is what produces the difference: a `PlanStep` is a call
+`execute` will make, so the steps are the calls in the order `execute` makes
+them. Those tools read BEFORE the call because the fact they report — whether
+the alert was already dismissed, whether the task was already enabled — is only
+readable beforehand. `pool.snapshot.clone` answers a bare `true`, so the only
+thing left to establish is whether the dataset is now there, and that is only
+readable afterwards. **Ask when the fact the result reports is readable, and put
+the step there** — a plan that lists a read first because the sibling tool does
+is a plan describing an order that will not happen.
+
+The plan step's `params` and the call `execute` makes come from one helper, and
+a test takes the step out of the plan and asserts the `query` spy was called
+with it. Two hand-written copies of the same params is how a plan stops being
+true one edit at a time, and nothing else in the repository would catch it.
+
+### An existence check reads the response, not the row count (#153)
+
+`assertDatasetExists` counted rows: an empty list meant the dataset was not
+there. It now finds a row whose `id` IS the name asked for, and `snapshot_clone`
+reads its source the same way. This is #121's *never act on the first row of a
+filtered read* applied to a guard rather than to a listing, and the guard is
+where it bites hardest — an unrecognised query parameter is dropped rather than
+refused, so a filter that did not apply comes back as the whole table, which a
+count reads as "it exists". **That fails in opposite directions on one call**:
+`snapshots_list` would stop reporting a dataset that is not there, and
+`snapshot_clone` would refuse every destination on the system. Neither looks
+like a filter problem from the outside.
+
+**Both declared name fields are compared for the snapshot.** A snapshot row
+declares `id` and `name` as two separate required strings and the surface states
+no relationship between them — the same shape as an alert's `uuid` and `id`
+(#119) — so a match on either is what keeps the plan from failing for a snapshot
+that is plainly there. #91's rule reaching an equality nobody wrote down.
+
+### `reversible` is not "this catalog can undo it" (#153)
+
+`snapshot_clone` adds a dataset and removes nothing, so `destructiveness` is the
+easy case — there is no account of the data to come apart from the field the way
+`cloudsync_run`'s does (#122, #128). The trap is one level over: a field saying
+`reversible` beside an operation that plainly removes nothing invites the
+reading *undoing this is easy*, and undoing a clone means deleting the dataset
+it made, which **no tool here does**. The description says that outright, next
+to the field's own meaning. **Where a tool's operation is genuinely reversible
+and the catalog still cannot reverse it, say so** — the field records the
+operation, and a caller reads a reversal it could ask for into it otherwise.
+
+The other half is the fact the operation's own shape hides. A clone shares
+blocks with its source snapshot, so **creating one pins that snapshot
+indefinitely** — it cannot be destroyed while the clone exists, and the space it
+references stays in use, including where a `scheduled_removal` `snapshots_list`
+reports would have taken it. An additive operation with a lasting consequence
+elsewhere is exactly what a caller will not infer, so it is in the description
+before anything about the result. How TrueNAS's retention path REPORTS a removal
+that then fails is marked `(unconfirmed)`, in `pool_resilver_config`'s form
+(#141): what is claimed is the pinning, which the ZFS semantics fix, and not the
+error, which was not read off a live system.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ confirmation UX, audit sinks) enters through injected interfaces.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
   `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run`,
-  `automated_task_set_enabled` — `cloudsync_run` the only one that starts a
-  background job, which it watches for a bounded time and then reports on
-  rather than waiting out. `destructiveness`
+  `automated_task_set_enabled`, `snapshot_clone` — `cloudsync_run` the only one
+  that starts a background job, which it watches for a bounded time and then
+  reports on rather than waiting out. `snapshot_clone` is the additive route
+  back to a snapshot's data: it adds a dataset and alters nothing, which is
+  what lets the catalog decline the rollback that answers the same question
+  destructively. `destructiveness`
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
   for good, which its description and its plan state and this field does not.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ confirmation UX, audit sinks) enters through injected interfaces.
   `automated_task_set_enabled`, `snapshot_clone` — `cloudsync_run` the only one
   that starts a background job, which it watches for a bounded time and then
   reports on rather than waiting out. `snapshot_clone` is the additive route
-  back to a snapshot's data: it adds a dataset and alters nothing, which is
-  what lets the catalog decline the rollback that answers the same question
-  destructively. `destructiveness`
+  back to a snapshot's data: it deletes nothing and modifies no dataset that
+  exists, which is what lets the catalog decline the rollback that answers the
+  same question destructively — though the clone it adds does pin its source
+  snapshot, which cannot then be destroyed while that clone is there, and its
+  description leads with that. `destructiveness`
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
   for good, which its description and its plan state and this field does not.

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,4 +139,5 @@ export {
   scheduledTaskSetEnabled,
   cloudsyncRun,
   automatedTaskSetEnabled,
+  snapshotClone,
 } from '@/tools/index';

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the sixty-two sketch tools', () => {
+  it('registers the sixty-three sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -67,6 +67,7 @@ describe('createDefaultCatalog', () => {
       'scheduled_task_set_enabled',
       'cloudsync_run',
       'automated_task_set_enabled',
+      'snapshot_clone',
     ]);
   });
 
@@ -91,6 +92,12 @@ describe('createDefaultCatalog', () => {
   it('does not advertise automated_task_set_enabled to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
       'automated_task_set_enabled',
+    );
+  });
+
+  it('does not advertise snapshot_clone to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'snapshot_clone',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,7 +22,7 @@ import {
 import { securityConfig } from '@/tools/security';
 import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
-import { createSnapshot, snapshotsList } from '@/tools/snapshots';
+import { createSnapshot, snapshotClone, snapshotsList } from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport, systemDatasetConfig } from '@/tools/storage';
 import {
   auditConfig,
@@ -45,7 +45,7 @@ import {
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: fifty-six read-only tools plus six mutating tools. */
+/** The sketch's catalog: fifty-six read-only tools plus seven mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -110,6 +110,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(scheduledTaskSetEnabled);
   catalog.register(cloudsyncRun);
   catalog.register(automatedTaskSetEnabled);
+  catalog.register(snapshotClone);
   return catalog;
 }
 
@@ -162,6 +163,7 @@ export {
   servicesStatus,
   shareAccess,
   sharesList,
+  snapshotClone,
   snapshotsList,
   snapshotTasksList,
   systemDatasetConfig,

--- a/src/tools/snapshots.spec.ts
+++ b/src/tools/snapshots.spec.ts
@@ -698,12 +698,20 @@ describe('snapshot_clone', () => {
     await expect(snapshotClone.plan(byId, args)).resolves.toHaveLength(2);
   });
 
-  it('asks the system for the source snapshot without every ZFS property', async () => {
+  it('asks the system for the source snapshot under either name field, without every ZFS property', async () => {
+    // `fakeSystem` answers every filter with the same rows, so the two cases
+    // above pass whatever this read asked for — which is why the filter itself
+    // is asserted here. On a system that honours it, an `id`-only filter
+    // answers with no row at all for a snapshot whose `name` is what the
+    // caller was told to pass, and the comparison above would have nothing
+    // left to rescue.
     const { ctx, query } = plannable();
     await snapshotClone.plan(ctx, args);
-    expect(query).toHaveBeenCalledWith('pool.snapshot.query', [['id', '=', SOURCE]], {
-      extra: { properties: ['creation'] },
-    });
+    expect(query).toHaveBeenCalledWith(
+      'pool.snapshot.query',
+      [['OR', [[['id', '=', SOURCE]], [['name', '=', SOURCE]]]]],
+      { extra: { properties: ['creation'] } },
+    );
   });
 
   it('executes the clone, then reports the destination the read found', async () => {

--- a/src/tools/snapshots.spec.ts
+++ b/src/tools/snapshots.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { fakeSystem } from '@/testing/fake-systems';
-import { createSnapshot, snapshotsList } from '@/tools/index';
+import { Role } from '@/interfaces';
+import { fakeSystem, failingSystem } from '@/testing/fake-systems';
+import { createSnapshot, snapshotClone, snapshotsList } from '@/tools/index';
 
 describe('snapshots_list', () => {
   /**
@@ -556,5 +557,245 @@ describe('snapshots_create', () => {
       { dataset: 'tank/media', name: 'before', recursive: false },
     ]);
     expect(result).toEqual({ created: 'tank/media@before' });
+  });
+});
+
+describe('snapshot_clone', () => {
+  const SOURCE = 'tank/media@nightly-1';
+  const DESTINATION = 'tank/media-restore';
+  const args = { snapshot: SOURCE, destination: DESTINATION };
+
+  /** The two positional params every dataset-existence read is made with. */
+  const DATASET_READ = [
+    [['id', '=', DESTINATION]],
+    { extra: { retrieve_children: false, properties: ['used'] } },
+  ];
+
+  /** The same read as the `query` spy records it, method included. */
+  const DATASET_READ_CALL = ['pool.dataset.query', ...DATASET_READ] as const;
+
+  /** A snapshot row as `pool.snapshot.query` reports one, trimmed to what is read. */
+  const sourceRow = (over: Record<string, unknown> = {}) => ({
+    id: SOURCE,
+    name: SOURCE,
+    dataset: 'tank/media',
+    ...over,
+  });
+
+  /**
+   * A system where the source snapshot is there and the destination is free —
+   * the state a plan is expected to succeed against.
+   */
+  const plannable = (over: Partial<Record<string, unknown>> = {}) =>
+    fakeSystem({
+      ['pool.snapshot.query']: [sourceRow()],
+      ['pool.dataset.query']: [],
+      ...over,
+    });
+
+  it('normalizes args: names the two it takes and drops everything else', () => {
+    // `dataset_properties` is the one that matters: the call declares it and
+    // this tool must neither accept it nor send it, so a caller supplying one
+    // must not reach `plan`, `execute` or the confirmation key with it.
+    expect(
+      snapshotClone.normalizeArgs?.({
+        ...args,
+        dataset_properties: { compression: 'off' },
+        extra: 1,
+      }),
+    ).toEqual({ snapshot: SOURCE, destination: DESTINATION });
+  });
+
+  it('requires both a snapshot and a destination', async () => {
+    const { ctx } = plannable();
+    for (const bad of [undefined, '', 123, null, {}]) {
+      await expect(
+        snapshotClone.plan(ctx, { snapshot: bad, destination: DESTINATION }),
+      ).rejects.toThrow(/"snapshot" is required/);
+      await expect(snapshotClone.plan(ctx, { snapshot: SOURCE, destination: bad })).rejects.toThrow(
+        /"destination" is required/,
+      );
+    }
+  });
+
+  it('plans the clone call and the read that follows it, in that order', async () => {
+    const { ctx } = plannable();
+    const steps = await snapshotClone.plan(ctx, args);
+    expect(steps).toEqual([
+      {
+        method: 'pool.snapshot.clone',
+        // No `dataset_properties`: absent rather than sent empty.
+        params: [{ snapshot: SOURCE, dataset_dst: DESTINATION }],
+        description:
+          `Clone snapshot "${SOURCE}" into a new dataset "${DESTINATION}". The snapshot ` +
+          'and the dataset it was taken of are not modified and nothing is deleted. The ' +
+          'new dataset shares its blocks with the snapshot, which then cannot be ' +
+          'destroyed while the clone exists.',
+      },
+      {
+        method: 'pool.dataset.query',
+        params: DATASET_READ,
+        description: `Read "${DESTINATION}" back, to report whether the clone is there. Changes nothing.`,
+      },
+    ]);
+  });
+
+  it('names the read step with the params execute actually makes it with', async () => {
+    // The two are derived from one helper, and this is what says so: a plan
+    // describing a call the tool does not make is a plan that is not true.
+    const { ctx } = plannable();
+    const [, readStep] = await snapshotClone.plan(ctx, args);
+    const { ctx: executing, query } = fakeSystem({
+      ['pool.dataset.query']: [{ id: DESTINATION }],
+    });
+    await snapshotClone.execute(executing, args);
+    expect(query).toHaveBeenCalledWith(readStep.method, ...(readStep.params as unknown[]));
+  });
+
+  it('fails the plan, naming the snapshot, where no snapshot has that name', async () => {
+    const { ctx } = plannable({ ['pool.snapshot.query']: [] });
+    await expect(snapshotClone.plan(ctx, args)).rejects.toThrow(
+      new RegExp(`No snapshot named "${SOURCE}" on this system`),
+    );
+  });
+
+  it('fails the plan, naming the destination, where a dataset already exists there', async () => {
+    const { ctx } = plannable({ ['pool.dataset.query']: [{ id: DESTINATION }] });
+    await expect(snapshotClone.plan(ctx, args)).rejects.toThrow(
+      new RegExp(`A dataset already exists at "${DESTINATION}"`),
+    );
+  });
+
+  it('reads both existence checks off the response rather than the row count', async () => {
+    // An unrecognised query parameter is dropped rather than refused, so a
+    // filter that did not apply comes back as the whole table. Counting rows
+    // would then plan a clone of a snapshot that does not exist, and refuse
+    // every destination on the system.
+    const { ctx: unfiltered } = plannable({
+      ['pool.snapshot.query']: [sourceRow({ id: 'tank/other@nightly-1', name: 'tank/other@nightly-1' })],
+    });
+    await expect(snapshotClone.plan(unfiltered, args)).rejects.toThrow(/No snapshot named/);
+
+    const { ctx: everyDataset } = plannable({
+      ['pool.dataset.query']: [{ id: 'tank' }, { id: 'tank/media' }],
+    });
+    await expect(snapshotClone.plan(everyDataset, args)).resolves.toHaveLength(2);
+  });
+
+  it('matches the source snapshot on either declared name field', async () => {
+    // The client declares `id` and `name` as two separate required strings and
+    // states no relationship between them, exactly as an alert declares `uuid`
+    // and `id`. Matching one alone would fail the plan for a snapshot that is
+    // plainly there on a system where the two differ.
+    const { ctx: byName } = plannable({
+      ['pool.snapshot.query']: [sourceRow({ id: 'something-else' })],
+    });
+    await expect(snapshotClone.plan(byName, args)).resolves.toHaveLength(2);
+
+    const { ctx: byId } = plannable({
+      ['pool.snapshot.query']: [sourceRow({ name: 'something-else' })],
+    });
+    await expect(snapshotClone.plan(byId, args)).resolves.toHaveLength(2);
+  });
+
+  it('asks the system for the source snapshot without every ZFS property', async () => {
+    const { ctx, query } = plannable();
+    await snapshotClone.plan(ctx, args);
+    expect(query).toHaveBeenCalledWith('pool.snapshot.query', [['id', '=', SOURCE]], {
+      extra: { properties: ['creation'] },
+    });
+  });
+
+  it('executes the clone, then reports the destination the read found', async () => {
+    const { ctx, call, query } = fakeSystem({
+      ['pool.snapshot.clone']: true,
+      ['pool.dataset.query']: [{ id: DESTINATION }],
+    });
+    const result = await snapshotClone.execute(ctx, args);
+    expect(call).toHaveBeenCalledWith('pool.snapshot.clone', [
+      { snapshot: SOURCE, dataset_dst: DESTINATION },
+    ]);
+    expect(query).toHaveBeenCalledWith(...DATASET_READ_CALL);
+    expect(result).toEqual({
+      snapshot: SOURCE,
+      destination: DESTINATION,
+      destination_found: true,
+      destination_read_error: null,
+    });
+  });
+
+  it('reports a read that completed and listed nothing as false, not as a failure', async () => {
+    const { ctx } = fakeSystem({
+      ['pool.snapshot.clone']: true,
+      ['pool.dataset.query']: [],
+    });
+    // The call did not reject and the dataset was not there to read back —
+    // which is the one answer a caller acts on.
+    expect(await snapshotClone.execute(ctx, args)).toEqual({
+      snapshot: SOURCE,
+      destination: DESTINATION,
+      destination_found: false,
+      destination_read_error: null,
+    });
+  });
+
+  it('reads the destination off the response here too', async () => {
+    // Same dropped-filter case as the plan's, on the other side of the call: a
+    // row count would report every clone as found on a system that answered
+    // with its whole dataset list.
+    const { ctx } = fakeSystem({
+      ['pool.snapshot.clone']: true,
+      ['pool.dataset.query']: [{ id: 'tank' }, { id: 'tank/media' }],
+    });
+    expect(await snapshotClone.execute(ctx, args)).toMatchObject({ destination_found: false });
+  });
+
+  it('reports a read that failed as null and why, rather than failing the call', async () => {
+    // The clone had already been accepted by then. Rejecting here would tell
+    // the caller a clone that exists does not.
+    const { ctx, call } = failingSystem(
+      { ['pool.snapshot.clone']: true },
+      { ['pool.dataset.query']: { reason: 'connection reset' } },
+    );
+    expect(await snapshotClone.execute(ctx, args)).toEqual({
+      snapshot: SOURCE,
+      destination: DESTINATION,
+      destination_found: null,
+      destination_read_error: 'connection reset',
+    });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.clone', [
+      { snapshot: SOURCE, dataset_dst: DESTINATION },
+    ]);
+  });
+
+  it('sends no dataset_properties even when the caller supplied one', async () => {
+    const { ctx, call } = fakeSystem({
+      ['pool.snapshot.clone']: true,
+      ['pool.dataset.query']: [{ id: DESTINATION }],
+    });
+    await snapshotClone.execute(ctx, { ...args, dataset_properties: { compression: 'off' } });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.clone', [
+      { snapshot: SOURCE, dataset_dst: DESTINATION },
+    ]);
+  });
+
+  it('is registered as a Full-role reversible mutation', () => {
+    // `reversible` records that the operation removes nothing. Nothing here
+    // deletes the dataset it made, which the description says outright.
+    expect(snapshotClone.requiredRole).toBe(Role.Full);
+    expect(snapshotClone.mutating).toBe(true);
+    expect(snapshotClone.destructiveness).toBe('reversible');
+  });
+
+  it('states the pinning, the untouched source and the clone it does not manage', () => {
+    // These three are the readings a caller is most likely to get wrong about
+    // an operation described as additive, and prose is the only place they can
+    // be stated — so they are pinned rather than left to a later edit.
+    expect(snapshotClone.description).toContain('DELETES NOTHING');
+    expect(snapshotClone.description).toContain('THE CLONE PINS THE SNAPSHOT IT CAME FROM');
+    expect(snapshotClone.description).toContain('(unconfirmed)');
+    expect(snapshotClone.description).toContain('NOTHING HERE TOUCHES THE CLONE AFTERWARDS');
+    expect(snapshotClone.description).toContain('storage_list_datasets');
+    expect(snapshotClone.description).toContain('`dataset_properties` IS NOT ACCEPTED');
   });
 });

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -6,12 +6,16 @@ import {
   MAX_TIME_MS,
   MiddlewareDate,
   effectiveLimit,
+  errorText,
   numberOrNull,
   recordOrNull,
   textOrNull,
 } from '@/tools/common';
 
-/** Snapshots family: the snapshots that exist, and taking a new one. */
+/**
+ * Snapshots family: the snapshots that exist, taking a new one, and cloning one
+ * into a new dataset.
+ */
 
 /**
  * The one mutating tool in the sketch — exists to exercise the two-phase
@@ -49,8 +53,53 @@ function createParams(args: SnapshotArgs): CallParams<ApiSurface, 'pool.snapshot
 }
 
 /**
- * Existence check for a dataset the caller named. Both tools in this family
- * use it, for different reasons.
+ * The options every dataset-existence read in this file is made with.
+ *
+ * Hoisted, where `storage.ts` inlines its filter and #115 requires a `select`
+ * to be inlined: neither reason reaches here. The filter below is still
+ * inlined, because written to a `const` it widens to `string[][]` and no longer
+ * satisfies the filter tuple; `extra` is typed by the client as an open record,
+ * so nothing about it is inferred from the literal and there is nothing to
+ * widen. What the hoisting buys is that {@link datasetExists} and the plan step
+ * naming that read cannot drift apart — a plan describing a call the tool does
+ * not make is the defect #119 is about.
+ */
+const DATASET_READ_OPTIONS = { extra: { retrieve_children: false, properties: ['used'] } };
+
+/**
+ * The two positional params a dataset-existence read reaches the middleware
+ * with, for the plan step that names one.
+ *
+ * `api.query(method, filters, options)` dispatches `[filters, options]`, so a
+ * step naming only the filter would show the user a call one argument shorter
+ * than the one that runs.
+ */
+function datasetReadParams(dataset: string): unknown {
+  return [[['id', '=', dataset]], DATASET_READ_OPTIONS];
+}
+
+/**
+ * Whether this system lists a dataset under the name given.
+ *
+ * The filter is bandwidth and the check on the response is the control: an
+ * unrecognised query parameter is dropped rather than refused, so a filter that
+ * did not apply comes back as every dataset on the system and is
+ * indistinguishable from one that matched everything. Reading the length alone
+ * would then answer "it exists" for any name at all — which for the two callers
+ * below means a listing that never reports a missing dataset, and a clone plan
+ * that refuses every destination.
+ */
+async function datasetExists(ctx: ToolContext, dataset: string): Promise<boolean> {
+  const matches = await firstValueFrom(
+    ctx.system.client.api.query('pool.dataset.query', [['id', '=', dataset]], DATASET_READ_OPTIONS),
+  );
+  return matches.some((row) => stringOrNull(row['id']) === dataset);
+}
+
+/**
+ * {@link datasetExists} as a failure, for the two tools that need a named
+ * dataset to be there. `snapshot_clone` reads the same fact for the opposite
+ * question and so calls the guard above directly.
  *
  * For `snapshots_create` it is a plan-time check and advisory by design:
  * execute deliberately does not re-check (the "pure function of (args,
@@ -62,12 +111,7 @@ function createParams(args: SnapshotArgs): CallParams<ApiSurface, 'pool.snapshot
  * come back empty.
  */
 async function assertDatasetExists(ctx: ToolContext, dataset: string): Promise<void> {
-  const matches = await firstValueFrom(
-    ctx.system.client.api.query('pool.dataset.query', [['id', '=', dataset]], {
-      extra: { retrieve_children: false, properties: ['used'] },
-    }),
-  );
-  if (matches.length === 0) {
+  if (!(await datasetExists(ctx, dataset))) {
     throw new Error(`Dataset "${dataset}" does not exist`);
   }
 }
@@ -570,6 +614,244 @@ export const snapshotsList: ReadOnlyTool = {
       snapshots: rows.sort(byNewestFirst).map((entry) => entry.row),
       truncated: snapshots.length > limit,
       limit,
+    };
+  },
+};
+
+/**
+ * `snapshot_clone`: the additive route back to a snapshot's data.
+ *
+ * "Get back the version from before" is the question a snapshot exists to
+ * answer, and the obvious route to it — rolling the dataset back — destroys
+ * everything written since. A tool composing that is rejected at registration
+ * (`catalog/catalog.ts`) and there is none here. Cloning answers the same
+ * question additively: the snapshot's contents appear as a new dataset, the
+ * original is untouched, and the caller copies out what it needs. This is what
+ * lets the catalog decline rollback without declining recovery.
+ *
+ * WHAT THE PLAN NAMES IS WHAT `execute` CALLS. `pool.snapshot.clone` answers a
+ * bare `true` — no entity, so there is nothing to read the outcome off — which
+ * places this with `alerts_dismiss` (#119) rather than with
+ * `scheduled_task_set_enabled` (#121): `execute` re-reads the destination to
+ * establish that the dataset is now there, and the plan names that read as a
+ * step. The read runs after the call rather than before it, and the steps are
+ * in that order for the same reason they are in `alerts_dismiss` — a plan is a
+ * list of the calls `execute` makes, in the order it makes them.
+ *
+ * PLAN-TIME VALIDATION, AND WHERE IT STOPS. The plan reads the source snapshot
+ * to fail on a name no snapshot has, and the destination to fail where a
+ * dataset already exists there — the middleware would refuse both, and a plan
+ * naming a call certain to fail is a plan wasting an approval. It does NOT
+ * check that the destination's parent exists or that the pool has room; those
+ * are the middleware's to refuse, and re-implementing them here would be a
+ * second opinion that drifts.
+ *
+ * `dataset_properties` IS DECLARED ON THE CALL AND IS NOT ACCEPTED. It is
+ * `{[k: string]: unknown}` — an open record, the same shape and the same reason
+ * as `app.upgrade`'s `values`: a tool cannot allowlist what it does not name,
+ * and an open record forwarded from a caller is the boundary this repository
+ * does not cross. The clone takes the snapshot's own properties.
+ *
+ * `destructiveness: 'reversible'` RECORDS THE OPERATION, per
+ * {@link Destructiveness}'s own declaration. This one is the easy case — the
+ * operation adds a dataset and removes nothing, so there is no account of the
+ * data to come apart from the field the way `cloudsync_run`'s does. What the
+ * description must not do is let that read as "undoing this is easy": undoing a
+ * clone means deleting the dataset it made, and no tool here deletes one.
+ */
+
+/** The two arguments the tool takes. */
+interface CloneArgs {
+  snapshot: string;
+  destination: string;
+}
+
+/**
+ * The caller's arguments, or the error naming what is missing.
+ *
+ * Strict, as `snapshots_create`'s `dataset` is and `alerts_dismiss`'s `uuid`
+ * is: neither of these can be read as anything else without cloning a snapshot
+ * nobody named, or naming a destination nobody asked for.
+ */
+function parseCloneArgs(args: Record<string, unknown>): CloneArgs {
+  const snapshot = args['snapshot'];
+  const destination = args['destination'];
+  if (typeof snapshot !== 'string' || snapshot.length === 0) {
+    throw new Error('"snapshot" is required');
+  }
+  if (typeof destination !== 'string' || destination.length === 0) {
+    throw new Error('"destination" is required');
+  }
+  return { snapshot, destination };
+}
+
+/**
+ * The clone call's own params.
+ *
+ * `dataset_properties` is optional on the declared argument and is absent here
+ * rather than sent empty — an empty record is a request to set nothing, and
+ * omitting the key is the tool never having had an opinion.
+ */
+function cloneParams(args: CloneArgs): CallParams<ApiSurface, 'pool.snapshot.clone'> {
+  return [{ snapshot: args.snapshot, dataset_dst: args.destination }];
+}
+
+/**
+ * Whether this system lists the snapshot the caller named.
+ *
+ * The response is checked rather than counted, for {@link datasetExists}'s
+ * reason: a dropped filter answers with every snapshot on the system, and a
+ * length test would then plan a clone of a snapshot that does not exist.
+ *
+ * BOTH `id` AND `name` ARE COMPARED. The client declares them as two separate
+ * required `string` fields on a snapshot row and states no relationship between
+ * them — the same shape as an alert's `uuid` and `id` (#119) — so matching only
+ * one of them would fail the plan for a snapshot that is plainly there on a
+ * system where they differ. `pool.snapshot.clone` takes the name either way.
+ *
+ * One property is asked for because this read needs none and the middleware is
+ * not documented to read an empty list as "no properties"; a snapshot row
+ * otherwise carries every ZFS property of the snapshot, on every row of a
+ * listing this filter may not have narrowed.
+ */
+async function snapshotExists(ctx: ToolContext, snapshot: string): Promise<boolean> {
+  const matches = await firstValueFrom(
+    ctx.system.client.api.query('pool.snapshot.query', [['id', '=', snapshot]], {
+      extra: { properties: ['creation'] },
+    }),
+  );
+  return matches.some(
+    (row) => stringOrNull(row['id']) === snapshot || stringOrNull(row['name']) === snapshot,
+  );
+}
+
+export const snapshotClone: MutatingTool = {
+  name: 'snapshot_clone',
+  description:
+    'Creates a new ZFS dataset from an existing snapshot, so the data in that ' +
+    'snapshot can be read and copied out without altering the dataset it was ' +
+    'taken of. Two-phase: called without a confirmation_token it returns a ' +
+    'plan for user approval; called with one it creates the clone. THIS ' +
+    'DELETES NOTHING AND CHANGES NOTHING THAT EXISTS. The source snapshot and ' +
+    'the dataset it was taken of are untouched, and everything written since ' +
+    'the snapshot was taken is still there — which is what makes this the ' +
+    'route back to a snapshot\'s contents, since rolling a dataset back would ' +
+    'discard that work and no tool here does it. THE CLONE PINS THE SNAPSHOT ' +
+    'IT CAME FROM: a clone shares its blocks with that snapshot, so the ' +
+    'snapshot cannot be destroyed while the clone exists and the space it ' +
+    'references stays in use. That reaches retention — a snapshot ' +
+    '`snapshots_list` reports a `scheduled_removal` for may still be there ' +
+    'after that time once it has been cloned. Standard ZFS refuses to destroy ' +
+    'a snapshot with dependent clones; HOW TRUENAS REPORTS A REMOVAL THAT ' +
+    'THEN FAILS IS (unconfirmed) here, so what is claimed is the pinning and ' +
+    'not the error. `snapshot` is the full `dataset@snapshot` name as ' +
+    '`snapshots_list` reports it in `name`; `destination` is the full name of ' +
+    'the dataset to create, in the form `storage_list_datasets` reports as ' +
+    '`id`. PLANNING FAILS, NAMING WHAT WAS WRONG, in exactly two cases: where ' +
+    'this system lists no snapshot under the name given, and where a dataset ' +
+    'already exists at the destination. It checks nothing else — whether the ' +
+    "destination's parent dataset exists, and whether the pool has room, are " +
+    'the middleware\'s to refuse, and this tool does not offer a second ' +
+    'opinion about either. `dataset_properties` IS NOT ACCEPTED and none is ' +
+    'sent: the clone takes the source snapshot\'s own properties. NOTHING ' +
+    'HERE TOUCHES THE CLONE AFTERWARDS — this tool does not promote it, ' +
+    'delete it or set anything on it, and no other tool in this catalog does ' +
+    'either. From that point it is an ordinary dataset, and ' +
+    '`storage_list_datasets` is where it is visible. So `destructiveness: ' +
+    "'reversible'` records that this operation removes nothing; it does not " +
+    'mean the clone can be undone from here, which would mean deleting the ' +
+    'dataset it made. The result reports the two arguments as they were sent, ' +
+    'under `snapshot` and `destination`, and what the read immediately after ' +
+    'the clone call found: `destination_found` is true where a dataset with ' +
+    'that name was listed, false where that read completed and listed none, ' +
+    'and NULL WHERE THE READ ITSELF FAILED, with `destination_read_error` ' +
+    'naming why and null in the other two cases. A null is not a failed ' +
+    'clone — the call had already been accepted by then, and this tool simply ' +
+    'could not establish the outcome; `storage_list_datasets` settles it. ' +
+    '`destination_found: false` is the one to act on: the call did not reject ' +
+    'and the dataset was not there to read back.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      snapshot: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'The snapshot to clone, as its full `dataset@snapshot` name — the ' +
+          '`name` `snapshots_list` reports, e.g. "tank/media@nightly-1", on ' +
+          'the system being targeted.',
+      },
+      destination: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'Full name of the dataset to create, e.g. "tank/media-restore". ' +
+          'Must not already exist; planning fails naming it if it does. Its ' +
+          'parent must exist, which this tool does not check.',
+      },
+    },
+    required: ['snapshot', 'destination'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    const args = parseCloneArgs(rawArgs);
+    // Named one by one, which is also what drops a `dataset_properties` a
+    // caller supplied: an unknown key normalized away never reaches `plan`,
+    // `execute` or the confirmation key.
+    return { snapshot: args.snapshot, destination: args.destination };
+  },
+  async plan(ctx, rawArgs) {
+    const args = parseCloneArgs(rawArgs);
+    // Each failure names the argument the caller supplied, because that is the
+    // part of it a caller can check. `assertDatasetExists` fails the same way
+    // for `snapshots_create`.
+    if (!(await snapshotExists(ctx, args.snapshot))) {
+      throw new Error(`No snapshot named "${args.snapshot}" on this system`);
+    }
+    if (await datasetExists(ctx, args.destination)) {
+      throw new Error(`A dataset already exists at "${args.destination}"`);
+    }
+    return [
+      {
+        method: 'pool.snapshot.clone',
+        params: cloneParams(args),
+        description:
+          `Clone snapshot "${args.snapshot}" into a new dataset ` +
+          `"${args.destination}". The snapshot and the dataset it was taken ` +
+          'of are not modified and nothing is deleted. The new dataset shares ' +
+          'its blocks with the snapshot, which then cannot be destroyed while ' +
+          'the clone exists.',
+      },
+      {
+        method: 'pool.dataset.query',
+        params: datasetReadParams(args.destination),
+        description:
+          `Read "${args.destination}" back, to report whether the clone is ` +
+          'there. Changes nothing.',
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const args = parseCloneArgs(rawArgs);
+    await firstValueFrom(ctx.system.client.api.call('pool.snapshot.clone', cloneParams(args)));
+    // Caught rather than thrown: this read exists to describe the outcome, and
+    // letting it fail the call would report a clone that was accepted as a
+    // failure. Same seam as `alerts_dismiss`'s lookup, on the other side of
+    // the mutation.
+    let found: boolean | null = null;
+    let readError: string | null = null;
+    try {
+      found = await datasetExists(ctx, args.destination);
+    } catch (reason) {
+      readError = errorText(reason);
+    }
+    return {
+      snapshot: args.snapshot,
+      destination: args.destination,
+      destination_found: found,
+      destination_read_error: readError,
     };
   },
 };

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -60,9 +60,13 @@ function createParams(args: SnapshotArgs): CallParams<ApiSurface, 'pool.snapshot
  * inlined, because written to a `const` it widens to `string[][]` and no longer
  * satisfies the filter tuple; `extra` is typed by the client as an open record,
  * so nothing about it is inferred from the literal and there is nothing to
- * widen. What the hoisting buys is that {@link datasetExists} and the plan step
- * naming that read cannot drift apart — a plan describing a call the tool does
- * not make is the defect #119 is about.
+ * widen. What the hoisting buys is that the options {@link datasetExists} reads
+ * with and the ones its plan step names cannot drift apart. The FILTER is still
+ * written twice — inlined below for the reason above, and again in
+ * {@link datasetReadParams} — so that half is held by the spec instead, which
+ * takes the read step back out of the plan and asserts `execute` made its call
+ * with it. A plan describing a call the tool does not make is the defect #119
+ * is about, and only one of these two halves is closed by construction.
  */
 const DATASET_READ_OPTIONS = { extra: { retrieve_children: false, properties: ['used'] } };
 
@@ -747,12 +751,15 @@ export const snapshotClone: MutatingTool = {
     'not the error. `snapshot` is the full `dataset@snapshot` name as ' +
     '`snapshots_list` reports it in `name`; `destination` is the full name of ' +
     'the dataset to create, in the form `storage_list_datasets` reports as ' +
-    '`id`. PLANNING FAILS, NAMING WHAT WAS WRONG, in exactly two cases: where ' +
-    'this system lists no snapshot under the name given, and where a dataset ' +
-    'already exists at the destination. It checks nothing else — whether the ' +
-    "destination's parent dataset exists, and whether the pool has room, are " +
-    'the middleware\'s to refuse, and this tool does not offer a second ' +
-    'opinion about either. `dataset_properties` IS NOT ACCEPTED and none is ' +
+    '`id`. PLANNING FAILS AND NAMES WHAT WAS WRONG in two cases: where this ' +
+    'system lists no snapshot under the name given, and where a dataset ' +
+    'already exists at the destination. THOSE ARE THE TWO IT CHECKS FOR, not ' +
+    'the only two ways planning fails — a malformed argument, or a read that ' +
+    'did not complete, fails it too and names neither. Nothing else about the ' +
+    "call is checked: whether the destination's parent dataset exists, and " +
+    'whether the pool has room, are the middleware\'s to refuse, and this ' +
+    'tool does not offer a second opinion about either. ' +
+    '`dataset_properties` IS NOT ACCEPTED and none is ' +
     'sent: the clone takes the source snapshot\'s own properties. NOTHING ' +
     'HERE TOUCHES THE CLONE AFTERWARDS — this tool does not promote it, ' +
     'delete it or set anything on it, and no other tool in this catalog does ' +

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -707,11 +707,26 @@ function cloneParams(args: CloneArgs): CallParams<ApiSurface, 'pool.snapshot.clo
  * reason: a dropped filter answers with every snapshot on the system, and a
  * length test would then plan a clone of a snapshot that does not exist.
  *
- * BOTH `id` AND `name` ARE COMPARED. The client declares them as two separate
- * required `string` fields on a snapshot row and states no relationship between
- * them — the same shape as an alert's `uuid` and `id` (#119) — so matching only
- * one of them would fail the plan for a snapshot that is plainly there on a
- * system where they differ. `pool.snapshot.clone` takes the name either way.
+ * BOTH `id` AND `name` ARE COMPARED, AND THE READ ASKS BOTH WAYS. The client
+ * declares them as two separate required `string` fields on a snapshot row and
+ * states no relationship between them — the same shape as an alert's `uuid` and
+ * `id` (#119) — so matching only one of them would fail the plan for a snapshot
+ * that is plainly there on a system where they differ.
+ * `pool.snapshot.clone` takes the name either way.
+ *
+ * The FILTER has to name both fields for that to be true of a read the
+ * middleware actually narrowed: filtering on `id` alone and then comparing
+ * `name` rescues nothing, because on the system where the two differ and the
+ * caller passes the `name` the tool's own description asks for, an honoured
+ * `id` filter answers with no row at all and there is nothing left to compare.
+ * The disjunction is the client's own declared filter form
+ * (`['OR', QueryFilters<T>[]]`), so each arm is a filter LIST rather than a
+ * bare condition.
+ *
+ * The two halves still do different work, and neither replaces the other. The
+ * filter is bandwidth and is what a system that honours it narrows on; the
+ * comparison is the control, and is what reads a dropped filter's whole-table
+ * answer correctly rather than as "every snapshot matches".
  *
  * One property is asked for because this read needs none and the middleware is
  * not documented to read an empty list as "no properties"; a snapshot row
@@ -720,9 +735,11 @@ function cloneParams(args: CloneArgs): CallParams<ApiSurface, 'pool.snapshot.clo
  */
 async function snapshotExists(ctx: ToolContext, snapshot: string): Promise<boolean> {
   const matches = await firstValueFrom(
-    ctx.system.client.api.query('pool.snapshot.query', [['id', '=', snapshot]], {
-      extra: { properties: ['creation'] },
-    }),
+    ctx.system.client.api.query(
+      'pool.snapshot.query',
+      [['OR', [[['id', '=', snapshot]], [['name', '=', snapshot]]]]],
+      { extra: { properties: ['creation'] } },
+    ),
   );
   return matches.some(
     (row) => stringOrNull(row['id']) === snapshot || stringOrNull(row['name']) === snapshot,

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -711,8 +711,14 @@ function cloneParams(args: CloneArgs): CallParams<ApiSurface, 'pool.snapshot.clo
  * declares them as two separate required `string` fields on a snapshot row and
  * states no relationship between them — the same shape as an alert's `uuid` and
  * `id` (#119) — so matching only one of them would fail the plan for a snapshot
- * that is plainly there on a system where they differ.
- * `pool.snapshot.clone` takes the name either way.
+ * that is plainly there on a system where they differ. WHETHER
+ * `pool.snapshot.clone` ITSELF ACCEPTS EITHER SPELLING IS (unconfirmed): its
+ * `snapshot` argument is a bare `string` and the surface states no relationship
+ * between the two fields, which is this check's own premise. What the read
+ * establishes is that the system lists something under the name given; the
+ * string the caller supplied is what `execute` forwards, so a middleware that
+ * takes only one of the two would reject at execute time rather than at plan
+ * time.
  *
  * The FILTER has to name both fields for that to be true of a read the
  * middleware actually narrowed: filtering on `id` alone and then comparing


### PR DESCRIPTION
Fixes #153

## What this adds

`snapshot_clone`, a `Role.Full` mutating tool over `pool.snapshot.clone`. It takes a source snapshot name and a destination dataset name and creates a new dataset holding that snapshot's contents. The source snapshot and the dataset it was taken of are untouched, and nothing is deleted — which is what lets the catalog keep declining the rollback that answers the same question destructively.

Registered in `createDefaultCatalog()`, re-exported from `src/tools/index.ts` and `src/index.ts`, with the exact-list assertion in `src/tools/index.spec.ts` updated and a read-only-credential exclusion test alongside the five existing mutating tools' ones. `src/index.spec.ts` (#151) needs no edit — it derives the barrel contract from the catalog — and it is what would have caught the barrel export had it been forgotten.

## The decisions, and where they are recorded

Three go in `app/CLAUDE.md` under `### … (#153)`:

- **The read a plan names can come after the mutation.** The two steps are `pool.snapshot.clone` then `pool.dataset.query`, the mutation first — where `alerts_dismiss` and `scheduled_task_set_enabled` both read first. #119 is unchanged and is what produces the difference: a `PlanStep` is a call `execute` makes, in the order it makes them. Those tools read beforehand because the fact they report is only readable beforehand; `pool.snapshot.clone` answers a bare `true`, so the only thing left to establish is whether the dataset is now there, which is only readable afterwards.

  **Half of that step's params are closed by construction and half are held by a test.** The read options come from one hoisted `const` that both the plan step and the live read name; the filter is written twice, deliberately, because written to a `const` it widens out of the filter tuple. So the spec takes the read step back out of the plan and asserts the `query` spy was called with it — that assertion, not a shared helper, is what keeps the two filters in step.

- **An existence check reads the response, not the row count.** `assertDatasetExists` counted rows; it now finds a row whose `id` *is* the name asked for, and the new tool's own two checks read the same way. This is #121's *never act on the first row of a filtered read* applied to a guard — and the guard is where it bites hardest, because it fails in **opposite directions on one call**: a dropped filter answers with the whole table, which a count reads as "it exists", so `snapshots_list` would stop reporting a missing dataset and `snapshot_clone` would refuse every destination on the system.

  The source snapshot is matched on **either** `id` or `name`, **and the read asks both ways**. Both are declared required strings on a snapshot row and the surface states no relationship between them — the same shape as an alert's `uuid` and `id` (#119) — so matching one alone would fail the plan for a snapshot that is plainly there. The filter names both fields too, through the client's own declared disjunction form (`['OR', QueryFilters<T>[]]`, each arm a filter list); see the review section below for why a comparison over two fields under an `id`-only filter rescues nothing.

- **`reversible` is not "this catalog can undo it".** The operation adds a dataset and removes nothing, so `destructiveness` is the easy case and there is no account of the data to come apart from the field the way `cloudsync_run`'s does. The trap is one level over: undoing a clone means deleting the dataset it made, and **no tool here does that**. The description says so next to the field's own meaning.

  The other half is the fact the operation's shape hides: **a clone pins its source snapshot**. It shares blocks with it, so that snapshot cannot be destroyed while the clone exists and the space stays in use, including where a `scheduled_removal` `snapshots_list` reports would have taken it. That is in the description before anything about the result. **How TrueNAS's retention path reports a removal that then fails is marked `(unconfirmed)`** — the pinning is fixed by ZFS semantics, the error was not read off a live system.

`dataset_properties` is declared on the call and is neither accepted nor sent: it is an open record, the same shape and the same reason as `app.upgrade`'s `values`. `normalizeArgs` names the two arguments one by one, which is what drops it before `plan`, `execute` or the confirmation key sees it — pinned by a test.

## Where the tests went

`snapshots.spec.ts`, under #87's default. **Measured rather than assumed**, as the ticket asked: the merged file is 809 lines against the 1,500 trigger, so the split exception is not met — this is #97's case rather than #121's.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test` (1461 passing), `yarn test:coverage` and `yarn build` all run locally and pass, on every round. `snapshots.ts` reports 100% statements / 99.24% branches — the one uncovered branch is `snapshots_create`'s pre-existing recursive plan wording, untouched here. Every job in `.github/workflows/ci.yml` was runnable on this machine.

## Review

**Round 1** (shared reviewer, run locally): five LOWs, nothing blocking. Three were prose the diff itself contradicted and were fixed in the second commit — the description claiming planning fails "in exactly two cases" where those are the two it *checks for*; the `DATASET_READ_OPTIONS` comment crediting the hoist with more than it closes; and `README.md` saying the tool "alters nothing", the opposite of the pinning the description leads with.

**Round 2** is the required check on this PR, which found **one MEDIUM**, and it was right:

> `snapshotExists` compared a row's `id` **and** its `name` against the snapshot asked for, but read with `[['id', '=', snapshot]]`. On the system that comparison was written for — one where the two fields genuinely differ — the caller passes the `name`, as this tool's own description instructs, and a middleware that honours the filter answers with **no row at all**. The `name` half then has nothing to run against and the plan fails with `No snapshot named "…"` for a snapshot that is plainly there: the outcome the comparison exists to prevent. It was reachable only on the dropped-filter path, which is a real case and a different one.

Taken as the first of the two resolutions the review offered — widen the read — because the client declares the disjunction itself, so it is checkable against the surface rather than guessed. The comparison stays: the filter is bandwidth and the check on the response is the control (#121), so a dropped filter's whole-table answer is still read correctly. `fakeSystem` answers every filter with the same rows, so the two divergent-field tests passed whatever the read asked for — the spec now asserts the dispatched filter itself, which is the half of the claim the suite could not previously see. `app/CLAUDE.md`'s #153 entry records the general rule: **a comparison over two fields needs a filter over both, or it rescues nothing on the system it was written for.**

**Round 3** (local, on the fixed diff): the shared reviewer timed out at 420s and charged its full round cap for nothing (harness#83), so this round is a subagent applying the same rubric from the brief — **a weaker signal than the check's own verdict, and that is stated rather than glossed**. It returned **three LOWs, nothing at MEDIUM or above**, which is where the local loop ends. It independently confirmed the fix against the client's declared `QueryFilter<T>` type and that the spec pins the literal filter. Two of its three findings were again prose the code contradicts, and are fixed in the last commit:

- the #153 entry in `app/CLAUDE.md` claimed the plan step's params and the executed call "come from one helper" — only the options do, and the note as written invited a later reader to drop the spec assertion holding the other half as redundant;
- `snapshotExists`'s JSDoc asserted flatly that `pool.snapshot.clone` "takes the name either way". Nothing on the surface says so — its `snapshot` argument is a bare `string`, and the paragraph's own premise is that the surface states no relationship between `id` and `name`. Now marked `(unconfirmed)` in #141's and #120's form, with what the check does and does not establish: a middleware taking only one spelling would reject at execute time, not at plan time.

## What I did not change, and why

Every one of these means touching executable code or a public contract, so they are left for this PR's reviewer and a later ticket rather than reopening the local review loop. All are LOW.

- **`matches.some` throws a raw `TypeError` where the payload is not a list.** The client declares an array and #91 says a declared type is a claim about what arrives — so a system answering with something else fails the plan rather than being read as unreadable. It fails closed (no clone is planned) and it is a new throw path *for the two pre-existing callers too*: the counting version answered `undefined` for `.length` and did not throw, so a `pool.dataset.query` answering with a non-list turns a `snapshots_list` that returned `{ snapshots: [], … }` into a failed tool call. Worth a decision about whether a non-list payload is fatal here the way it is in `system_ntp_status` (#133) or unreadable the way it is elsewhere — that is a question about the whole file's reads, not this tool's.
- **`DATASET_READ_OPTIONS` is handed out by reference in the plan step and reused for every live call**, so an adapter mutating a plan step's `params` would reach the executed read. No consumer does, and freezing or copying it is a change to how every tool hands out plan params rather than to this one.
- **`destination_found: false`'s description says "that read completed and listed none"**, which is narrower than what the code establishes: `false` is also the answer where the read completed with rows and none carried that `id` — the dropped-filter case this PR deliberately handles and pins. Something like *"listed no dataset under that name"* would say what is actually established.
- **No test covers the `pool.snapshot.clone` call itself rejecting.** `execute` awaits it outside the `try`, so a middleware refusal — parent missing, pool full, name taken between plan and confirm — propagates and fails the tool call, which is correct and is the one path where the caller must learn the clone did *not* happen. The suite only exercises the read failing.
- **The tool is named `snapshot_clone` where its two siblings in this file are `snapshots_list` and `snapshots_create`**, and it is one character from the unrelated `snapshot_tasks_list`. The name is the one the ticket specifies, and a tool name is a public contract pinned by `src/index.spec.ts` — so changing it is a decision for the ticket that asked for it, not a cleanup to fold in here.
