### PR TITLE
feat(tasks): add snapshot_task_run, and say what its retention pass reaches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1818,6 +1818,78 @@ that then fails is marked `(unconfirmed)`, in `pool_resilver_config`'s form
 (#141): what is claimed is the pinning, which the ZFS semantics fix, and not the
 error, which was not read off a live system.
 
+### A triggering tool states the SCOPE of the effect it does not author (#154)
+
+`snapshot_task_run` is the second job-backed tool and it copies `cloudsync_run`
+whole — `callAndGetJobId` and `trackJob` apart, a bounded watch that does not
+end the job, `ended` off the tracking completing, `job_id` off the correlation.
+Nothing in #122 needed rethinking, and none of it is re-argued in the code. What
+this ticket had to decide is the PLAN, and the decision generalises past this
+tool.
+
+**A run of a periodic snapshot task PRUNES, and the pruning reaches past the
+task named.** `pool.snapshottask.run` interrupts zettarepl's scheduler with the
+task, which goes round the same loop a scheduled fire goes round and ends in the
+retention pass — and that pass builds its owners from *every* periodic snapshot
+task on the system. So running task A can destroy snapshots owned by task B
+whose retention had lapsed and whose own tick had not come round. A plan reading
+"this takes a snapshot now" would omit a deletion, which is
+`transferModeSentence`'s defect in a second family.
+
+**So the plan states the MECHANISM and its SCOPE, and computes no outcome.** It
+says the run applies retention, says the pass is system-wide in those words,
+names the two protections that bound it — a snapshot whose name matches no
+task's naming schema is skipped, and the newest snapshot for a schema is kept
+where destroying it would leave none — and then points at `snapshots_list`'s
+`report_scheduled_removal`. Enumerating instead would be a second opinion about
+retention beside the middleware's own (#44), and it could not be sound anyway:
+that listing is bounded, and its own description says a truncated list cannot
+show a snapshot is absent. **Ask what an operation does and to what, and say
+that; do not compute what it will hit.**
+
+**The scope sentence needs the protections, and the protections need the scope
+sentence.** "Retention runs across every task" alone reads as "anything may go"
+and teaches an approver to discount the warning; the protections alone read as
+"only stale scheduled snapshots go", which is the claim the first sentence
+exists to refuse. Neither half is optional and they are one text
+(`RETENTION_PASS`) so that no later edit can keep one and drop the other.
+
+**None of that account is on the API surface, and the description says so.**
+Nothing the client declares says a run applies retention, says it applies
+system-wide, or says which snapshots survive — the reading comes from the
+TrueNAS implementation. That is #133's shape (the measured half of a question
+being unreachable from here) reaching an EFFECT rather than a fact, and #120's
+rule pointed the other way: a side effect that could not be established is
+stated rather than settled, and one that was established somewhere this
+repository cannot check is stated *as that*. Silence would have been read as
+"this only creates".
+
+**Only an explicit `false` refuses the plan.** `enabled` is optional on the
+entity and the middleware rejects a disabled task, so the plan reads it and
+fails at plan time naming the task — but a null is "the system reported no
+value", which is not the same answer as off, and failing on it would refuse a
+plan the middleware would have accepted. The unreadable case says the call may
+be rejected and names `scheduled_task_set_enabled` instead. That check is
+plan-time only, as `snapshots_create`'s dataset check is (#119), so a task
+disabled between plan and confirmation is refused by the middleware — stated in
+the description rather than fixed by re-reading, because `execute` re-reading
+would make it branch on state the confirmation token cannot bind.
+
+**The two tools keep separate watch bounds, equal though they are.** The bound
+is a ceiling on a TOOL's patience and not an estimate of its job (#122), so one
+shared constant would assert that the two ceilings must move together, which
+nothing requires. What IS shared is `schedulePhrase`, which now takes the
+pointer rather than a whole `TaskKind` — a second spelling of "the schedule
+could not be put into words" in one file is the drift `common.ts` was cut to
+stop, one size down. **Share a SENTENCE, not a number.**
+
+`tasks.spec.ts` was 1,352 lines and this block is several hundred more, so the
+#87 exception is met and the tests took `snapshot-task-run.spec.ts`. Its fake
+system is local, as `cloudsync-run.spec.ts`'s is: a job is a stream rather than
+a response, and `src/testing/fake-systems.ts` stubs `call` and `query` off one
+method→response map. Two copies now exist, which is when a shared fixture could
+be designed from evidence — a later ticket's call, not a side effect of this one.
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1854,6 +1854,22 @@ and teaches an approver to discount the warning; the protections alone read as
 exists to refuse. Neither half is optional and they are one text
 (`RETENTION_PASS`) so that no later edit can keep one and drop the other.
 
+**A protection stated as a CONDITION may not be restated as a class of
+snapshot, and this is where the description convention bites hardest.** The
+first protection is about the NAME: a snapshot whose name matches no task's
+naming schema is skipped. The first draft of both texts drew the obvious
+inference from it — *so a snapshot taken by hand is not at risk* — and that is
+false. `snapshots_create` takes the snapshot name straight from the caller
+(`required: ['dataset', 'name']`) and checks it against no task's schema, so a
+manual `tank/media@auto-2026-09-01_02-00` matches the periodic schema, is owned
+by the retention pass, and is destroyed by it. **A condition rewritten as a
+guarantee about who did something is a description promising more than the
+normalization delivers** — reached through an inference rather than through a
+field, which is why it survived a round. The failure direction is the costly
+one: the reader is reassured about the exact case that is unsafe, in the one
+text a person reads before approving. State the condition and say what does not
+check it.
+
 **None of that account is on the API surface, and the description says so.**
 Nothing the client declares says a run applies retention, says it applies
 system-wide, or says which snapshots survive — the reading comes from the

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ confirmation UX, audit sinks) enters through injected interfaces.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
   `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run`,
-  `automated_task_set_enabled`, `snapshot_clone` — `cloudsync_run` the only one
-  that starts a background job, which it watches for a bounded time and then
-  reports on rather than waiting out. `snapshot_clone` is the additive route
+  `automated_task_set_enabled`, `snapshot_clone`, `snapshot_task_run` —
+  `cloudsync_run` and `snapshot_task_run` the two that start a background job,
+  which each watches for a bounded time and then reports on rather than waiting
+  out. `snapshot_clone` is the additive route
   back to a snapshot's data: it deletes nothing and modifies no dataset that
   exists, which is what lets the catalog decline the rollback that answers the
   same question destructively — though the clone it adds does pin its source
@@ -49,7 +50,10 @@ confirmation UX, audit sinks) enters through injected interfaces.
   description leads with that. `destructiveness`
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
-  for good, which its description and its plan state and this field does not.
+  for good, and `snapshot_task_run` starts a run that ends in a system-wide
+  retention pass that destroys snapshots belonging to every periodic snapshot
+  task and not only the one being run — which each tool's description and plan
+  state and this field does not.
   `scheduled_task_set_enabled` and `automated_task_set_enabled` switch a task
   on or off between them and neither covers the other's kinds: the first takes
   the six that run on a schedule, and the second the init/shutdown scripts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,4 +140,5 @@ export {
   cloudsyncRun,
   automatedTaskSetEnabled,
   snapshotClone,
+  snapshotTaskRun,
 } from '@/tools/index';

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -3,7 +3,7 @@ import { Role } from '@/interfaces';
 import { createDefaultCatalog } from '@/tools/index';
 
 describe('createDefaultCatalog', () => {
-  it('registers the sixty-three sketch tools', () => {
+  it('registers the sixty-four sketch tools', () => {
     expect(createDefaultCatalog().list(Role.Full).map((t) => t.name)).toEqual([
       'system_info',
       'system_update_status',
@@ -68,6 +68,7 @@ describe('createDefaultCatalog', () => {
       'cloudsync_run',
       'automated_task_set_enabled',
       'snapshot_clone',
+      'snapshot_task_run',
     ]);
   });
 
@@ -98,6 +99,12 @@ describe('createDefaultCatalog', () => {
   it('does not advertise snapshot_clone to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
       'snapshot_clone',
+    );
+  });
+
+  it('does not advertise snapshot_task_run to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'snapshot_task_run',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,12 +40,13 @@ import {
   cloudsyncRun,
   cloudsyncTasksList,
   scheduledTaskSetEnabled,
+  snapshotTaskRun,
   snapshotTasksList,
   tasksRecentRuns,
 } from '@/tools/tasks';
 import { vmDevices, vmLogs, vmsList } from '@/tools/vms';
 
-/** The sketch's catalog: fifty-six read-only tools plus seven mutating tools. */
+/** The sketch's catalog: fifty-six read-only tools plus eight mutating tools. */
 export function createDefaultCatalog(): ToolCatalog {
   const catalog = new ToolCatalog();
   catalog.register(systemInfo);
@@ -111,6 +112,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(cloudsyncRun);
   catalog.register(automatedTaskSetEnabled);
   catalog.register(snapshotClone);
+  catalog.register(snapshotTaskRun);
   return catalog;
 }
 
@@ -165,6 +167,7 @@ export {
   sharesList,
   snapshotClone,
   snapshotsList,
+  snapshotTaskRun,
   snapshotTasksList,
   systemDatasetConfig,
   systemGeneralConfig,

--- a/src/tools/snapshot-task-run.spec.ts
+++ b/src/tools/snapshot-task-run.spec.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it, vi } from 'vitest';
+import { concat, EMPTY, NEVER, Observable, of, throwError } from 'rxjs';
+import { Role } from '@/interfaces';
+import { PlanStep, SystemHandle, ToolContext } from '@/catalog/tool';
+import { snapshotTaskRun } from '@/tools/index';
+
+/**
+ * `snapshot_task_run`'s tests live here rather than in `tasks.spec.ts` under
+ * the #87 split trigger, measured rather than felt: `tasks.spec.ts` is 1,352
+ * lines and this block is several hundred more, so the merged file would cross
+ * 1,500 exactly as it did at #121 and at `cloudsync_run`. The four listing
+ * tools stay where they are.
+ *
+ * The fake system is local to this file for the reason `cloudsync-run.spec.ts`
+ * gives about its own: `src/testing/fake-systems.ts` stubs `call` and `query`
+ * from one method→response map, and a job is not one response — it is a stream,
+ * and half of what is tested here is what happens when that stream does NOT
+ * complete. Two callers now exist, which is the point at which a shared job
+ * fixture could be designed from evidence rather than guessed at; promoting it
+ * is a change to `src/testing/` that this ticket did not ask for, and the two
+ * fixtures differ in the method they read and in nothing else.
+ */
+
+/** A periodic snapshot task row as `pool.snapshottask.query` answers with one. */
+const task = {
+  id: 4,
+  dataset: 'tank/media',
+  recursive: true,
+  enabled: true,
+  lifetime_value: 2,
+  lifetime_unit: 'WEEK',
+  schedule: { minute: '0', hour: '2', dom: '*', month: '*', dow: '*' },
+};
+
+/** A second task, to catch a filter that did not apply coming back as the table. */
+const otherTask = { ...task, id: 9, dataset: 'tank/docs' };
+
+/** A job as the client's tracking emits one. */
+const jobAt = (state: string, extra: Record<string, unknown> = {}) => ({
+  id: 77,
+  method: 'pool.snapshottask.run',
+  state,
+  // Null on this method whether the run worked or failed — which is the whole
+  // reason the outcome is read from `state`.
+  result: null,
+  error: null,
+  time_finished: { $date: 1_756_000_000_000 },
+  ...extra,
+});
+
+/**
+ * A system listing `rows` for `pool.snapshottask.query`, correlating a started
+ * job's id through `callAndGetJobId` and following it through `trackJob`.
+ *
+ * Those are the two halves `api.job` pipes together, and the tool uses them
+ * apart so that the id is in hand before anything is read about the job — so
+ * the fake has to be able to move them independently.
+ */
+function jobSystem(
+  options: {
+    rows?: unknown;
+    started?: Observable<number>;
+    job?: Observable<unknown>;
+    queryFails?: unknown;
+  } = {},
+): {
+  ctx: ToolContext;
+  query: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+} {
+  const query = vi.fn(() =>
+    'queryFails' in options ? throwError(() => options.queryFails) : of(options.rows ?? [task]),
+  );
+  const start = vi.fn(() => options.started ?? of(77));
+  const track = vi.fn(() => options.job ?? of(jobAt('SUCCESS')));
+  const system = {
+    name: 'nas',
+    client: { api: { query, callAndGetJobId: start, trackJob: track } },
+  } as unknown as SystemHandle;
+  return { ctx: { system }, query, start, track };
+}
+
+/** The one step the plan returns, typed. */
+const planStep = async (ctx: ToolContext, args: Record<string, unknown>): Promise<PlanStep> => {
+  const steps = await snapshotTaskRun.plan(ctx, args);
+  expect(steps).toHaveLength(1);
+  return steps[0];
+};
+
+/** The plan's description for a task row, which is what most of these read. */
+const planText = async (rows?: unknown): Promise<string> =>
+  (await planStep(jobSystem(rows === undefined ? {} : { rows }).ctx, { id: 4 })).description;
+
+describe('snapshot_task_run', () => {
+  it('is a reversible mutating tool needing the full role', () => {
+    expect(snapshotTaskRun).toMatchObject({
+      name: 'snapshot_task_run',
+      mutating: true,
+      // The task's dataset, recursion, naming schema and retention were all
+      // authored by whoever configured it, and the system does exactly this at
+      // the next window; this tool moves the moment, not the effect.
+      destructiveness: 'reversible',
+      requiredRole: Role.Full,
+    });
+  });
+
+  it('takes the task id and nothing else', () => {
+    const schema = snapshotTaskRun.inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(schema.properties)).toEqual(['id']);
+    expect(schema.required).toEqual(['id']);
+  });
+
+  describe('description', () => {
+    it('says the run applies retention and that the pass is system-wide', () => {
+      // The reading that costs data is "this only takes a snapshot", so both
+      // halves are pinned: that it prunes at all, and that what it prunes is
+      // not limited to the task being run.
+      expect(snapshotTaskRun.description).toContain('IT ALSO APPLIES RETENTION');
+      expect(snapshotTaskRun.description).toContain(
+        'it considers every periodic snapshot task on the system, not only the one being run',
+      );
+    });
+
+    it('points at snapshots_list for what is due to be destroyed, and enumerates nothing', () => {
+      expect(snapshotTaskRun.description).toContain('DOES NOT ENUMERATE WHAT A RUN WILL DESTROY');
+      expect(snapshotTaskRun.description).toContain(
+        'call `snapshots_list` with `report_scheduled_removal`',
+      );
+    });
+
+    it('says the account of the pruning is not something this catalog can check', () => {
+      // The API surface declares nothing about the retention pass, so the
+      // account comes from the TrueNAS implementation — stated, not settled.
+      expect(snapshotTaskRun.description).toContain(
+        'READ FROM THE TRUENAS IMPLEMENTATION AND IS NOT SOMETHING THIS CATALOG CAN CHECK',
+      );
+    });
+
+    it('points at tasks_recent_runs for following a run past the bound', () => {
+      expect(snapshotTaskRun.description).toContain(
+        'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A RUN THAT WAS STILL GOING IS ' +
+          'FOLLOWED UP',
+      );
+    });
+
+    it('says ended false is not one answer and does not partition it', () => {
+      expect(snapshotTaskRun.description).toContain(
+        'FALSE MEANS NOTHING WAS ESTABLISHED AND IS NOT ONE ANSWER',
+      );
+      expect(snapshotTaskRun.description).toContain('DO NOT PARTITION IT');
+    });
+  });
+
+  describe('normalizeArgs', () => {
+    it('keeps the id and drops anything else', () => {
+      expect(snapshotTaskRun.normalizeArgs?.({ id: 4, systems: 'all' })).toEqual({ id: 4 });
+    });
+
+    it.each([
+      ['a missing id', {}],
+      ['an id that is not a number', { id: '4' }],
+      ['an id that is not whole', { id: 4.5 }],
+    ])('rejects %s', (_name, args) => {
+      expect(() => snapshotTaskRun.normalizeArgs?.(args)).toThrow('"id" is required');
+    });
+  });
+
+  describe('plan', () => {
+    it('names one call: the job, with the params it will run with', async () => {
+      const step = await planStep(jobSystem().ctx, { id: 4 });
+      expect(step.method).toBe('pool.snapshottask.run');
+      expect(step.params).toEqual([4]);
+    });
+
+    it('names the task the way snapshot_tasks_list does', async () => {
+      expect(await planText()).toContain(
+        'Run the periodic snapshot task with dataset "tank/media", schedule at 02:00, every ' +
+          'day (id 4) now.',
+      );
+    });
+
+    it('states a dataset the system reported nothing for as exactly that', async () => {
+      expect(await planText([{ id: 4 }])).toContain(
+        'the periodic snapshot task with dataset (the system reported none)',
+      );
+    });
+
+    it('sends an unrenderable schedule to the tool that reports the cron fields', async () => {
+      // Not "the system reported no schedule": a shape this file will not put
+      // into English is a limit of this file rather than a task without one.
+      expect(await planText([{ ...task, schedule: { minute: '*/7', hour: '3' } }])).toContain(
+        'schedule (not rendered in words here; `snapshot_tasks_list` reports its cron fields)',
+      );
+    });
+
+    it('says outright when the run also snapshots the children', async () => {
+      expect(await planText()).toContain('It snapshots that dataset AND ITS CHILDREN.');
+    });
+
+    it('says outright when it does not', async () => {
+      expect(await planText([{ ...task, recursive: false }])).toContain(
+        'It snapshots that dataset only, not its children.',
+      );
+    });
+
+    it('does not read an unreadable recursion as the narrow case', async () => {
+      const text = await planText([{ ...task, recursive: 'yes' }]);
+      expect(text).toContain(
+        "Whether it also snapshots that dataset's children could not be read, so how much of " +
+          'the tree this run snapshots is not established here.',
+      );
+      expect(text).not.toContain('that dataset only');
+    });
+
+    it("states the task's own retention as the listing reports it", async () => {
+      expect(await planText()).toContain(
+        'Its own retention is 2 WEEK, as `snapshot_tasks_list` reports it, so the snapshot ' +
+          'this run takes is destroyed that long after it is taken.',
+      );
+    });
+
+    it.each([
+      ['no value', { ...task, lifetime_value: undefined }],
+      ['no unit', { ...task, lifetime_unit: undefined }],
+      ['a value that is not a number', { ...task, lifetime_value: 'two' }],
+    ])('states rather than omits a retention it could not read: %s', async (_name, row) => {
+      // A value with no unit names no duration, and a unit with no value names
+      // none either — and neither is a task that keeps its snapshots forever.
+      const text = await planText([row]);
+      expect(text).toContain(
+        "This task's own retention could not be read here, so how long the snapshot this run " +
+          'takes will be kept is NOT established',
+      );
+      expect(text).not.toContain('Its own retention is');
+    });
+
+    it('states that the retention pass is system-wide, not this task alone', async () => {
+      const text = await planText();
+      expect(text).toContain('RUNNING THIS DOES NOT ONLY TAKE A SNAPSHOT.');
+      expect(text).toContain(
+        'THAT PASS IS SYSTEM-WIDE: it considers EVERY periodic snapshot task on this system ' +
+          'rather than only the one being run, so snapshots belonging to OTHER tasks whose ' +
+          'retention had already lapsed can be destroyed by this run.',
+      );
+    });
+
+    it('states both protections, which is what bounds the alarm above', async () => {
+      const text = await planText();
+      expect(text).toContain(
+        "a snapshot whose name matches no task's naming schema is skipped entirely, so a " +
+          'snapshot taken by hand — through `snapshots_create` or otherwise — is not at risk',
+      );
+      expect(text).toContain(
+        'the newest snapshot for a naming schema is kept where destroying it would leave that ' +
+          'schema with none',
+      );
+    });
+
+    it('refuses to say which snapshots go, and points at where that is reported', async () => {
+      expect(await planText()).toContain(
+        'THIS PLAN DOES NOT SAY WHICH SNAPSHOTS WILL BE DESTROYED and this tool does not ' +
+          'compute it: call `snapshots_list` with `report_scheduled_removal` first, which ' +
+          'reports the removal the middleware itself works out per snapshot.',
+      );
+    });
+
+    it('says the job is followed for a bounded time and then left running', async () => {
+      const text = await planText();
+      expect(text).toContain('for at most 30 seconds');
+      expect(text).toContain('The run continues after that whether or not it has finished.');
+      // The client's tracking read is named in the step rather than being a
+      // step of its own: its params are not knowable until the job exists.
+      expect(text).toContain('core.get_jobs');
+    });
+
+    it('says the task was enabled when the plan was made', async () => {
+      expect(await planText()).toContain('The task was enabled when this plan was made.');
+    });
+
+    it('fails, naming the task and the tool that switches it on, where it is disabled', async () => {
+      const { ctx } = jobSystem({ rows: [{ ...task, enabled: false }] });
+      await expect(snapshotTaskRun.plan(ctx, { id: 4 })).rejects.toThrow(
+        'The periodic snapshot task with id 4 on this system is disabled, and the middleware ' +
+          'refuses to run a disabled task — switch it on with `scheduled_task_set_enabled` ' +
+          'with `kind` `periodic_snapshot` first',
+      );
+    });
+
+    it.each([
+      ['a missing enabled', { ...task, enabled: undefined }],
+      ['an enabled that is not a boolean', { ...task, enabled: 'yes' }],
+    ])('does not read %s as a disabled task, and says the call may be refused', async (_n, row) => {
+      // `enabled: false` is a positive claim and null is not, so failing on an
+      // unreadable one would refuse a plan the middleware would have accepted.
+      expect(await planText([row])).toContain(
+        'Whether the task is enabled could not be read, and the middleware REFUSES to run a ' +
+          'disabled task — so this call may be rejected; `scheduled_task_set_enabled` with ' +
+          '`kind` `periodic_snapshot` is what switches one on.',
+      );
+    });
+
+    it('filters the read by id', async () => {
+      const { ctx, query } = jobSystem();
+      await planStep(ctx, { id: 4 });
+      expect(query).toHaveBeenCalledWith('pool.snapshottask.query', [['id', '=', 4]]);
+    });
+
+    it('finds the task by id in the response, never by taking the first row', async () => {
+      // What a filter that was dropped rather than refused comes back as — and
+      // the first row of it is a different task, on a different dataset.
+      expect(await planText([otherTask, task])).toContain('dataset "tank/media"');
+    });
+
+    it('fails when the read lists no task with that id, naming the listing tool', async () => {
+      const { ctx } = jobSystem({ rows: [otherTask] });
+      await expect(snapshotTaskRun.plan(ctx, { id: 4 })).rejects.toThrow(
+        'No periodic snapshot task with id 4 on this system — the ids this tool takes come ' +
+          'from `snapshot_tasks_list`',
+      );
+    });
+
+    it('fails when the read answers with something that is not a list', async () => {
+      const { ctx } = jobSystem({ rows: { id: 4 } });
+      await expect(snapshotTaskRun.plan(ctx, { id: 4 })).rejects.toThrow(
+        'No periodic snapshot task with id 4',
+      );
+    });
+
+    it('starts nothing', async () => {
+      const { ctx, start } = jobSystem();
+      await planStep(ctx, { id: 4 });
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it('lets a failed read fail the plan, since nothing has been approved yet', async () => {
+      const { ctx } = jobSystem({ queryFails: new Error('middleware is down') });
+      await expect(snapshotTaskRun.plan(ctx, { id: 4 })).rejects.toThrow('middleware is down');
+    });
+
+    it('rejects arguments it cannot read before making any call', async () => {
+      const { ctx, query } = jobSystem();
+      await expect(snapshotTaskRun.plan(ctx, { id: 'four' })).rejects.toThrow('"id" is required');
+      expect(query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('execute', () => {
+    it('starts the job through the job surface, with the params the plan named', async () => {
+      const { ctx, start, track } = jobSystem();
+      await snapshotTaskRun.execute(ctx, { id: 4 });
+      expect(start).toHaveBeenCalledWith('pool.snapshottask.run', [4]);
+      // And follows the job the client correlated, rather than one it named.
+      expect(track).toHaveBeenCalledWith(77);
+    });
+
+    it('re-reads nothing: the plan-time read is not repeated', async () => {
+      // Which is also why a task disabled between the plan and the
+      // confirmation is refused by the middleware rather than here.
+      const { ctx, query } = jobSystem();
+      await snapshotTaskRun.execute(ctx, { id: 4 });
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('reports a run that succeeded, with its id and the bound that applied', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('RUNNING'), jobAt('SUCCESS')) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toEqual({
+        task_id: 4,
+        job_id: 77,
+        watched_seconds: 30,
+        ended: true,
+        succeeded: true,
+        state: 'SUCCESS',
+        error: null,
+        finished_at: '2025-08-24T01:46:40.000Z',
+      });
+    });
+
+    it('counts FINISHED as success, as the rest of this family does', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('FINISHED')) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({ succeeded: true });
+    });
+
+    it('reports a failed job as a failure from its state, never from a null result', async () => {
+      const { ctx } = jobSystem({
+        job: of(jobAt('FAILED', { error: 'dataset is locked' })),
+      });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: false,
+        state: 'FAILED',
+        error: 'dataset is locked',
+      });
+    });
+
+    // The tracking completing on a state neither this file nor the pinned
+    // client calls terminal is a stream that client CANNOT currently produce:
+    // its `terminalStates` holds the same five as `ENDED_JOB_STATES`. What this
+    // fixture models is a client release that widens that set — the one case
+    // where the two lists come apart — and it is written as a test because both
+    // fields have to stay honest when it happens.
+    it('reads a terminal state neither list names as ended and not as a success', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUPERSEDED')) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: false,
+        state: 'SUPERSEDED',
+        // And the finish time follows `ended`. Reading `ENDED_JOB_STATES` here
+        // instead would have one result call the run over and refuse to say
+        // when it ended.
+        finished_at: '2025-08-24T01:46:40.000Z',
+      });
+    });
+
+    it('reports no finish time for an ended job that recorded none it can read', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { time_finished: 'yesterday' })) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        ended: true,
+        succeeded: true,
+        finished_at: null,
+      });
+    });
+
+    it('reports no error text where the job recorded none, and none for an empty string', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('FAILED', { error: '' })) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({ error: null });
+    });
+
+    it('reports a run still going when the watch runs out, and leaves it going', async () => {
+      vi.useFakeTimers();
+      try {
+        const { ctx } = jobSystem({ job: concat(of(jobAt('RUNNING')), NEVER) });
+        const pending = snapshotTaskRun.execute(ctx, { id: 4 });
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(await pending).toMatchObject({
+          job_id: 77,
+          ended: false,
+          // Still going is neither a success nor a failure.
+          succeeded: null,
+          state: 'RUNNING',
+          // The record carries a time and it is still not a finish time: a run
+          // that was not established to be over was not established to have
+          // ended then.
+          finished_at: null,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('establishes nothing from a job it never saw, and does not call that a failure', async () => {
+      // No job event named the request, so there is no id and nothing to track.
+      const { ctx, track } = jobSystem({ started: EMPTY });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: null,
+        ended: false,
+        succeeded: null,
+        state: null,
+        error: null,
+        finished_at: null,
+      });
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('keeps the id of a job the client named and then reported nothing about', async () => {
+      // The event correlated the id — the run IS going — and the tracking said
+      // nothing readable. `ended` is false and the caller still gets the one
+      // thing that can name the run.
+      const { ctx } = jobSystem({ job: EMPTY });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
+      });
+    });
+
+    it('establishes nothing from an emission carrying no readable state', async () => {
+      const { ctx } = jobSystem({ job: of(jobAt('SUCCESS', { state: 42 })) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
+      });
+    });
+
+    it('reports no job id where the event carried none this tool can read', async () => {
+      // The client declares the id a number; a declared type is a claim about
+      // what is sent rather than about the value received.
+      const { ctx } = jobSystem({ started: of('seventy-seven' as unknown as number) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: null,
+        succeeded: true,
+      });
+    });
+
+    it('lets a rejected call fail, since there is then no run to report on', async () => {
+      const { ctx } = jobSystem({ started: throwError(() => new Error('not authorised')) });
+      await expect(snapshotTaskRun.execute(ctx, { id: 4 })).rejects.toThrow('not authorised');
+    });
+
+    it('does not fail the call when the FOLLOW-UP READ fails before it reports anything', async () => {
+      // `trackJob` starts by dispatching `core.get_jobs`, which can fail on its
+      // own — after the event correlated the id, so the run is going. Through
+      // `api.job` this would reject with nothing: the id is consumed inside
+      // that method's `switchMap` and never reaches the tool.
+      const { ctx } = jobSystem({ job: throwError(() => new Error('core.get_jobs failed')) });
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: null,
+      });
+    });
+
+    it('keeps the job id when following the job fails after it has been seen', async () => {
+      const { ctx } = jobSystem({
+        job: concat(of(jobAt('RUNNING')), throwError(() => new Error('connection dropped'))),
+      });
+      // The run is going and this is the only call that ever knew its id, so
+      // rejecting here would tell the caller the mutation failed and lose the
+      // one thing that could still name the run.
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        job_id: 77,
+        ended: false,
+        succeeded: null,
+        state: 'RUNNING',
+        finished_at: null,
+      });
+    });
+
+    it('does not report a job as ended because following it stopped', async () => {
+      const { ctx } = jobSystem({
+        job: concat(of(jobAt('SUCCESS')), throwError(() => new Error('connection dropped'))),
+      });
+      // The state read is SUCCESS and the stream did not complete, so nothing
+      // established that the run is over — `ended` is what says so and it is
+      // false, which is what keeps `succeeded` from being read off a state the
+      // job may still move out of.
+      expect(await snapshotTaskRun.execute(ctx, { id: 4 })).toMatchObject({
+        state: 'SUCCESS',
+        ended: false,
+        succeeded: null,
+        finished_at: null,
+      });
+    });
+
+    it('rejects arguments it cannot read before making any call', async () => {
+      const { ctx, start } = jobSystem();
+      await expect(snapshotTaskRun.execute(ctx, { id: 'four' })).rejects.toThrow(
+        '"id" is required',
+      );
+      expect(start).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tools/snapshot-task-run.spec.ts
+++ b/src/tools/snapshot-task-run.spec.ts
@@ -125,6 +125,16 @@ describe('snapshot_task_run', () => {
       );
     });
 
+    it('keeps the naming-schema protection about the name rather than about the taker', () => {
+      // Pinned in both texts a reader can reach, because either one alone
+      // saying "a snapshot you took is safe" is the reassurance that costs
+      // data — `snapshots_create` takes the name from the caller.
+      expect(snapshotTaskRun.description).toContain(
+        'WHICH IS A FACT ABOUT THE NAME AND NOT ABOUT WHO TOOK THE SNAPSHOT',
+      );
+      expect(snapshotTaskRun.description).not.toContain('is not at risk');
+    });
+
     it('points at snapshots_list for what is due to be destroyed, and enumerates nothing', () => {
       expect(snapshotTaskRun.description).toContain('DOES NOT ENUMERATE WHAT A RUN WILL DESTROY');
       expect(snapshotTaskRun.description).toContain(
@@ -251,13 +261,27 @@ describe('snapshot_task_run', () => {
     it('states both protections, which is what bounds the alarm above', async () => {
       const text = await planText();
       expect(text).toContain(
-        "a snapshot whose name matches no task's naming schema is skipped entirely, so a " +
-          'snapshot taken by hand — through `snapshots_create` or otherwise — is not at risk',
+        "a snapshot whose name matches no task's naming schema is skipped entirely",
       );
       expect(text).toContain(
         'the newest snapshot for a naming schema is kept where destroying it would leave that ' +
           'schema with none',
       );
+    });
+
+    // The name is the whole of the first protection, and a plan that turned it
+    // into "a snapshot you took yourself is safe" would reassure the approver
+    // about the one case that is not: `snapshots_create` takes the name from
+    // the caller and checks it against no task's schema.
+    it('does not read the naming-schema protection as being about who took the snapshot', async () => {
+      const text = await planText();
+      expect(text).toContain(
+        'which is a fact about the NAME and not about who took the snapshot, so a snapshot ' +
+          'taken by hand through `snapshots_create` or otherwise is outside this pass ONLY ' +
+          "where the name it was given matches no task's schema, and NOTHING IN THIS CATALOG " +
+          'CHECKS THAT',
+      );
+      expect(text).not.toContain('is not at risk');
     });
 
     it('refuses to say which snapshots go, and points at where that is reported', async () => {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2893,8 +2893,10 @@ const RETENTION_PASS =
   'snapshot task on this system rather than only the one being run, so snapshots belonging ' +
   'to OTHER tasks whose retention had already lapsed can be destroyed by this run. Two ' +
   "things it leaves alone: a snapshot whose name matches no task's naming schema is skipped " +
-  'entirely, so a snapshot taken by hand — through `snapshots_create` or otherwise — is not ' +
-  'at risk; and the newest snapshot for a naming schema is kept where destroying it would ' +
+  'entirely — which is a fact about the NAME and not about who took the snapshot, so a ' +
+  'snapshot taken by hand through `snapshots_create` or otherwise is outside this pass ONLY ' +
+  "where the name it was given matches no task's schema, and NOTHING IN THIS CATALOG CHECKS " +
+  'THAT; and the newest snapshot for a naming schema is kept where destroying it would ' +
   'leave that schema with none. THIS PLAN DOES NOT SAY WHICH SNAPSHOTS WILL BE DESTROYED ' +
   'and this tool does not compute it: call `snapshots_list` with `report_scheduled_removal` ' +
   'first, which reports the removal the middleware itself works out per snapshot.';
@@ -2916,10 +2918,13 @@ export const snapshotTaskRun: MutatingTool = {
     'SYSTEM-WIDE: it considers every periodic snapshot task on the system, not ' +
     'only the one being run, so snapshots owned by OTHER tasks whose retention ' +
     'had lapsed can be destroyed by this call. Two things it leaves alone: a ' +
-    "snapshot whose name matches no task's naming schema is skipped entirely, " +
-    'so a snapshot taken by hand is not at risk, and the newest snapshot for a ' +
-    'naming schema is kept where destroying it would leave that schema with ' +
-    'none. THIS TOOL DOES NOT ENUMERATE WHAT A RUN WILL DESTROY AND MUST NOT ' +
+    "snapshot whose name matches no task's naming schema is skipped entirely " +
+    '— WHICH IS A FACT ABOUT THE NAME AND NOT ABOUT WHO TOOK THE SNAPSHOT, so ' +
+    'a snapshot taken by hand through `snapshots_create` is outside this pass ' +
+    "ONLY where the name it was given matches no task's schema, and NOTHING " +
+    'HERE CHECKS THAT — and the newest snapshot for a naming schema is kept ' +
+    'where destroying it would leave that schema with none. THIS TOOL DOES ' +
+    'NOT ENUMERATE WHAT A RUN WILL DESTROY AND MUST NOT ' +
     'BE READ AS HAVING CHECKED: call `snapshots_list` with ' +
     '`report_scheduled_removal` beforehand, which reports the removal the ' +
     'middleware itself computes per snapshot. THAT WHOLE ACCOUNT OF THE ' +

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -65,6 +65,12 @@ import {
  * scheduled, so `scheduled_task_set_enabled`'s name cannot carry it. The two
  * together are what makes every `enabled` in this family's listings actionable;
  * neither name covers what the other does, and each description says so.
+ *
+ * `snapshot_task_run` is the fourth, and it is `cloudsync_run` for the family's
+ * other job-backed kind: it starts one of the tasks `snapshot_tasks_list`
+ * reports and names it in that listing's terms. What is not `cloudsync_run` is
+ * the plan, because a periodic snapshot run also applies retention, and the
+ * retention it applies is the system's rather than the task's.
  */
 
 /**
@@ -1458,15 +1464,21 @@ const NONE_REPORTED = '(the system reported none)';
  * pointer: it reads as the exact account being one call away, and the approver
  * who makes that call finds no such field and cannot tell a tool that omits it
  * from a task that has none.
+ *
+ * It takes the pointer rather than the whole {@link TaskKind} so that
+ * {@link snapshotTaskRun}, which has no `TaskKind` to hand, renders this
+ * sentence through the same function instead of writing a second account of it.
+ * Two spellings of "the schedule could not be put into words" in one file is
+ * exactly the drift `common.ts` was cut to stop, one level down.
  */
-function schedulePhrase(spec: TaskKind, row: Record<string, unknown>): string {
+function schedulePhrase(cronFieldsListedBy: string | null, row: Record<string, unknown>): string {
   const schedule = taskSchedule(row);
   const words = schedule === null ? null : describeSchedule(schedule);
   if (words !== null) return `schedule ${words}`;
   return `schedule ${
-    spec.cronFieldsListedBy === null
+    cronFieldsListedBy === null
       ? '(not rendered in words here, and no tool in this catalog reports its cron fields)'
-      : `(not rendered in words here; \`${spec.cronFieldsListedBy}\` reports its cron fields)`
+      : `(not rendered in words here; \`${cronFieldsListedBy}\` reports its cron fields)`
   }`;
 }
 
@@ -1482,7 +1494,7 @@ function describeTask(spec: TaskKind, row: Record<string, unknown>, id: number):
   const labelled = spec
     .label(row)
     .map(([name, value]) => `${name} ${value === null ? NONE_REPORTED : `"${value}"`}`);
-  return `the ${spec.noun} with ${[...labelled, schedulePhrase(spec, row)].join(', ')} (id ${id})`;
+  return `the ${spec.noun} with ${[...labelled, schedulePhrase(spec.cronFieldsListedBy, row)].join(', ')} (id ${id})`;
 }
 
 /**
@@ -2682,6 +2694,441 @@ export const automatedTaskSetEnabled: MutatingTool = {
         id,
         enabled,
       )),
+    };
+  },
+};
+
+/**
+ * `snapshot_task_run`: taking one periodic snapshot task's snapshot now, and
+ * the catalog's SECOND job-backed tool.
+ *
+ * THE JOB SHAPE IS {@link cloudsyncRun}'S AND IS COPIED RATHER THAN REDERIVED.
+ * `callAndGetJobId` and `trackJob` are called apart rather than through
+ * `api.job`, so the two failure eras stay separable; the watch is bounded and
+ * ending it does not end the job; `ended` is read from the tracking COMPLETING
+ * rather than from {@link ENDED_JOB_STATES}; `job_id` comes from the
+ * correlation and never from the tracking's last emission. Every reason for
+ * every one of those is written out at {@link cloudsyncRun} and in
+ * `CLAUDE.md`'s #122 decision, and none of them is re-argued here — what is
+ * written below is only what this tool has to decide for itself.
+ *
+ * WHAT IT HAS TO DECIDE FOR ITSELF IS THE PLAN, because a run of a periodic
+ * snapshot task PRUNES. `pool.snapshottask.run` does not stop at creating a
+ * snapshot: it interrupts zettarepl's scheduler with the task, which then goes
+ * round the same loop a scheduled fire goes round, ending in the retention
+ * pass. So a plan reading "this takes a snapshot now" would be a plan that
+ * omits a deletion — {@link transferModeSentence}'s defect in a second family,
+ * and the one reading that costs data.
+ *
+ * AND THE BLAST RADIUS IS WIDER THAN THE TASK NAMED. That retention pass builds
+ * its owners from every periodic snapshot task on the system, so running task A
+ * can destroy snapshots owned by task B whose retention had lapsed and whose
+ * own tick had not yet come round. The plan states the SCOPE, in those words.
+ *
+ * IT STILL DOES NOT SAY WHICH SNAPSHOTS. Two reasons, and they are different
+ * from each other. The middleware already computes that per snapshot, with the
+ * same owner-class retention the pass itself uses, and `snapshots_list` reports
+ * it as `scheduled_removal` — re-deriving it here would be the drifting second
+ * opinion composites exist to prevent (#44). And it could not be done soundly
+ * from this side anyway: that listing is bounded, and its own description says a
+ * truncated list cannot show a snapshot is absent. So this tool names the
+ * mechanism and its scope and POINTS, which is {@link TRANSFER_MODE_EFFECT}'s
+ * posture — say what the operation does, do not compute the outcome.
+ *
+ * THE ACCOUNT OF THE PRUNING IS NOT READ OFF THE API SURFACE, and that is
+ * stated in the description rather than glossed. Nothing the client declares
+ * says a run applies retention, says it applies system-wide, or says which
+ * snapshots survive; the account comes from the TrueNAS implementation. It is
+ * the strongest true thing this tool can tell a person before they approve, and
+ * it is not a normalization this repository can check — the same shape as
+ * `system_ntp_status` saying outright that the measured half of its question is
+ * not on this surface (#133).
+ *
+ * A DISABLED TASK IS REFUSED BY THE MIDDLEWARE, so the plan reads `enabled` and
+ * fails at plan time naming the task, rather than letting a raw rejection reach
+ * the caller at execute time. `enabled: false` is a positive claim and null is
+ * not, so ONLY AN EXPLICIT FALSE FAILS: a task whose switch could not be read is
+ * not a task that is off, and the plan says exactly that instead of guessing —
+ * `snapshot_tasks_list`'s own reading of the same field.
+ */
+
+/**
+ * How long {@link snapshotTaskRun} watches the job it started before reporting
+ * what it has and returning.
+ *
+ * ITS OWN NUMBER RATHER THAN {@link SYNC_WATCH_MS}, although the two are equal.
+ * The bound is a ceiling on a TOOL's patience and not an estimate of its job
+ * (#122), so sharing one constant between two tools would assert that the two
+ * ceilings must move together, which nothing here requires. Both are chosen to
+ * sit comfortably inside the shortest MCP host timeout in ordinary use, and the
+ * host's own deadline is not readable from here — `src/interfaces.ts` is the
+ * whole environment boundary and carries none.
+ */
+const SNAPSHOT_RUN_WATCH_MS = 30_000;
+
+/** Seconds, for the result, so the bound is reported in the unit it is stated in. */
+const SNAPSHOT_RUN_WATCH_SECONDS = SNAPSHOT_RUN_WATCH_MS / 1000;
+
+/** Where the ids this tool takes come from, in the one wording used throughout. */
+const SNAPSHOT_TASK_IDS_FROM = 'the ids this tool takes come from `snapshot_tasks_list`';
+
+/** The tool that switches a periodic snapshot task on, named the one way. */
+const SNAPSHOT_TASK_SWITCH = '`scheduled_task_set_enabled` with `kind` `periodic_snapshot`';
+
+/**
+ * The one argument this tool takes, or the error naming what is wrong with it.
+ *
+ * Strict for {@link parseRun}'s reason: the middleware holds these tasks under
+ * integer primary keys, and a coerced `"4"` or a `4.5` names no task.
+ */
+function parseSnapshotTaskId(args: Record<string, unknown>): number {
+  const id = args['id'];
+  if (typeof id !== 'number' || !Number.isInteger(id)) {
+    throw new Error('"id" is required and must be a whole number');
+  }
+  return id;
+}
+
+/**
+ * The params the job is started with, typed off the job directory — a disjoint
+ * key space from the call directory, so `CallParams` cannot name them.
+ */
+function snapshotRunParams(id: number): JobParams<ApiSurface, 'pool.snapshottask.run'> {
+  return [id];
+}
+
+/**
+ * The task in the terms `snapshot_tasks_list` reports it, for the human
+ * approving the plan.
+ *
+ * The dataset and the schedule are what make the approval meaningful — "run
+ * periodic snapshot task 4" says nothing about what is about to be snapshotted
+ * or how often the system does it unasked. The schedule goes through
+ * {@link schedulePhrase} so that a shape this file will not put into English
+ * reads as that rather than as a task without a schedule.
+ */
+function describePeriodicSnapshotTask(task: Record<string, unknown>, id: number): string {
+  const dataset = textOrNull(task['dataset']);
+  return `the periodic snapshot task with dataset ${
+    dataset === null ? NONE_REPORTED : `"${dataset}"`
+  }, ${schedulePhrase('snapshot_tasks_list', task)} (id ${id})`;
+}
+
+/**
+ * How much of the tree this run snapshots, or that it could not be read.
+ *
+ * Not defaulted to the narrow reading. An approver told nothing reads the
+ * silence as "just that dataset", and a recursive task on a pool root is the
+ * case where that assumption is most wrong — the same refusal
+ * {@link transferModeSentence} makes about a mode it cannot read.
+ */
+function recursionSentence(task: Record<string, unknown>): string {
+  const recursive = booleanOrNull(task['recursive']);
+  if (recursive === null) {
+    return (
+      "Whether it also snapshots that dataset's children could not be read, so how much of " +
+      'the tree this run snapshots is not established here.'
+    );
+  }
+  return recursive
+    ? "It snapshots that dataset AND ITS CHILDREN."
+    : 'It snapshots that dataset only, not its children.';
+}
+
+/**
+ * How long this task's own snapshots are kept, or that the retention could not
+ * be read.
+ *
+ * A task whose retention is unreadable is NOT a task that keeps its snapshots
+ * forever, and the sentence says so — the reading `snapshot_tasks_list` already
+ * spells out for the same two fields. Both are needed: a value with no unit
+ * names no duration, and a unit with no value names no duration either.
+ */
+function retentionSentence(task: Record<string, unknown>): string {
+  const value = numberOrNull(task['lifetime_value']);
+  const unit = textOrNull(task['lifetime_unit']);
+  if (value === null || unit === null) {
+    return (
+      "This task's own retention could not be read here, so how long the snapshot this run " +
+      'takes will be kept is NOT established — which is a gap in this reading rather than a ' +
+      'task that keeps its snapshots forever.'
+    );
+  }
+  return (
+    `Its own retention is ${value} ${unit}, as \`snapshot_tasks_list\` reports it, so the ` +
+    'snapshot this run takes is destroyed that long after it is taken.'
+  );
+}
+
+/**
+ * What the plan says about the switch, given that an explicit `false` has
+ * already failed the plan.
+ *
+ * So there are two cases here and not three: read as enabled, or not read at
+ * all. The second is stated as the rejection it may become rather than as a
+ * task that is fine — the middleware refuses a disabled task, and this tool
+ * cannot tell whether it is about to be refused.
+ */
+function snapshotTaskEnabledSentence(task: Record<string, unknown>): string {
+  return booleanOrNull(task['enabled']) === null
+    ? 'Whether the task is enabled could not be read, and the middleware REFUSES to run a ' +
+        `disabled task — so this call may be rejected; ${SNAPSHOT_TASK_SWITCH} is what ` +
+        'switches one on.'
+    : 'The task was enabled when this plan was made.';
+}
+
+/**
+ * What the run does beyond taking a snapshot, in the plan's own words.
+ *
+ * One string because it is one text: it says the same thing whatever the task
+ * is, and every clause in it is load-bearing. The scope sentence is what stops
+ * an approver reading "retention" as "this task's old snapshots"; the two
+ * protections are what stop the scope sentence reading as "anything may go";
+ * and the pointer is what a caller does instead of asking this tool to
+ * enumerate, which it must not.
+ */
+const RETENTION_PASS =
+  'RUNNING THIS DOES NOT ONLY TAKE A SNAPSHOT. The run ends in the same retention pass a ' +
+  'scheduled fire ends in, and THAT PASS IS SYSTEM-WIDE: it considers EVERY periodic ' +
+  'snapshot task on this system rather than only the one being run, so snapshots belonging ' +
+  'to OTHER tasks whose retention had already lapsed can be destroyed by this run. Two ' +
+  "things it leaves alone: a snapshot whose name matches no task's naming schema is skipped " +
+  'entirely, so a snapshot taken by hand — through `snapshots_create` or otherwise — is not ' +
+  'at risk; and the newest snapshot for a naming schema is kept where destroying it would ' +
+  'leave that schema with none. THIS PLAN DOES NOT SAY WHICH SNAPSHOTS WILL BE DESTROYED ' +
+  'and this tool does not compute it: call `snapshots_list` with `report_scheduled_removal` ' +
+  'first, which reports the removal the middleware itself works out per snapshot.';
+
+export const snapshotTaskRun: MutatingTool = {
+  name: 'snapshot_task_run',
+  description:
+    'Runs one periodic snapshot task on this TrueNAS system now, without ' +
+    'waiting for its schedule, and reports how far it got. Two-phase: called ' +
+    'without a confirmation_token it returns a plan for user approval; called ' +
+    "with one it starts the run. `id` is the task's `id` as " +
+    '`snapshot_tasks_list` reports it, on the system being targeted, and ' +
+    'PLANNING AGAINST AN id NO PERIODIC SNAPSHOT TASK HAS FAILS naming that id ' +
+    '— so an approved plan is always about a task that existed when it was ' +
+    'made. The plan names the task the way that listing does: its dataset, ' +
+    "whether it recurses into that dataset's children, its schedule in words, " +
+    'and its retention. THIS RUN DOES NOT ONLY TAKE A SNAPSHOT — IT ALSO ' +
+    'APPLIES RETENTION, WHICH DESTROYS SNAPSHOTS, AND THE RETENTION PASS IS ' +
+    'SYSTEM-WIDE: it considers every periodic snapshot task on the system, not ' +
+    'only the one being run, so snapshots owned by OTHER tasks whose retention ' +
+    'had lapsed can be destroyed by this call. Two things it leaves alone: a ' +
+    "snapshot whose name matches no task's naming schema is skipped entirely, " +
+    'so a snapshot taken by hand is not at risk, and the newest snapshot for a ' +
+    'naming schema is kept where destroying it would leave that schema with ' +
+    'none. THIS TOOL DOES NOT ENUMERATE WHAT A RUN WILL DESTROY AND MUST NOT ' +
+    'BE READ AS HAVING CHECKED: call `snapshots_list` with ' +
+    '`report_scheduled_removal` beforehand, which reports the removal the ' +
+    'middleware itself computes per snapshot. THAT WHOLE ACCOUNT OF THE ' +
+    'PRUNING IS READ FROM THE TRUENAS IMPLEMENTATION AND IS NOT SOMETHING THIS ' +
+    'CATALOG CAN CHECK: nothing the API surface declares says a run applies ' +
+    'retention, says it applies system-wide, or says which snapshots survive, ' +
+    'so this tool states the mechanism and its scope and reports nothing about ' +
+    'the outcome. A DISABLED TASK IS REFUSED BY THE MIDDLEWARE, so the plan ' +
+    'reads `enabled` and FAILS AT PLAN TIME, naming the task, where the task ' +
+    'is switched off — `scheduled_task_set_enabled` with `kind` ' +
+    '`periodic_snapshot` is what switches one back on. That check is made when ' +
+    'the plan is made and IS NOT REPEATED at execute time, so a task disabled ' +
+    'between the plan and the confirmation is rejected by the middleware ' +
+    'instead; and a task whose `enabled` could not be READ is not a task that ' +
+    'is off, so the plan says so and proceeds rather than guessing. THE RESULT ' +
+    'IS ABOUT THE JOB THIS CALL STARTED, AND "STARTED" IS NOT "SUCCEEDED". ' +
+    'Taking the snapshot is ordinarily quick and the retention pass behind it ' +
+    'need not be, so this tool WATCHES THE JOB FOR AT MOST `watched_seconds` ' +
+    'AND THEN RETURNS WHATEVER IT HAS, leaving the run going. It never waits ' +
+    'for the run to finish. THE WATCH ALSO ENDS IF FOLLOWING THE JOB FAILS — a ' +
+    'dropped connection, a failed read of the job list — and that is reported ' +
+    'as what was established rather than as the run having failed, since it ' +
+    'was already under way. A failure BEFORE anything was seen of the job ' +
+    'fails this call instead, and even then MAY STILL HAVE STARTED THE RUN: ' +
+    'check `tasks_recent_runs` rather than assuming nothing ran. `ended` is ' +
+    'whether the job was ESTABLISHED to have reached a state it will not move ' +
+    'out of. TRUE MEANS THE RUN IS OVER. FALSE MEANS NOTHING WAS ESTABLISHED ' +
+    'AND IS NOT ONE ANSWER — the run is still going, or the watch was cut ' +
+    'short by either of the failures above, or the job reached a state the ' +
+    'system does not treat as ending a run and so may or may not be over, or ' +
+    'the job reported a state this tool could not read, or no job was seen at ' +
+    'all. `state` and `job_id` narrow that and DO NOT PARTITION IT: a non-null ' +
+    '`state` beside `ended: false` is any of the first three and this tool ' +
+    'cannot say which, a null `state` beside a `job_id` is a job the system ' +
+    'NAMED and then said nothing readable about — following it failed, or the ' +
+    'watch ran out before anything came back, or the state it reported could ' +
+    'not be read, and this tool cannot say which of those either — and both ' +
+    'null is a job no event named within the watch OR one whose id was ' +
+    'unreadable and whose state was too. IN NONE OF THEM HAS ANYTHING FAILED, ' +
+    'AND IN NONE OF THEM HAS THE RETENTION PASS BEEN SHOWN NOT TO HAVE RUN. ' +
+    '`succeeded` is the answer to "did it work": true where the run ENDED in a ' +
+    'state this catalog reads as success, false where it ENDED in any other ' +
+    'state, and NULL WHERE NOTHING ESTABLISHED IT — which is every case above ' +
+    'where `ended` is false. A null `succeeded` IS NOT A FAILURE AND IS NOT A ' +
+    'SUCCESS, and A STATE THAT LOOKS LIKE A SUCCESS DOES NOT MAKE ONE: ' +
+    '`succeeded` is null beside a `state` of `SUCCESS` where the run was not ' +
+    'established to be over, since a job can still move out of a state this ' +
+    'tool merely saw. NO STATE THIS CATALOG DOES NOT KNOW IS EVER READ AS A ' +
+    'SUCCESS, whether the run ended in it or the watch ended without the run ' +
+    'ending — so a state a later TrueNAS release adds reports as itself and ' +
+    'never as a success. `state` is the state the system last reported, passed ' +
+    'through as the system spelled it and null where none was read; `SUCCESS` ' +
+    "and `FINISHED` are the two this tool counts as success. The job's " +
+    '`result` is NOT read and could not settle any of this: ' +
+    '`pool.snapshottask.run` returns nothing, so a finished job carries a null ' +
+    'result whether it worked or failed. `error` is the text the job recorded ' +
+    'and is null where it recorded none, so a job that ended without ' +
+    'succeeding and with a null `error` failed for a reason the system did not ' +
+    'record — it has not succeeded. `finished_at` is when the job ended, as an ' +
+    'ISO 8601 UTC timestamp, REPORTED ONLY WHERE `ended` IS TRUE — so it moves ' +
+    'with `ended` and never contradicts it — and NULL EVERYWHERE ELSE EVEN IF ' +
+    'THE JOB RECORD CARRIES A TIME, since a run that was not established to be ' +
+    'over has not been established to have ended then. It is also null where ' +
+    "the job ended and recorded no time this tool could read. `job_id` is the " +
+    "job's numeric identity, TAKEN FROM THE JOB EVENT THAT NAMED THIS REQUEST " +
+    'rather than from anything read about the job afterwards — so it is ' +
+    'reported even where the watch established nothing else at all — and it ' +
+    'MATCHES `id` IN `tasks_recent_runs`, WHICH IS HOW A RUN THAT WAS STILL ' +
+    'GOING IS FOLLOWED UP — this tool reports no progress percentage and no ' +
+    'live status, and that tool reports both. `job_id` is null where no job ' +
+    'event named the job within the watch, and ALSO where such an event was ' +
+    'seen and the id it carried was not a number this tool could read — so a ' +
+    'null `job_id` beside a non-null `state` is the second of those. NEITHER ' +
+    'MEANS THE RUN DID NOT START: the call was made, and `tasks_recent_runs` ' +
+    'will report it. `task_id` is the `id` that was asked for and ' +
+    '`watched_seconds` the CEILING that applied to the watch, not how long it ' +
+    'actually lasted — a run that ended in two seconds still reports the full ' +
+    'bound. THIS TOOL CANNOT STOP A RUNNING JOB, cannot create, change or ' +
+    'delete a task, cannot snapshot anything that is not already a task on the ' +
+    'system, and CANNOT UNDO THE RETENTION THE RUN APPLIES — a destroyed ' +
+    'snapshot stays destroyed. Running the task again takes another snapshot; ' +
+    'it does not bring one back.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer',
+        description:
+          "The periodic snapshot task's `id` as `snapshot_tasks_list` reports " +
+          'it, on the system being targeted.',
+      },
+    },
+    required: ['id'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  // THIS TOOL TRIGGERS AN OPERATION IT DOES NOT AUTHOR, which is the case
+  // `Destructiveness` names at its own declaration in `catalog/tool.ts` and the
+  // same reading {@link cloudsyncRun} takes. The dataset, the recursion, the
+  // naming schema and the retention were all decided by whoever configured the
+  // task, and the system does exactly this on its own at the next scheduled
+  // window; what this changes is WHEN, not WHAT. The account of what the run
+  // does to the data — including that its retention pass destroys snapshots
+  // across every task on the system — is in the description above and in the
+  // plan, which is where the person approving reads it, and where that
+  // declaration says it belongs.
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    return { id: parseSnapshotTaskId(rawArgs) };
+  },
+  async plan(ctx, rawArgs): Promise<PlanStep[]> {
+    const id = parseSnapshotTaskId(rawArgs);
+    // The id is checked on the response and not only asked for in the filter,
+    // for the reason {@link rowWithId} gives: a filter that did not apply comes
+    // back as the whole table, and the first row of that is a different task.
+    const rows = await firstValueFrom(
+      ctx.system.client.api.query('pool.snapshottask.query', [['id', '=', id]]),
+    );
+    const task = rowWithId(rows, id);
+    if (task === null) {
+      throw new Error(
+        `No periodic snapshot task with id ${id} on this system — ${SNAPSHOT_TASK_IDS_FROM}`,
+      );
+    }
+    // Only an explicit false. `enabled` is optional on the entity and null is
+    // "the system reported no value", which is not the same answer as off —
+    // failing on it would refuse a plan the middleware would have accepted, and
+    // the sentence in the step states the uncertainty instead.
+    if (booleanOrNull(task['enabled']) === false) {
+      throw new Error(
+        `The periodic snapshot task with id ${id} on this system is disabled, and the ` +
+          `middleware refuses to run a disabled task — switch it on with ${SNAPSHOT_TASK_SWITCH} ` +
+          'first',
+      );
+    }
+    return [
+      {
+        method: 'pool.snapshottask.run',
+        params: snapshotRunParams(id),
+        description:
+          `Run ${describePeriodicSnapshotTask(task, id)} now. ` +
+          `${recursionSentence(task)} ${retentionSentence(task)} ` +
+          `${snapshotTaskEnabledSentence(task)} ` +
+          `${RETENTION_PASS} ` +
+          'This starts a background job; the job is then followed through the ' +
+          "client's own tracking, which reads `core.get_jobs` and changes " +
+          `nothing, for at most ${SNAPSHOT_RUN_WATCH_SECONDS} seconds. The run ` +
+          'continues after that whether or not it has finished.',
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const id = parseSnapshotTaskId(rawArgs);
+    const api = ctx.system.client.api;
+    // Every one of these three is {@link cloudsyncRun}'s, for the reasons
+    // written out there: completion rather than a state list is what says the
+    // run ended, the job having been seen is what turns the guard below on, and
+    // the correlated id is the one thing that survives a watch establishing
+    // nothing else.
+    let completed = false;
+    let sawJob = false;
+    let jobId: number | null = null;
+    const watched = await lastValueFrom(
+      api.callAndGetJobId('pool.snapshottask.run', snapshotRunParams(id)).pipe(
+        tap((correlated) => {
+          sawJob = true;
+          jobId = numberOrNull(correlated);
+        }),
+        switchMap((correlated) => api.trackJob(correlated)),
+        tap({
+          complete: () => {
+            completed = true;
+          },
+        }),
+        // An error raised once a job event has named this request is not the
+        // call failing: the run is going, and rejecting here would report a
+        // failure that did not happen AND take the job id with it. Before that
+        // event there is nothing to report and no id to keep, so an error there
+        // still fails.
+        catchError((error: unknown) => (sawJob ? EMPTY : throwError(() => error))),
+        takeUntil(timer(SNAPSHOT_RUN_WATCH_MS)),
+      ),
+      { defaultValue: null },
+    );
+    const record = lastRunOf(watched);
+    // Deliberately not {@link lastRunState}, whose null case means "the task has
+    // never run" — an answer about a task, where this is an answer about one job
+    // that has just been started.
+    const state = stringField(watched, 'state');
+    // A completion with no emission is the client having found no such job,
+    // which establishes nothing about the run; both halves are required.
+    const ended = completed && state !== null;
+    return {
+      task_id: id,
+      job_id: jobId,
+      watched_seconds: SNAPSHOT_RUN_WATCH_SECONDS,
+      ended,
+      // `pool.snapshottask.run` declares `response: null`, so the job's
+      // `result` is null whether the run worked or failed and the state is the
+      // only thing there is to read. A terminal state this catalog does not
+      // recognise is not read as a success.
+      succeeded: ended ? SUCCEEDED_JOB_STATES.has(state) : null,
+      state,
+      error: jobError(record),
+      // Gated on `ended` rather than through {@link jobFinishedAt}, so the
+      // finish time follows the claim this tool has already made and cannot
+      // contradict it — {@link cloudsyncRun} spells out why the two readings
+      // are not the same one.
+      finished_at: ended ? isoOrNull(jobMillis(record?.time_finished)) : null,
     };
   },
 };


### PR DESCRIPTION
Adds `snapshot_task_run`, a mutating tool that runs one periodic snapshot task
now, watches the job for a bounded thirty seconds and reports either how it
ended or that it is still going.

Fixes #154

## The job shape is `cloudsync_run`'s, copied rather than rederived

Every rule #122 settled applies unchanged and none of it is re-argued in the
code: `callAndGetJobId` and `trackJob` are called apart rather than through
`api.job`, so the two failure eras stay separable; the bound ends the watch and
not the job; `ended` is read from the tracking COMPLETING rather than from
`ENDED_JOB_STATES`; `job_id` comes from the correlation and never from the
tracking's last emission; a terminal state this catalog does not recognise is
not read as a success.

The two tools keep **separate** watch constants although both are 30s. The
bound is a ceiling on a tool's patience and not an estimate of its job, so one
shared constant would assert that the two ceilings must move together, which
nothing requires.

## What this tool had to decide for itself is the plan

**A run of a periodic snapshot task prunes, and the pruning reaches past the
task named.** `pool.snapshottask.run` interrupts zettarepl's scheduler with the
task, which goes round the same loop a scheduled fire goes round and ends in
the retention pass — and that pass builds its owners from *every* periodic
snapshot task on the system. So running task A can destroy snapshots owned by
task B whose retention had lapsed and whose own tick had not come round. A plan
reading "this takes a snapshot now" would omit a deletion, which is
`transferModeSentence`'s defect in a second family.

The plan therefore states the mechanism and its **scope**, in those words, and
computes no outcome:

- it says the run applies retention and that the pass is system-wide;
- it names both protections that bound it — a snapshot whose name matches no
  task's naming schema is skipped entirely, and the newest snapshot for a
  schema is kept where destroying it would leave none;
- it points at `snapshots_list`'s `report_scheduled_removal` rather than
  enumerating. The middleware already computes that per snapshot with the same
  owner-class retention the pass itself uses, so re-deriving it here would be
  the drifting second opinion composites exist to prevent (#44) — and it could
  not be sound from this side anyway, since that listing is bounded and its own
  description says a truncated list cannot show a snapshot is absent.

The scope sentence and the protections are one string (`RETENTION_PASS`) rather
than two, because either half alone is misleading: the scope alone reads as
"anything may go" and teaches an approver to discount the warning, and the
protections alone read as "only stale scheduled snapshots go".

**The first protection is a condition on the NAME, and round 2 fixed both texts
for having restated it as a class of snapshot.** They said a snapshot whose
name matches no schema is skipped *"so a snapshot taken by hand is not at
risk"*, and that inference is false: `snapshots_create` takes the snapshot name
straight from the caller (`required: ['dataset', 'name']`) and checks it
against no task's schema, so a manual `tank/media@auto-2026-09-01_02-00`
matches the periodic schema, is owned by the retention pass, and is destroyed
by it. The plan and the description now state the condition and say outright
that nothing here checks it — the protection and its bounding of the scope
sentence are unchanged; what is gone is the reading laid over it. Both texts
are pinned in the spec, each with a `not.toContain('is not at risk')` beside
it, on #128's rule that a redefinition living only in prose is one edit away
from being undone.

**None of that account is on the API surface, and the description says so.**
Nothing the client declares says a run applies retention, says it applies
system-wide, or says which snapshots survive — the reading comes from the
TrueNAS implementation. That is `system_ntp_status`'s posture (#133) reaching
an *effect* rather than a fact, and #120's rule pointed the other way: an
effect established somewhere this repository cannot check is stated as that.

## A disabled task is refused at plan time, on an explicit `false` only

The middleware rejects a disabled task, so the plan reads `enabled` and fails
naming the task, pointing at `scheduled_task_set_enabled` with `kind`
`periodic_snapshot`. But `enabled` is optional on the entity and null is "the
system reported no value", which is not the same answer as off — failing on it
would refuse a plan the middleware would have accepted. The unreadable case
says the call may be rejected and proceeds.

That check is plan-time only, as `snapshots_create`'s dataset check is (#119),
so a task disabled between the plan and the confirmation is refused by the
middleware. Stated in the description rather than fixed by re-reading:
`execute` re-reading would make it branch on state the confirmation token
cannot bind.

## Everything else

- `schedulePhrase` now takes the pointer rather than a whole `TaskKind`, so
  both tools render "the schedule could not be put into words" through one
  sentence. A second spelling of it in one file is the drift `common.ts` was
  cut to stop, one size down.
- `destructiveness: 'reversible'` on #122's and #128's test — the dataset, the
  recursion, the naming schema and the retention were all authored by whoever
  configured the task, and the system does exactly this unattended at the next
  window. This tool moves the moment, not the effect. Following the rule #153
  landed, the description also says outright that nothing here undoes the
  retention the run applies: a destroyed snapshot stays destroyed, and running
  the task again takes another snapshot rather than bringing one back.
- Tests took `src/tools/snapshot-task-run.spec.ts`. `tasks.spec.ts` was 1,352
  lines and this block is several hundred more, so #87's split exception is met
  — measured, as #121 measured it and #97 declined to. The four listing tools
  stay where they are.
- Registered in `createDefaultCatalog()`, re-exported from `src/tools/index.ts`
  and `src/index.ts`, added to the exact-list assertion, and the README's
  tool-surface list and `destructiveness: 'reversible'` line. The catalog
  comment's mutating count went from seven to eight.
- A `## Decisions` entry in `CLAUDE.md`, which round 2 extended with the
  condition-versus-class shape above.

## Checks

`yarn typecheck`, `yarn lint`, `yarn test:coverage` (1,519 tests, 40 files) and
`yarn build` all pass locally — the four jobs CI runs. `src/tools/tasks.ts` is
at 100% statements and branches; the global floors are unchanged and not
approached.

## What I did not change, and why

Round 2's local review came back with nothing at MEDIUM or above, which is
where this stops. Five LOW findings are outstanding across the two rounds and
are recorded here rather than acted on — every fix is a new diff and a new diff
starts another round.

**`describePeriodicSnapshotTask` duplicates `describeTask` for the
`periodic_snapshot` `TaskKind`** (`src/tools/tasks.ts:2810`, raised in both
rounds). Accurate: the two renderings produce the same string today, and the
`schedulePhrase` doc's claim that this tool "has no `TaskKind` to hand" is
wrong — `TASK_KINDS_BY_NAME.get('periodic_snapshot')` reaches one. Reusing it
means coupling a job-backed tool to the switching table for an entry whose
`update` and `updateMethod` it has no use for, and carrying the lookup's absent
case, to save one `label` list. A trade rather than a clear win, so it is left
for a reader who disagrees to take deliberately.

**A third copy of the whole-number id check** (`src/tools/tasks.ts:2784`).
`parseIdAndEnabled` and `parseRun` carry the identical three lines and message,
and the first one's own doc states the rule this adds a third instance of. The
proposed `parseWholeNumberId(args): number` shared by all three is the right
shape and touches two tools this ticket did not open.

**`A DISABLED TASK IS REFUSED BY THE MIDDLEWARE` is unmarked while the claim
two sentences from it is marked** (`src/tools/tasks.ts:2930`). Correct, and it
is the load-bearing one: `plan` throws on an explicit `false` on the strength
of it, and nothing the pinned surface declares about `pool.snapshottask.run`
says a disabled task is refused. `(unconfirmed)` in `pool_resilver_config`'s
form (#141) is what it is owed. The plan-time refusal is safe either way.

**The plan makes safety turn on a naming schema it does not report**
(`src/tools/tasks.ts:2895`, round 2). No tool reports `naming_schema`, and this
plan reads the task row without naming it — so an approver is told the
protection and given no way to check their own snapshot against it. Real, and
the fix reaches `snapshot_tasks_list`'s contract rather than this tool's.

The review's suggestion that the naming-schema correction was also owed in
`README.md` is the one finding not carried here: the README's paragraph on this
tool names the system-wide retention pass and states neither protection, so
there was no version of the claim there to correct. Checked rather than assumed.
