### PR TITLE
feat(snapshots): add snapshot_set_hold, protecting one snapshot from destruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1949,6 +1949,26 @@ outright, because side-by-side fields are what an implied completeness looks
 like from the outside (#138), and a caller reading `changed: false` as "no
 effect" is the one reading that costs a snapshot's protection.
 
+**A sentence derived from a state read may not reach past what was read, and
+`recursive` is where that bites.** `readHoldState` queries the one snapshot
+named while the call reaches every child of it, so the plan's
+already-in-the-target-state sentence — *"it already carries that tag, so this
+changes nothing"* — was true of the snapshot and false of the operation, in the
+reassuring direction, in the one text a person reads before approving. The
+effect sentence therefore takes `recursive`: each arm names the snapshot it is
+about and says outright that the children's hold state was not read, which is
+all a read of one snapshot supports. The same scoping is owed by the result,
+where the three readings above are the named snapshot's alone — so a recursive
+hold of an already-held snapshot reports `changed: false` having placed holds on
+children, which the description states beside the release reading it sits next
+to.
+
+**A scope sentence beside an effect sentence does not scope it.**
+`recursiveSentence` already said the call reaches more than the snapshot named,
+one clause earlier, and the no-op claim still read as being about the call —
+adjacency is not qualification, which is #138's implied-join finding arriving in
+a single paragraph of prose.
+
 **`reversible` is #153's trap again, one tool over.** The operation destroys no
 data — it changes what may destroy a snapshot later — but a release is not
 undoable from here: setting the hold again places the `truenas` tag and only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1906,6 +1906,64 @@ a response, and `src/testing/fake-systems.ts` stubs `call` and `query` off one
 method→response map. Two copies now exist, which is when a shared fixture could
 be designed from evidence — a later ticket's call, not a side effect of this one.
 
+### One call made twice is named once, and the step says when (#156)
+
+`snapshot_set_hold` returns **two** plan steps and `execute` makes **three**
+calls. `pool.snapshot.hold` and `pool.snapshot.release` answer `null`, so there
+is no updated entity to read the outcome off (#121) and the state has to be read
+both before and after — which is `alerts_dismiss`'s position (#119) with a
+second read on the far side of the mutation. Both reads are the SAME call: same
+method, same params, from one helper. Listing it twice would show an approver
+two entries it has no way to tell apart, so it is named once and that step's own
+description says it runs again immediately after the call. That is the seam
+`cloudsync_run` uses for the `core.get_jobs` its tracking issues (#122), reached
+for a different reason — there the params do not exist until the approved call
+has been made, here they are identical to a step already in the plan.
+
+**#119 is unchanged and this is not an exception to it.** The rule is that
+nothing `execute` calls may be missing from the approval; a repeated call is not
+a further call to disclose, it is the same one happening twice, and the plan says
+so in words. **Ask whether an approver reading the plan could be surprised by a
+call `execute` makes** — that is the test, not whether the step count equals the
+call count.
+
+### The two directions of one mutation need not be symmetric (#156)
+
+`held: true` places TrueNAS's own hold tag and only that tag; `held: false`
+removes **every** hold tag on the snapshot, including any placed outside TrueNAS
+that `snapshots_list` never reported — its `held` is the `truenas` tag alone
+(#155). The middleware's own methods are what differ: `hold` names the tag,
+`release` names none, and the second is documented as removing all of them.
+
+**A tool with a discriminator must not describe one arm and let the other
+inherit it.** The description and the plan step both state the asymmetry, and
+the plan's already-in-the-target-state sentence refuses the obvious wording for
+a release: *"it is not held, so this changes nothing"* is the tool claiming to
+know about tags it never reads. What it says instead is that this is not an
+error AND that a hold under another tag would still be removed.
+
+That reaches the result, which is where it is easiest to miss. `changed`
+compares the two readings, and both readings are the `truenas` tag — so
+**`changed: false` on a release does not mean nothing was removed**. Said
+outright, because side-by-side fields are what an implied completeness looks
+like from the outside (#138), and a caller reading `changed: false` as "no
+effect" is the one reading that costs a snapshot's protection.
+
+**`reversible` is #153's trap again, one tool over.** The operation destroys no
+data — it changes what may destroy a snapshot later — but a release is not
+undoable from here: setting the hold again places the `truenas` tag and only
+that tag, so a foreign tag a release removed is restored by nothing in this
+catalog. Where a tool's operation is reversible in principle and this catalog
+still cannot reverse it, say so.
+
+**Whether a hold actually stops retention destroying the snapshot is
+`(unconfirmed)`**, in `pool_resilver_config`'s form (#141). What is claimed is
+the ZFS mechanism — a hold makes the destroy itself fail, and
+`annotate_snapshots` never reads holds, so `snapshots_list` can report a
+`scheduled_removal` for a snapshot that survives it. How TrueNAS reports or
+recovers from a destroy that fails was not read off a live system, and asserting
+a guessed side effect is worse than saying nothing (#120).
+
 ## Conventions
 
 - **A tool description must not promise more than the normalization delivers.**

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ confirmation UX, audit sinks) enters through injected interfaces.
   Mutating family, all of them two-phase plan/confirm and all
   `destructiveness: 'reversible'`: `snapshots_create`, `alerts_dismiss`,
   `alerts_restore`, `scheduled_task_set_enabled`, `cloudsync_run`,
-  `automated_task_set_enabled`, `snapshot_clone`, `snapshot_task_run` —
+  `automated_task_set_enabled`, `snapshot_clone`, `snapshot_task_run`,
+  `snapshot_set_hold` —
   `cloudsync_run` and `snapshot_task_run` the two that start a background job,
   which each watches for a bounded time and then reports on rather than waiting
   out. `snapshot_clone` is the additive route
@@ -47,7 +48,14 @@ confirmation UX, audit sinks) enters through injected interfaces.
   exists, which is what lets the catalog decline the rollback that answers the
   same question destructively — though the clone it adds does pin its source
   snapshot, which cannot then be destroyed while that clone is there, and its
-  description leads with that. `destructiveness`
+  description leads with that. `snapshot_set_hold` is the one mutation that
+  prevents data loss rather than risking it: it places TrueNAS's hold on a
+  snapshot, or removes the holds on one, and since nothing here deletes a named
+  snapshot it is the only protection the catalog can offer the snapshot an
+  operator would recover from. The two directions are not symmetric — placing a
+  hold adds the `truenas` tag alone, removing one removes every hold tag on the
+  snapshot, including any this catalog never reported — which its description
+  and its plan both state. `destructiveness`
   is about a tool's own operation and not about the data that operation acts
   on: `cloudsync_run` starts a task whose own `transfer_mode` may delete data
   for good, and `snapshot_task_run` starts a run that ends in a system-wide

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,4 +141,5 @@ export {
   automatedTaskSetEnabled,
   snapshotClone,
   snapshotTaskRun,
+  snapshotSetHold,
 } from '@/tools/index';

--- a/src/tools/index.spec.ts
+++ b/src/tools/index.spec.ts
@@ -69,6 +69,7 @@ describe('createDefaultCatalog', () => {
       'automated_task_set_enabled',
       'snapshot_clone',
       'snapshot_task_run',
+      'snapshot_set_hold',
     ]);
   });
 
@@ -105,6 +106,12 @@ describe('createDefaultCatalog', () => {
   it('does not advertise snapshot_task_run to a read-only credential', () => {
     expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
       'snapshot_task_run',
+    );
+  });
+
+  it('does not advertise snapshot_set_hold to a read-only credential', () => {
+    expect(createDefaultCatalog().list(Role.ReadOnly).map((t) => t.name)).not.toContain(
+      'snapshot_set_hold',
     );
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,7 +22,12 @@ import {
 import { securityConfig } from '@/tools/security';
 import { servicesStatus } from '@/tools/services';
 import { shareAccess, sharesList } from '@/tools/shares';
-import { createSnapshot, snapshotClone, snapshotsList } from '@/tools/snapshots';
+import {
+  createSnapshot,
+  snapshotClone,
+  snapshotSetHold,
+  snapshotsList,
+} from '@/tools/snapshots';
 import { listDatasets, poolStatus, quotaReport, systemDatasetConfig } from '@/tools/storage';
 import {
   auditConfig,
@@ -113,6 +118,7 @@ export function createDefaultCatalog(): ToolCatalog {
   catalog.register(automatedTaskSetEnabled);
   catalog.register(snapshotClone);
   catalog.register(snapshotTaskRun);
+  catalog.register(snapshotSetHold);
   return catalog;
 }
 
@@ -166,6 +172,7 @@ export {
   shareAccess,
   sharesList,
   snapshotClone,
+  snapshotSetHold,
   snapshotsList,
   snapshotTaskRun,
   snapshotTasksList,

--- a/src/tools/snapshots.spec.ts
+++ b/src/tools/snapshots.spec.ts
@@ -958,6 +958,71 @@ describe('snapshot_set_hold', () => {
     expect(call).toHaveBeenCalledWith('pool.snapshot.release', [SNAPSHOT, { recursive: true }]);
   });
 
+  it('does not call a recursive hold of an already-held snapshot a no-op', async () => {
+    // The state is read off the one snapshot named while the call reaches every
+    // child of it, so "this changes nothing" would tell an approver a call is a
+    // no-op while it places holds on children that carry no tag — wrong in the
+    // reassuring direction, in the text approval is given against.
+    const { ctx } = fakeSystem({ ['pool.snapshot.query']: [heldRow()] });
+    const [, mutation] = await snapshotSetHold.plan(ctx, {
+      snapshot: SNAPSHOT,
+      held: true,
+      recursive: true,
+    });
+    expect(mutation.description).toContain(
+      'The snapshot named already carries that tag, so this changes nothing for the ' +
+        'snapshot named and is not an error.',
+    );
+    expect(mutation.description).toContain(
+      "Its children's hold state was not read, so nothing here says what this does to them.",
+    );
+    expect(mutation.description).not.toContain('so this changes nothing and is not an error');
+  });
+
+  it('scopes every other effect sentence to the snapshot named on a recursive call', async () => {
+    // One reading, four remaining sentences: each names its subject and none of
+    // them may reach past it.
+    const unread = "Its children's hold state was not read";
+    const systems = [
+      { held: true, rows: [holdRow()], says: 'so this will place one.' },
+      {
+        held: false,
+        rows: [heldRow()],
+        says: 'The snapshot named carries that tag, so this will remove it,',
+      },
+      {
+        held: false,
+        rows: [holdRow()],
+        says: 'The snapshot named carries no `truenas` tag, so this is not an error',
+      },
+      {
+        held: true,
+        rows: [holdRow({ holds: 'not a record' })],
+        says:
+          "Whether TrueNAS's hold tag is on the snapshot named could not be read, so this " +
+          'may change nothing for the snapshot named.',
+      },
+    ];
+    for (const { held, rows, says } of systems) {
+      const { ctx } = fakeSystem({ ['pool.snapshot.query']: rows });
+      const [, mutation] = await snapshotSetHold.plan(ctx, {
+        snapshot: SNAPSHOT,
+        held,
+        recursive: true,
+      });
+      expect(mutation.description).toContain(says);
+      expect(mutation.description).toContain(unread);
+    }
+  });
+
+  it('leaves the non-recursive sentences saying nothing about children', async () => {
+    // The clause is a recursive call's alone: on a call that reaches one
+    // snapshot there are no children for it to be about.
+    const { ctx } = fakeSystem({ ['pool.snapshot.query']: [heldRow()] });
+    const [, mutation] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true });
+    expect(mutation.description).not.toContain('children');
+  });
+
   it('names the read step with the params execute actually makes it with', async () => {
     // The plan step and both of `execute`'s reads come from one helper for the
     // options and are written twice for the filter, so this is what keeps the
@@ -1173,6 +1238,9 @@ describe('snapshot_set_hold', () => {
     );
     expect(snapshotSetHold.description).toContain(
       'IT DOES NOT MEAN A RELEASE CAN BE UNDONE FROM HERE',
+    );
+    expect(snapshotSetHold.description).toContain(
+      'ALL THREE ARE READ FROM THE SNAPSHOT NAMED AND ESTABLISH NOTHING ABOUT ITS CHILDREN',
     );
     expect(snapshotSetHold.description).toContain('snapshots_list');
   });

--- a/src/tools/snapshots.spec.ts
+++ b/src/tools/snapshots.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { of } from 'rxjs';
 import { Role } from '@/interfaces';
 import { fakeSystem, failingSystem } from '@/testing/fake-systems';
-import { createSnapshot, snapshotClone, snapshotsList } from '@/tools/index';
+import { createSnapshot, snapshotClone, snapshotSetHold, snapshotsList } from '@/tools/index';
 
 describe('snapshots_list', () => {
   /**
@@ -805,5 +806,374 @@ describe('snapshot_clone', () => {
     expect(snapshotClone.description).toContain('NOTHING HERE TOUCHES THE CLONE AFTERWARDS');
     expect(snapshotClone.description).toContain('storage_list_datasets');
     expect(snapshotClone.description).toContain('`dataset_properties` IS NOT ACCEPTED');
+  });
+});
+
+describe('snapshot_set_hold', () => {
+  const SNAPSHOT = 'tank/media@nightly-1';
+
+  /** The two positional params every hold-state read is made with. */
+  const HOLD_READ = [
+    [['OR', [[['id', '=', SNAPSHOT]], [['name', '=', SNAPSHOT]]]]],
+    { extra: { properties: ['creation'], holds: true } },
+  ];
+
+  /** A snapshot row as a hold-state read reports one, trimmed to what is read. */
+  const holdRow = (over: Record<string, unknown> = {}) => ({
+    id: SNAPSHOT,
+    name: SNAPSHOT,
+    holds: {},
+    ...over,
+  });
+
+  /** The row a held snapshot answers with: the `truenas` tag, count normalised. */
+  const heldRow = (over: Record<string, unknown> = {}) => holdRow({ holds: { truenas: 1 }, ...over });
+
+  /** A system where the snapshot is there and unheld — the plannable state. */
+  const plannable = (over: Partial<Record<string, unknown>> = {}) =>
+    fakeSystem({ ['pool.snapshot.query']: [holdRow()], ...over });
+
+  /**
+   * A system whose hold-state read answers differently each time it is made.
+   *
+   * `fakeSystem` answers every read of one method from the same map, so it
+   * cannot express a snapshot whose state moved — which is the whole of what
+   * `changed` compares. The last reading is repeated once the list runs out.
+   */
+  const holdingSystem = (readings: unknown[]) => {
+    const fake = fakeSystem({
+      ['pool.snapshot.hold']: null,
+      ['pool.snapshot.release']: null,
+    });
+    let made = 0;
+    fake.query.mockImplementation(() => of(readings[Math.min(made++, readings.length - 1)]));
+    return fake;
+  };
+
+  it('normalizes args: names the three it takes and drops everything else', () => {
+    expect(
+      snapshotSetHold.normalizeArgs?.({
+        snapshot: SNAPSHOT,
+        held: true,
+        recursive: true,
+        tag: 'mine',
+      }),
+    ).toEqual({ snapshot: SNAPSHOT, held: true, recursive: true });
+  });
+
+  it('requires a snapshot and a held boolean, and refuses a non-boolean recursive', async () => {
+    const { ctx } = plannable();
+    for (const bad of [undefined, '', 123, null, {}]) {
+      await expect(snapshotSetHold.plan(ctx, { snapshot: bad, held: true })).rejects.toThrow(
+        /"snapshot" is required/,
+      );
+    }
+    // `held` is the whole difference between protecting a snapshot and removing
+    // every hold on it, so a coerced "false" would release one the caller asked
+    // to hold.
+    for (const bad of [undefined, null, 'true', 1, {}]) {
+      await expect(snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: bad })).rejects.toThrow(
+        /"held" is required and must be a boolean/,
+      );
+    }
+    await expect(
+      snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true, recursive: 'yes' }),
+    ).rejects.toThrow(/"recursive" must be a boolean/);
+  });
+
+  it('plans the hold-state read and the hold, in that order', async () => {
+    const { ctx } = plannable();
+    expect(await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true })).toEqual([
+      {
+        method: 'pool.snapshot.query',
+        params: HOLD_READ,
+        description:
+          `Read the hold state of "${SNAPSHOT}", to report whether it was already in the ` +
+          'state this call moves it to. Changes nothing. This same read is made again ' +
+          'immediately after the call, to report the state that resulted.',
+      },
+      {
+        method: 'pool.snapshot.hold',
+        params: [SNAPSHOT, { recursive: false }],
+        description:
+          `Place TrueNAS's hold on snapshot "${SNAPSHOT}". It carries no \`truenas\` tag, ` +
+          'so this will place one.',
+      },
+    ]);
+  });
+
+  it('plans a release naming every hold tag it removes, not only TrueNAS\'s', async () => {
+    // The asymmetry is the finding this tool carries: `release` passes no tag,
+    // which the middleware documents as removing all of them — including holds
+    // `snapshots_list` never reported.
+    const { ctx } = fakeSystem({ ['pool.snapshot.query']: [heldRow()] });
+    const [, mutation] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: false });
+    expect(mutation.method).toBe('pool.snapshot.release');
+    expect(mutation.params).toEqual([SNAPSHOT, { recursive: false }]);
+    expect(mutation.description).toContain('THIS REMOVES EVERY HOLD TAG ON IT');
+    expect(mutation.description).toContain('placed outside TrueNAS');
+    expect(mutation.description).toContain('this will remove it, along with any other hold tag');
+  });
+
+  it('says a release of an unheld snapshot may still remove a hold it cannot see', async () => {
+    // "It is not held, so this changes nothing" would be the plan claiming to
+    // know about tags this tool never reads.
+    const { ctx } = plannable();
+    const [, mutation] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: false });
+    expect(mutation.description).toContain('this is not an error');
+    expect(mutation.description).toContain('a hold placed under any other tag would still be removed');
+  });
+
+  it('says a hold on an already-held snapshot changes nothing and is not an error', async () => {
+    const { ctx } = fakeSystem({ ['pool.snapshot.query']: [heldRow()] });
+    const [, mutation] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true });
+    expect(mutation.description).toContain(
+      'It already carries that tag, so this changes nothing and is not an error.',
+    );
+  });
+
+  it('claims neither state where the hold state could not be read', async () => {
+    // A snapshot listed with no readable holds payload is neither already there
+    // nor about to move, and the plan must say so rather than pick one.
+    const { ctx } = fakeSystem({ ['pool.snapshot.query']: [holdRow({ holds: 'not a record' })] });
+    const [, mutation] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true });
+    expect(mutation.description).toContain(
+      "Whether TrueNAS's hold tag is on it could not be read, so this may change nothing.",
+    );
+  });
+
+  it('names the recursive scope in the plan and passes it to the call', async () => {
+    const { ctx } = plannable();
+    const [, mutation] = await snapshotSetHold.plan(ctx, {
+      snapshot: SNAPSHOT,
+      held: false,
+      recursive: true,
+    });
+    expect(mutation.description).toContain('RECURSIVELY');
+    expect(mutation.description).toContain('reaches more than the one snapshot named');
+    expect(mutation.params).toEqual([SNAPSHOT, { recursive: true }]);
+
+    const { ctx: executing, call } = holdingSystem([[holdRow()]]);
+    await snapshotSetHold.execute(executing, { snapshot: SNAPSHOT, held: false, recursive: true });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.release', [SNAPSHOT, { recursive: true }]);
+  });
+
+  it('names the read step with the params execute actually makes it with', async () => {
+    // The plan step and both of `execute`'s reads come from one helper for the
+    // options and are written twice for the filter, so this is what keeps the
+    // two halves in step.
+    const { ctx } = plannable();
+    const [readStep] = await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true });
+    const { ctx: executing, query } = holdingSystem([[holdRow()]]);
+    await snapshotSetHold.execute(executing, { snapshot: SNAPSHOT, held: true });
+    expect(query).toHaveBeenCalledWith(readStep.method, ...(readStep.params as unknown[]));
+  });
+
+  it('fails the plan, naming the snapshot, where no snapshot has that name', async () => {
+    const { ctx } = plannable({ ['pool.snapshot.query']: [] });
+    await expect(snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true })).rejects.toThrow(
+      new RegExp(`No snapshot named "${SNAPSHOT}" on this system`),
+    );
+  });
+
+  it('reads the snapshot off the response rather than the row count', async () => {
+    // A dropped filter answers with every snapshot on the system, which a count
+    // would read as "it exists" — and the holds reported would be a different
+    // snapshot's.
+    const { ctx } = plannable({
+      ['pool.snapshot.query']: [holdRow({ id: 'tank/other@nightly-1', name: 'tank/other@nightly-1' })],
+    });
+    await expect(snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true })).rejects.toThrow(
+      /No snapshot named/,
+    );
+  });
+
+  it('matches the snapshot on either declared name field', async () => {
+    const { ctx: byName } = plannable({
+      ['pool.snapshot.query']: [holdRow({ id: 'something-else' })],
+    });
+    await expect(
+      snapshotSetHold.plan(byName, { snapshot: SNAPSHOT, held: true }),
+    ).resolves.toHaveLength(2);
+
+    const { ctx: byId } = plannable({ ['pool.snapshot.query']: [holdRow({ name: 'something-else' })] });
+    await expect(
+      snapshotSetHold.plan(byId, { snapshot: SNAPSHOT, held: true }),
+    ).resolves.toHaveLength(2);
+  });
+
+  it('asks the system for hold state under either name field', async () => {
+    // `fakeSystem` answers every filter with the same rows, so the two cases
+    // above pass whatever this read asked for — the filter and `holds: true`
+    // are asserted here instead. Without `holds`, every reading would be null
+    // and every `changed` with it.
+    const { ctx, query } = plannable();
+    await snapshotSetHold.plan(ctx, { snapshot: SNAPSHOT, held: true });
+    expect(query).toHaveBeenCalledWith('pool.snapshot.query', ...HOLD_READ);
+  });
+
+  it('reads the state, holds the snapshot, and reads it back', async () => {
+    const { ctx, call, query } = holdingSystem([[holdRow()], [heldRow()]]);
+    const result = await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.hold', [SNAPSHOT, { recursive: false }]);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      snapshot: SNAPSHOT,
+      requested_held: true,
+      recursive: false,
+      previous_lookup: 'FOUND',
+      previous_read_error: null,
+      previously_held: false,
+      resulting_lookup: 'FOUND',
+      resulting_read_error: null,
+      resulting_held: true,
+      changed: true,
+    });
+  });
+
+  it('reports holding an already-held snapshot as changed: false, not as an error', async () => {
+    const { ctx } = holdingSystem([[heldRow()], [heldRow()]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previously_held: true,
+      resulting_held: true,
+      changed: false,
+    });
+  });
+
+  it('reports releasing an unheld snapshot as changed: false, not as an error', async () => {
+    const { ctx, call } = holdingSystem([[holdRow()], [holdRow()]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: false })).toMatchObject({
+      previously_held: false,
+      resulting_held: false,
+      changed: false,
+    });
+    // `changed: false` here does not say nothing was removed — a hold under
+    // another tag is invisible to both readings — which is why the call is
+    // still made and the description says so.
+    expect(call).toHaveBeenCalledWith('pool.snapshot.release', [SNAPSHOT, { recursive: false }]);
+  });
+
+  it('derives changed from the two readings rather than from the request', async () => {
+    // A system that accepted the call and applied nothing: the request says
+    // held, both readings say otherwise, and `changed` follows the readings.
+    const { ctx } = holdingSystem([[holdRow()], [holdRow()]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      requested_held: true,
+      previously_held: false,
+      resulting_held: false,
+      changed: false,
+    });
+  });
+
+  it('makes the call, and reports null, where the read before it failed', async () => {
+    // Skipping the mutation for a read that failed would be `execute` branching
+    // on state read at execution time, which the confirmation token cannot bind.
+    const { ctx, call } = failingSystem(
+      { ['pool.snapshot.hold']: null },
+      { ['pool.snapshot.query']: { reason: 'connection reset' } },
+    );
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toEqual({
+      snapshot: SNAPSHOT,
+      requested_held: true,
+      recursive: false,
+      previous_lookup: 'UNREADABLE',
+      previous_read_error: 'connection reset',
+      previously_held: null,
+      resulting_lookup: 'UNREADABLE',
+      resulting_read_error: 'connection reset',
+      resulting_held: null,
+      changed: null,
+    });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.hold', [SNAPSHOT, { recursive: false }]);
+  });
+
+  it('does not fail the tool where only the read after the call failed', async () => {
+    // The mutation had already landed by then. Rejecting here would report a
+    // hold that was placed as a failure.
+    const { ctx, query } = holdingSystem([[holdRow()]]);
+    query.mockImplementationOnce(() => of([holdRow()]));
+    query.mockImplementationOnce(() => {
+      throw new Error('socket closed');
+    });
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previous_lookup: 'FOUND',
+      previously_held: false,
+      resulting_lookup: 'UNREADABLE',
+      resulting_read_error: 'socket closed',
+      resulting_held: null,
+      changed: null,
+    });
+  });
+
+  it('reports a read that completed and listed nothing as NOT_FOUND', async () => {
+    // The snapshot cleared between the plan and the confirmation. The call is
+    // still made, because what runs must be what was approved.
+    const { ctx, call } = holdingSystem([[]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previous_lookup: 'NOT_FOUND',
+      previous_read_error: null,
+      previously_held: null,
+      resulting_lookup: 'NOT_FOUND',
+      resulting_held: null,
+      changed: null,
+    });
+    expect(call).toHaveBeenCalledWith('pool.snapshot.hold', [SNAPSHOT, { recursive: false }]);
+  });
+
+  it('reports a snapshot that was listed with no readable hold state as FOUND beside a null', async () => {
+    // The fourth cause of a null reading, which the lookup alone cannot
+    // separate from the other three.
+    const { ctx } = holdingSystem([[holdRow({ holds: 'not a record' })]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previous_lookup: 'FOUND',
+      previously_held: null,
+      resulting_lookup: 'FOUND',
+      resulting_held: null,
+      changed: null,
+    });
+  });
+
+  it('reads each hold state as TrueNAS\'s own tag and never as any ZFS hold', async () => {
+    // The middleware normalises the count, and a payload that is not a record —
+    // including a system that ignored the `holds` request — is null and never
+    // false: `false` says nothing is protecting this snapshot, and a caller
+    // acting on that prunes it.
+    const { ctx } = holdingSystem([[holdRow({ holds: { truenas: 0 } })]]);
+    expect(await snapshotSetHold.execute(ctx, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previously_held: false,
+    });
+
+    const { ctx: absent } = holdingSystem([[holdRow({ holds: undefined })]]);
+    expect(await snapshotSetHold.execute(absent, { snapshot: SNAPSHOT, held: true })).toMatchObject({
+      previously_held: null,
+    });
+  });
+
+  it('is registered as a Full-role reversible mutation', () => {
+    // `reversible` records that the operation destroys no data. It does not
+    // mean a release can be undone from here, which the description says.
+    expect(snapshotSetHold.requiredRole).toBe(Role.Full);
+    expect(snapshotSetHold.mutating).toBe(true);
+    expect(snapshotSetHold.destructiveness).toBe('reversible');
+  });
+
+  it('states the asymmetry, the narrow reading and the release it cannot undo', () => {
+    // Every one of these is a reading a caller would otherwise get wrong, and
+    // prose is the only place they can be stated — so they are pinned rather
+    // than left to a later edit.
+    expect(snapshotSetHold.description).toContain(
+      '`held: false` REMOVES EVERY HOLD TAG ON THE SNAPSHOT, NOT ONLY TRUENAS\'S',
+    );
+    expect(snapshotSetHold.description).toContain('(unconfirmed)');
+    expect(snapshotSetHold.description).toContain(
+      "EACH READING IS TRUENAS'S OWN HOLD TAG AND NOT ANY ZFS HOLD",
+    );
+    expect(snapshotSetHold.description).toContain(
+      'A `changed: false` ON A RELEASE THEREFORE DOES NOT MEAN NOTHING WAS REMOVED',
+    );
+    expect(snapshotSetHold.description).toContain(
+      'IT DOES NOT MEAN A RELEASE CAN BE UNDONE FROM HERE',
+    );
+    expect(snapshotSetHold.description).toContain('snapshots_list');
   });
 });

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -13,8 +13,8 @@ import {
 } from '@/tools/common';
 
 /**
- * Snapshots family: the snapshots that exist, taking a new one, and cloning one
- * into a new dataset.
+ * Snapshots family: the snapshots that exist, taking a new one, cloning one
+ * into a new dataset, and protecting one from destruction.
  */
 
 /**
@@ -882,6 +882,368 @@ export const snapshotClone: MutatingTool = {
       destination: args.destination,
       destination_found: found,
       destination_read_error: readError,
+    };
+  },
+};
+
+/**
+ * `snapshot_set_hold`: the one snapshot mutation that PREVENTS data loss.
+ *
+ * Deleting a snapshot and rolling a dataset back are both rejected at
+ * registration (`catalog/catalog.ts`), so a hold is the only protection this
+ * catalog can offer the snapshot an operator would recover from — and the
+ * cheapest safety move before anything risky, since retention, a periodic
+ * snapshot task or a person can otherwise destroy it while the risky work is
+ * still in progress.
+ *
+ * ONE TOOL WITH A DISCRIMINATOR, WHICH IS #121's TEST AND NOT #97's.
+ * `pool.snapshot.hold` and `pool.snapshot.release` take literally the same
+ * params — `(id, { recursive })` in, `null` out — so two tools would be two
+ * copies of one `plan`/`execute` pair differing in which method is dialled.
+ * Nothing is missing from a mutation, so there is no section to be the finding.
+ *
+ * THE TWO DIRECTIONS ARE NOT SYMMETRIC, AND THAT IS THE FINDING THIS TOOL
+ * CARRIES. `hold` adds the `truenas` tag and only that tag; `release` passes no
+ * tag at all, which the middleware documents as removing ALL hold tags. So a
+ * release removes holds this tool never placed and that `snapshots_list` never
+ * reported — its `held` is the `truenas` tag alone (#155). Reporting a narrower
+ * effect than the call has is this repository's most common finding pointed at
+ * a mutation, so the description and the plan both say it outright.
+ *
+ * THE METHOD ANSWERS `null`, SO THE OUTCOME IS READ BY RE-READING. That places
+ * this with `alerts_dismiss` (#119) rather than `scheduled_task_set_enabled`
+ * (#121): there is no updated entity to read the result off, so `execute` reads
+ * the hold state, makes the call, and reads it again. `changed` compares the
+ * two READINGS — a `changed` derived from the request would report a call the
+ * system accepted and did not apply as having changed something.
+ *
+ * THE PLAN NAMES TWO STEPS AND `execute` MAKES THREE CALLS, AND THAT IS
+ * DELIBERATE. The two reads are ONE call — same method, same params, from
+ * {@link holdReadParams} — made twice, so listing it twice would show an
+ * approver two entries it cannot tell apart. It is named once, and the step's
+ * own description says it runs again after the mutation, which is the seam
+ * `cloudsync_run` uses for the `core.get_jobs` its tracking issues (#122).
+ * Nothing `execute` calls is hidden from the approval, which is what #119 is
+ * about.
+ *
+ * `destructiveness: 'reversible'` RECORDS THE OPERATION: it destroys no data,
+ * and what it changes is what may destroy a snapshot later. It is #153's trap
+ * one tool over — a release is NOT undoable from here, because setting the hold
+ * again places the `truenas` tag and only that tag, so a foreign tag a release
+ * removed is restored by nothing in this catalog. The description says so.
+ */
+
+/** The three arguments the tool takes. */
+interface HoldArgs {
+  snapshot: string;
+  held: boolean;
+  recursive: boolean;
+}
+
+/**
+ * The caller's arguments, or the error naming what is wrong with them.
+ *
+ * `held` is required and strict for the reason it exists: it is the whole
+ * difference between protecting a snapshot and removing every hold on it, and a
+ * coerced `"false"` would release one the caller asked to hold. `recursive` is
+ * strict for {@link parseArgs}'s reason — a silently-dropped `recursive` widens
+ * or narrows a call the user approved as the other one.
+ */
+function parseHoldArgs(args: Record<string, unknown>): HoldArgs {
+  const snapshot = args['snapshot'];
+  if (typeof snapshot !== 'string' || snapshot.length === 0) {
+    throw new Error('"snapshot" is required');
+  }
+  const held = args['held'];
+  if (typeof held !== 'boolean') {
+    throw new Error('"held" is required and must be a boolean');
+  }
+  const recursive = args['recursive'];
+  if (recursive != null && typeof recursive !== 'boolean') {
+    throw new Error('"recursive" must be a boolean');
+  }
+  return { snapshot, held, recursive: recursive === true };
+}
+
+/**
+ * The options every hold-state read in this file is made with.
+ *
+ * Hoisted for {@link DATASET_READ_OPTIONS}'s reason, and with the same half
+ * left open: the FILTER is written twice — inlined in {@link readHoldState}
+ * because written to a `const` it widens out of the filter tuple, and again in
+ * {@link holdReadParams} for the plan step — so a test takes the read step back
+ * out of the plan and asserts `execute` made its call with it.
+ *
+ * `holds: true` is what makes the middleware report hold state at all, and one
+ * property is asked for because this read needs none and an empty list is not
+ * documented to mean "no properties" — a snapshot row otherwise carries every
+ * ZFS property of the snapshot.
+ */
+const HOLD_READ_OPTIONS = { extra: { properties: ['creation'], holds: true } };
+
+/**
+ * The two positional params a hold-state read reaches the middleware with, for
+ * the plan step that names one.
+ */
+function holdReadParams(snapshot: string): unknown {
+  return [[['OR', [[['id', '=', snapshot]], [['name', '=', snapshot]]]]], HOLD_READ_OPTIONS];
+}
+
+/** What one hold-state read established. */
+interface HoldReading {
+  /** Whether the system listed a snapshot under the name given. */
+  listed: boolean;
+  /**
+   * TrueNAS's own hold tag, as {@link heldOf} reads it — null both where the
+   * snapshot was not listed and where it was listed and reported no hold state
+   * this tool can read.
+   */
+  held: boolean | null;
+}
+
+/**
+ * The hold state this system reports for the snapshot named.
+ *
+ * Both declared name fields are compared and the read asks both ways, for
+ * {@link snapshotExists}'s reason: `id` and `name` are two separate required
+ * strings with no stated relationship, and the response is checked rather than
+ * counted because a dropped filter answers with every snapshot on the system.
+ * Reading the first row of that would report a different snapshot's holds.
+ */
+async function readHoldState(ctx: ToolContext, snapshot: string): Promise<HoldReading> {
+  const matches = await firstValueFrom(
+    ctx.system.client.api.query(
+      'pool.snapshot.query',
+      [['OR', [[['id', '=', snapshot]], [['name', '=', snapshot]]]]],
+      HOLD_READ_OPTIONS,
+    ),
+  );
+  const row = matches.find(
+    (candidate) =>
+      stringOrNull(candidate['id']) === snapshot || stringOrNull(candidate['name']) === snapshot,
+  );
+  return row === undefined
+    ? { listed: false, held: null }
+    : { listed: true, held: heldOf(row['holds']) };
+}
+
+/** What a hold-state read did, where the reading alone cannot say. */
+function lookupOf(reading: HoldReading | null, error: string | null): string {
+  if (error !== null) return 'UNREADABLE';
+  return reading !== null && reading.listed ? 'FOUND' : 'NOT_FOUND';
+}
+
+/**
+ * What the plan says the call will do to the snapshot, given the state it is in
+ * now.
+ *
+ * Three cases and not two, as `alerts_dismiss`'s is: a snapshot whose hold
+ * state could not be read is neither already there nor about to move. The
+ * already-released case carries the asymmetry rather than reading as a no-op —
+ * "it is not held, so this changes nothing" would be the tool claiming to know
+ * about tags it cannot see.
+ */
+function holdEffectSentence(current: boolean | null, target: boolean): string {
+  if (current === null) {
+    return "Whether TrueNAS's hold tag is on it could not be read, so this may change nothing.";
+  }
+  if (target) {
+    return current
+      ? 'It already carries that tag, so this changes nothing and is not an error.'
+      : 'It carries no `truenas` tag, so this will place one.';
+  }
+  return current
+    ? 'It carries that tag, so this will remove it, along with any other hold tag on it.'
+    : 'It carries no `truenas` tag, so this is not an error — but a hold placed ' +
+        'under any other tag would still be removed, and this catalog cannot see one.';
+}
+
+/** The scope a recursive call reaches, for the plan step that names it. */
+function recursiveSentence(recursive: boolean): string {
+  return recursive
+    ? ' RECURSIVELY: this is applied to the snapshot\'s children as well as to it, ' +
+        'so it reaches more than the one snapshot named.'
+    : '';
+}
+
+export const snapshotSetHold: MutatingTool = {
+  name: 'snapshot_set_hold',
+  description:
+    "Places or removes TrueNAS's hold on one ZFS snapshot, so the snapshot can " +
+    'be protected from destruction or released again. Two-phase: called ' +
+    'without a confirmation_token it returns a plan for user approval; called ' +
+    'with one it sets the hold. A hold is the cheapest protection available ' +
+    'here for the snapshot an operator would recover from — this catalog has ' +
+    'no tool that deletes a named snapshot or rolls a dataset back, but ' +
+    'retention, a periodic snapshot task or a person can still destroy one, ' +
+    'and `snapshot_task_run` triggers a retention pass that does exactly that. ' +
+    '`snapshot` is the full `dataset@snapshot` name as `snapshots_list` ' +
+    'reports it in `name`, on the system being targeted. `held` says which of ' +
+    'the two to do and is required: true places the hold, false removes it. ' +
+    '`held: false` REMOVES EVERY HOLD TAG ON THE SNAPSHOT, NOT ONLY ' +
+    "TRUENAS'S. The two directions are not symmetric — placing a hold adds the " +
+    '`truenas` tag and only that tag, while removing one asks the system to ' +
+    'remove all hold tags, including any placed outside TrueNAS, by another ' +
+    'tool or by hand, which `snapshots_list` never reported and this tool ' +
+    "cannot see. `recursive` applies the same operation to the snapshot's " +
+    'children as well as to it, and a recursive release is the widest form of ' +
+    'that: it can remove holds this catalog never reported, on snapshots it ' +
+    'never named. Default false. PLANNING FAILS, NAMING THE SNAPSHOT, where ' +
+    'this system lists no snapshot under the name given. WHETHER A HOLD ' +
+    'ACTUALLY STOPS RETENTION DESTROYING THE SNAPSHOT IS (unconfirmed) HERE: a ' +
+    'ZFS hold makes the destroy itself fail, and `snapshots_list`\'s ' +
+    '`scheduled_removal` does not account for holds, so a held snapshot can ' +
+    'report a removal time and the removal can still be attempted — but how ' +
+    'TrueNAS reports or recovers from a destroy that fails was not read off a ' +
+    'live system and is not claimed here. SETTING A HOLD ON AN ALREADY-HELD ' +
+    'SNAPSHOT IS NOT AN ERROR, and neither is releasing one that is not held; ' +
+    'the plan says which of the two it is about to do. The result reports ' +
+    '`requested_held`, what was asked for; `previously_held`, the state read ' +
+    'immediately before the call; `resulting_held`, the state read immediately ' +
+    'after it; and `changed`, those two readings compared rather than the ' +
+    "request. EACH READING IS TRUENAS'S OWN HOLD TAG AND NOT ANY ZFS HOLD, the " +
+    'same reading `snapshots_list` reports as `held`: the system answers ' +
+    'whether the `truenas` tag is on the snapshot and nothing else, so ' +
+    '`previously_held: false` means "no `truenas` tag" rather than "nothing ' +
+    'was holding this". A `changed: false` ON A RELEASE THEREFORE DOES NOT ' +
+    'MEAN NOTHING WAS REMOVED — a hold under another tag is invisible to both ' +
+    'readings and would still have been removed. `previous_lookup` and ' +
+    '`resulting_lookup` say what each read did: `FOUND` is a read that named ' +
+    'this snapshot, `NOT_FOUND` a read that completed and listed none under ' +
+    'this name, and `UNREADABLE` a read that failed, with ' +
+    '`previous_read_error` and `resulting_read_error` naming why and null in ' +
+    'the other two cases. EACH HAS THREE VALUES AND ITS READING HAS FOUR ' +
+    'CAUSES FOR A NULL: the two failures above, and ALSO `FOUND` where the ' +
+    'snapshot was listed and reported no hold state this tool could read. So a ' +
+    'lookup alone does not tell them apart, and `FOUND` beside a null reading ' +
+    'is that fourth case. `changed` IS NULL WHERE EITHER READING IS, WHICH IS ' +
+    'NOT "NOTHING CHANGED". THE CALL IS MADE IN ALL OF THOSE CASES, because ' +
+    'what runs must be what was approved — and a read that failed after it is ' +
+    'not a failed call: the mutation had already landed and this tool simply ' +
+    'could not establish the outcome. `snapshots_list` with `report_held` ' +
+    "settles it. `destructiveness: 'reversible'` records that this operation " +
+    'destroys no data; it changes what may destroy a snapshot later and ' +
+    'destroys nothing itself. IT DOES NOT MEAN A RELEASE CAN BE UNDONE FROM ' +
+    'HERE: setting the hold again places the `truenas` tag and only that tag, ' +
+    'so any other tag a release removed is restored by nothing in this catalog.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      snapshot: {
+        type: 'string',
+        minLength: 1,
+        description:
+          'The snapshot to hold or release, as its full `dataset@snapshot` ' +
+          'name — the `name` `snapshots_list` reports, e.g. ' +
+          '"tank/media@nightly-1", on the system being targeted.',
+      },
+      held: {
+        type: 'boolean',
+        description:
+          "True places TrueNAS's hold on the snapshot; false removes the " +
+          'holds on it. FALSE REMOVES EVERY HOLD TAG, including any placed ' +
+          'outside TrueNAS that this catalog never reported.',
+      },
+      recursive: {
+        type: 'boolean',
+        default: false,
+        description:
+          "Apply the same operation to the snapshot's children as well as to " +
+          'it. Default false.',
+      },
+    },
+    required: ['snapshot', 'held'],
+  },
+  requiredRole: Role.Full,
+  mutating: true,
+  destructiveness: 'reversible',
+  normalizeArgs(rawArgs) {
+    const args = parseHoldArgs(rawArgs);
+    return { snapshot: args.snapshot, held: args.held, recursive: args.recursive };
+  },
+  async plan(ctx, rawArgs) {
+    const args = parseHoldArgs(rawArgs);
+    const reading = await readHoldState(ctx, args.snapshot);
+    // The failure names the argument the caller supplied, because that is the
+    // part of it a caller can check. `snapshot_clone` fails the same way.
+    if (!reading.listed) {
+      throw new Error(`No snapshot named "${args.snapshot}" on this system`);
+    }
+    return [
+      {
+        method: 'pool.snapshot.query',
+        params: holdReadParams(args.snapshot),
+        description:
+          `Read the hold state of "${args.snapshot}", to report whether it was ` +
+          'already in the state this call moves it to. Changes nothing. This ' +
+          'same read is made again immediately after the call, to report the ' +
+          'state that resulted.',
+      },
+      {
+        method: args.held ? 'pool.snapshot.hold' : 'pool.snapshot.release',
+        params: [args.snapshot, { recursive: args.recursive }],
+        description:
+          (args.held
+            ? `Place TrueNAS's hold on snapshot "${args.snapshot}".`
+            : `Remove the holds on snapshot "${args.snapshot}". THIS REMOVES EVERY ` +
+              'HOLD TAG ON IT, including any placed outside TrueNAS that this ' +
+              'catalog never reported.') +
+          recursiveSentence(args.recursive) +
+          ' ' +
+          holdEffectSentence(reading.held, args.held),
+      },
+    ];
+  },
+  async execute(ctx, rawArgs) {
+    const args = parseHoldArgs(rawArgs);
+    // Caught rather than thrown, as `alerts_dismiss`'s lookup is: this read
+    // exists to describe the outcome, and letting it fail the call would lose
+    // an approval the user has already given for a mutation that is still safe
+    // to make.
+    let previous: HoldReading | null = null;
+    let previousError: string | null = null;
+    try {
+      previous = await readHoldState(ctx, args.snapshot);
+    } catch (reason) {
+      previousError = errorText(reason);
+    }
+    // Unconditional, whatever the read said. Branching on state read at
+    // execution time is what the confirmation token cannot bind.
+    await firstValueFrom(
+      args.held
+        ? ctx.system.client.api.call('pool.snapshot.hold', [
+            args.snapshot,
+            { recursive: args.recursive },
+          ])
+        : ctx.system.client.api.call('pool.snapshot.release', [
+            args.snapshot,
+            { recursive: args.recursive },
+          ]),
+    );
+    // The mutation has landed by here, so this read may not fail the tool
+    // either — the result says the resulting state could not be established.
+    let resulting: HoldReading | null = null;
+    let resultingError: string | null = null;
+    try {
+      resulting = await readHoldState(ctx, args.snapshot);
+    } catch (reason) {
+      resultingError = errorText(reason);
+    }
+    const previouslyHeld = previous?.held ?? null;
+    const resultingHeld = resulting?.held ?? null;
+    return {
+      snapshot: args.snapshot,
+      requested_held: args.held,
+      recursive: args.recursive,
+      previous_lookup: lookupOf(previous, previousError),
+      previous_read_error: previousError,
+      previously_held: previouslyHeld,
+      resulting_lookup: lookupOf(resulting, resultingError),
+      resulting_read_error: resultingError,
+      resulting_held: resultingHeld,
+      // Both readings or nothing.
+      changed:
+        previouslyHeld === null || resultingHeld === null ? null : previouslyHeld !== resultingHeld,
     };
   },
 };

--- a/src/tools/snapshots.ts
+++ b/src/tools/snapshots.ts
@@ -1042,20 +1042,41 @@ function lookupOf(reading: HoldReading | null, error: string | null): string {
  * already-released case carries the asymmetry rather than reading as a no-op —
  * "it is not held, so this changes nothing" would be the tool claiming to know
  * about tags it cannot see.
+ *
+ * `recursive` is taken here for that same reason, one scope out.
+ * {@link readHoldState} reads the one snapshot named and the call reaches every
+ * child of it, so an already-held snapshot rendered as "this changes nothing"
+ * tells an approver a call is a no-op while it places a hold on every child
+ * that carries no tag — a state read off one snapshot restated as a guarantee
+ * about the operation, in the one text a person reads before approving. Each
+ * sentence therefore names the snapshot it is about and says outright that the
+ * children were not read; none of them can say more than that, because nothing
+ * here read them.
  */
-function holdEffectSentence(current: boolean | null, target: boolean): string {
+function holdEffectSentence(current: boolean | null, target: boolean, recursive: boolean): string {
+  // Spelled out rather than "it" on a recursive call: the scope sentence before
+  // this one has just said the call reaches more than the snapshot named, which
+  // is what makes the pronoun read as the whole operation.
+  const subject = recursive ? 'The snapshot named' : 'It';
+  const scope = recursive ? ' for the snapshot named' : '';
+  const unread = recursive
+    ? " Its children's hold state was not read, so nothing here says what this does to them."
+    : '';
   if (current === null) {
-    return "Whether TrueNAS's hold tag is on it could not be read, so this may change nothing.";
+    return (
+      `Whether TrueNAS's hold tag is on ${recursive ? 'the snapshot named' : 'it'} could not ` +
+      `be read, so this may change nothing${scope}.${unread}`
+    );
   }
   if (target) {
     return current
-      ? 'It already carries that tag, so this changes nothing and is not an error.'
-      : 'It carries no `truenas` tag, so this will place one.';
+      ? `${subject} already carries that tag, so this changes nothing${scope} and is not an error.${unread}`
+      : `${subject} carries no \`truenas\` tag, so this will place one.${unread}`;
   }
   return current
-    ? 'It carries that tag, so this will remove it, along with any other hold tag on it.'
-    : 'It carries no `truenas` tag, so this is not an error — but a hold placed ' +
-        'under any other tag would still be removed, and this catalog cannot see one.';
+    ? `${subject} carries that tag, so this will remove it, along with any other hold tag on it.${unread}`
+    : `${subject} carries no \`truenas\` tag, so this is not an error — but a hold placed ` +
+        `under any other tag would still be removed, and this catalog cannot see one.${unread}`;
 }
 
 /** The scope a recursive call reaches, for the plan step that names it. */
@@ -1101,7 +1122,12 @@ export const snapshotSetHold: MutatingTool = {
     '`requested_held`, what was asked for; `previously_held`, the state read ' +
     'immediately before the call; `resulting_held`, the state read immediately ' +
     'after it; and `changed`, those two readings compared rather than the ' +
-    "request. EACH READING IS TRUENAS'S OWN HOLD TAG AND NOT ANY ZFS HOLD, the " +
+    'request. ALL THREE ARE READ FROM THE SNAPSHOT NAMED AND ESTABLISH NOTHING ' +
+    'ABOUT ITS CHILDREN, so on a recursive call `changed` is not a statement ' +
+    'about what the call reached: a recursive hold of an already-held snapshot ' +
+    'reports `changed: false` having placed holds on children, and a recursive ' +
+    'release reports what it removed from the snapshot named and nothing about ' +
+    "the rest. EACH READING IS TRUENAS'S OWN HOLD TAG AND NOT ANY ZFS HOLD, the " +
     'same reading `snapshots_list` reports as `held`: the system answers ' +
     'whether the `truenas` tag is on the snapshot and nothing else, so ' +
     '`previously_held: false` means "no `truenas` tag" rather than "nothing ' +
@@ -1190,7 +1216,7 @@ export const snapshotSetHold: MutatingTool = {
               'catalog never reported.') +
           recursiveSentence(args.recursive) +
           ' ' +
-          holdEffectSentence(reading.held, args.held),
+          holdEffectSentence(reading.held, args.held, args.recursive),
       },
     ];
   },


### PR DESCRIPTION
Closes #156.

Adds `snapshot_set_hold`, a mutating tool that places or removes TrueNAS's hold
on one snapshot. Deleting a snapshot and rolling a dataset back are both
rejected at registration (`catalog.ts:63`), so a hold is the only protection
this catalog can offer the snapshot an operator would recover from — and
`snapshot_task_run` triggers a retention pass that destroys snapshots, so there
is something to be protected from.

## What it does

- `snapshotSetHold: MutatingTool` in `src/tools/snapshots.ts`, catalog name
  `snapshot_set_hold`, `requiredRole: Role.Full`, `mutating: true`,
  `destructiveness: 'reversible'`.
- Arguments: `snapshot` (the full `dataset@snapshot` name), a required `held`
  boolean discriminator, and an optional `recursive` boolean. All three are
  parsed strictly — a coerced `"false"` on `held` would release a snapshot the
  caller asked to hold.
- Registered in `createDefaultCatalog()`, re-exported from `src/tools/index.ts`
  and `src/index.ts`, and added to the exact-list assertion in
  `src/tools/index.spec.ts` with a read-only-credential exclusion beside its
  siblings'.
- Tests in `src/tools/snapshots.spec.ts` (#87's default — the merged file is
  under the 1,500-line trigger, measured rather than assumed).
- `README.md`: the tool is in the mutating list and in the
  `destructiveness: 'reversible'` line, with the asymmetry below stated there.

## The three decisions behind it

**One tool with a discriminator, not two.** `pool.snapshot.hold` and
`pool.snapshot.release` take literally the same params — `(id, { recursive })`
in, `null` out — and differ only in which method is dialled, which is #121's
test. Nothing is missing from a mutation, so there is no section to be the
finding (#97).

**The plan names two steps and `execute` makes three calls.** Both methods
answer `null`, so there is no updated entity to read the outcome off (#121) and
the state has to be read before and after the call — `alerts_dismiss`'s
position (#119) with a second read on the far side of the mutation. Both reads
are the *same* call, from one helper, with identical params; listing it twice
would show an approver two entries it cannot tell apart, so it is named once and
that step's description says outright that it runs again immediately after the
call. That is `cloudsync_run`'s seam for the `core.get_jobs` its tracking issues
(#122), reached for a different reason. Nothing `execute` calls is missing from
the approval, which is what #119 is about. The plan step's params are pinned to
the params `execute` reads with by a test that takes the step back out of the
plan.

**`hold` and `release` are not symmetric, and that is the finding the tool
carries.** `hold` adds the `truenas` tag and only that tag; `release` names no
tag, which the middleware documents as removing *all* hold tags — including any
placed outside TrueNAS that `snapshots_list` never reported, since its `held` is
the `truenas` tag alone (#155). Three consequences, all stated in the
description and the plan rather than left to be inferred:

- The plan's already-in-the-target-state sentence refuses the obvious wording
  for a release. *"It is not held, so this changes nothing"* would be the tool
  claiming to know about tags it never reads; it says instead that this is not
  an error **and** that a hold under another tag would still be removed.
- `changed` compares the two readings, and both readings are the `truenas` tag —
  so **`changed: false` on a release does not mean nothing was removed.**
- `reversible` records that the operation destroys no data; it does **not** mean
  a release can be undone from here, since setting the hold again places the
  `truenas` tag alone and restores no foreign tag (#153's trap, one tool over).

`execute` issues the mutating call unconditionally, whatever either read said —
branching on state read at execution time is what the confirmation token cannot
bind. Both reads are caught: the first because losing an approval already given
for a safe mutation is worse than a null field, the second because the mutation
had already landed by then. `previous_lookup`/`resulting_lookup` report
`FOUND`/`NOT_FOUND`/`UNREADABLE` with the error text beside them, and the
description says outright that each has three values while its reading has four
causes for a null.

Whether a hold actually stops retention destroying the snapshot is marked
`(unconfirmed)`, in `pool_resilver_config`'s form (#141): what is claimed is the
ZFS mechanism, and how TrueNAS reports a destroy that fails was not read off a
live system.

**The state is read off one snapshot, and no sentence may reach past it (round
2).** `readHoldState` queries the snapshot named while a `recursive: true` call
reaches every child of it, so the effect sentence takes `recursive`: each arm
names the snapshot it is about and adds that the children's hold state was not
read. Without it, a recursive hold of an already-held snapshot rendered as *"It
already carries that tag, so this changes nothing"* — true of the snapshot,
false of the operation, and false in the reassuring direction in the one text a
person reads before approving. The same scoping is owed by the result, where
`previously_held`, `resulting_held` and `changed` are the named snapshot's
alone, so the description now says a recursive hold of an already-held snapshot
reports `changed: false` having placed holds on children. A scope sentence
*beside* an effect sentence does not scope it: `recursiveSentence` already said
the call reaches more than the snapshot named, one clause earlier, and the no-op
claim still read as being about the call.

`CLAUDE.md` gains two `## Decisions` entries for the first and third of those,
and the third now carries the recursive-scope rule above.

## Checks

`yarn lint`, `yarn typecheck`, `yarn test:coverage` (1,547 passing, against the
floors in `vitest.config.ts`) and `yarn build` all run clean locally at this
head. Nothing was skipped.

The project's own reviewer runs locally in a separate process, same rubric and
threshold as the required check. **Round 1's clean local result did not predict
the required check**, which returned the HIGH about `recursive` fixed above —
so read the round-2 clean result as what it is: the same reviewer, a second
time, finding nothing at or above MEDIUM on the new diff.

## What I did not change, and why

Round 2's review returned four LOW findings, none of which is fixed here: every
fix is a new diff, a new diff reopens the review loop, and none of these makes
the description contradict the code.

1. **`readHoldState` duplicates `snapshotExists`'s OR filter and its
   both-name comparison.** #153 pairs the filter with the comparison for a
   reason, and two copies can drift apart independently. Sharing them is a
   change to `snapshotExists` as well, which this ticket does not otherwise
   touch.
2. **`lookupOf` returns `string` rather than the three-value literal union**,
   and its `reading !== null` arm is unreachable while `errorText` never returns
   null — a permanently uncovered branch.
3. **The hold/release method and params tuple is written three times** — once in
   the plan step and once per arm in `execute` — where `snapshots_create` and
   `snapshot_clone` each hoist a single params constructor. The two arms are two
   different methods, which is why it reads this way; the fair half of the
   finding is that no note says which test holds them in step, unlike the one
   `DATASET_READ_OPTIONS` carries.
4. **The pointer between this tool and `snapshots_list` is one-way.** This
   description names that tool; its `held` field says nothing about the tool
   that now sets it (#101 asks for both directions).

Carried over from round 1, still unfixed and still LOW:

5. **"Holding an already-held snapshot is not an error" is unhedged.** ZFS can
   answer `EEXIST`, and the surface does not establish what TrueNAS does — but
   the ticket states the unhedged form as an acceptance criterion, so hedging it
   is a decision to make deliberately rather than in passing.
6. **The cost of the hold read is not named in the description.** #155 made
   `report_held` opt-in on `snapshots_list` because `extra.holds` widens the read
   before any bound applies; the reads here are filtered to one snapshot, which
   is why it was not raised at design time, and the description says nothing
   either way.
7. **`recursive` is described as reaching "the snapshot's children".** `zfs hold
   -r` reaches the same-named snapshot on descendent datasets, which
   `snapshots_create`'s wording states more precisely; the wording here avoids
   asserting ZFS semantics the surface does not declare.
